### PR TITLE
make libuuid public for include path

### DIFF
--- a/src/lib/fcitx/CMakeLists.txt
+++ b/src/lib/fcitx/CMakeLists.txt
@@ -67,7 +67,7 @@ target_include_directories(Fcitx5Core PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}/Fcitx5/Core>)
-target_link_libraries(Fcitx5Core PUBLIC Fcitx5::Config Fcitx5::Utils PRIVATE LibUUID::LibUUID LibIntl::LibIntl XKBCommon::XKBCommon ${FMT_TARGET})
+target_link_libraries(Fcitx5Core PUBLIC Fcitx5::Config Fcitx5::Utils LibUUID::LibUUID PRIVATE LibIntl::LibIntl XKBCommon::XKBCommon ${FMT_TARGET})
 
 configure_file(Fcitx5Core.pc.in ${CMAKE_CURRENT_BINARY_DIR}/Fcitx5Core.pc @ONLY)
 


### PR DESCRIPTION
inputcontext_p.h includes uuid.h. As a result, anything using this header file needs the include path of libuuid. Some modules fall in this class.