### PR TITLE
Fix another #define None in X11/X.h

### DIFF
--- a/src/lib/fcitx-utils/keysym.h
+++ b/src/lib/fcitx-utils/keysym.h
@@ -30,6 +30,11 @@
 #include <fcitx-utils/macros.h>
 
 namespace fcitx {
+
+#ifdef None
+#undef None
+#endif
+
 /// \brief KeyState to represent modifier keys.
 enum class KeyState : uint32_t {
     None = 0,


### PR DESCRIPTION
`X11/X.h` already define a `None`:
```
/*****************************************************************
 * RESERVED RESOURCE AND CONSTANT DEFINITIONS
 *****************************************************************/

#ifndef None
#define None                 0L /* universal null resource or null atom */
#endif

#define ParentRelative       1L /* background pixmap in CreateWindow
                                    and ChangeWindowAttributes */

#define CopyFromParent       0L /* border pixmap in CreateWindow
```