### PR TITLE
Fix UniqueCPtr build error

### DIFF
--- a/src/ui/classic/waylandeglwindow.cpp
+++ b/src/ui/classic/waylandeglwindow.cpp
@@ -16,8 +16,7 @@
 namespace fcitx {
 namespace classicui {
 WaylandEGLWindow::WaylandEGLWindow(WaylandUI *ui)
-    : WaylandWindow(ui), window_(nullptr, &wl_egl_window_destroy),
-      cairoSurface_(nullptr, &cairo_surface_destroy) {}
+    : WaylandWindow(ui), window_(nullptr), cairoSurface_(nullptr) {}
 
 WaylandEGLWindow::~WaylandEGLWindow() { destroyWindow(); }
 


### PR DESCRIPTION
测试环境：Gentoo

最新commit无法编译，Clang 10及GCC 9.3.0均报错

错误信息见https://pastebin.ubuntu.com/p/snk3TX6t72/

另外`fcitx5-chinese-addons`也有一个相关的编译错误，貌似是`UniqueCPtr`没有定义，见https://pastebin.ubuntu.com/p/ZYgMQS2Dz5/