### PR TITLE
fix enchant's include path

### DIFF
--- a/src/modules/spell/spell-custom-dict.cpp
+++ b/src/modules/spell/spell-custom-dict.cpp
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
-#include <endian.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 

--- a/src/modules/spell/spell-enchant.cpp
+++ b/src/modules/spell/spell-enchant.cpp
@@ -25,7 +25,7 @@
 
 #include "spell-enchant.h"
 #include <dlfcn.h>
-#include <enchant/enchant.h>
+#include <enchant.h>
 
 namespace fcitx {
 

--- a/src/modules/spell/spell-enchant.h
+++ b/src/modules/spell/spell-enchant.h
@@ -22,7 +22,7 @@
 #define _FCITX_MODULES_SPELL_SPELL_ENCHANT_H_
 
 #include "spell.h"
-#include <enchant/enchant.h>
+#include <enchant.h>
 
 namespace fcitx {
 


### PR DESCRIPTION
Fix the include path of enchant. If you check other users of enchant (https://github.com/GNOME/gspell/blob/a04b0a8b96b2a928cad2c368bc8495edcad8cb3a/gspell/gspell-checker.h, https://sourceforge.net/p/gtkspell/gtkspell/ci/master/tree/gtkspell/gtkspell.c), you'll find out that they use `#include <enchant.h>`