### PR TITLE
make fcitx5-diagnose.sh able to handle the situation when env is set to `fcitx5`

### DIFF
--- a/data/fcitx5-diagnose.sh
+++ b/data/fcitx5-diagnose.sh
@@ -1087,6 +1087,10 @@ check_xim() {
     elif [ "${XMODIFIERS}" = '@im=fcitx' ]; then
         _env_correct 'XMODIFIERS' '@im=fcitx'
         __need_blank_line=0
+    elif [ "${XMODIFIERS}" = '@im=fcitx5' ]; then
+        _env_correct 'XMODIFIERS' '@im=fcitx5'
+        __need_blank_line=0
+        xim_name=fcitx5
     else
         _env_incorrect 'XMODIFIERS' '@im=fcitx' "${XMODIFIERS}"
         set_env_link XMODIFIERS '@im=fcitx'
@@ -1151,6 +1155,8 @@ _check_toolkit_env() {
         set_env_link "${env_name}" 'fcitx'
     elif [ "${!env_name}" = 'fcitx' ]; then
         _env_correct "${env_name}" 'fcitx'
+    elif [ "${!env_name}" = 'fcitx5' ]; then
+        _env_correct "${env_name}" 'fcitx5'
     else
         _env_incorrect "${env_name}" 'fcitx' "${!env_name}"
         __need_blank_line=0


### PR DESCRIPTION
Don't raise confusing error message like 
```
    **Environment variable GTK_IM_MODULE is "fcitx5" instead of "fcitx". Please check if you have exported it incorrectly in any of your init files.**
    **You may have trouble using fcitx in gtk programs.**

    **Please set environment variable GTK_IM_MODULE to "fcitx" using the tool your distribution provides or add `export GTK_IM_MODULE=fcitx` to your `~/.xprofile`. See [Input Method Related Environment Variables: GTK_IM_MODULE](http://fcitx-im.org/wiki/Input_method_related_environment_variables#GTK_IM_MODULE).**
```
When those environment variable is set to `fcitx5`