### PR TITLE
Fix default install path for autostart file

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -17,7 +17,7 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/org.fcitx.Fcitx5.desktop"
         DESTINATION "${FCITX_INSTALL_DATADIR}/applications")
 
 if (ENABLE_XDGAUTOSTART)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/org.fcitx.Fcitx5.desktop" DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/xdg/autostart)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/org.fcitx.Fcitx5.desktop" DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/xdg/autostart)
 endif()
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/org.fcitx.Fcitx5.metainfo.xml" DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)


### PR DESCRIPTION
see https://cmake.org/cmake/help/v3.4/module/GNUInstallDirs.html

In case when `CMAKE_INSTALL_PREFIX=/usr`, `CMAKE_INSTALL_SYSCONFDIR` will be `/usr/etc`, which is weird.

While we can use `-DCMAKE_INSTALL_SYSCONFDIR=/etc` to workaround but `CMAKE_INSTALL_FULL_SYSCONFDIR` should be used in this case (which is `/etc` by default)