### PR TITLE
add missing headers

### DIFF
--- a/src/lib/fcitx/icontheme.cpp
+++ b/src/lib/fcitx/icontheme.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <stdexcept>
 #include <unordered_set>
+#include <limits>
 #include "fcitx-config/iniparser.h"
 #include "fcitx-config/marshallfunction.h"
 #include "fcitx-utils/fs.h"


### PR DESCRIPTION
Fix a build failure due to missing headers on fedora rawhide (GCC 11 prerelease)

```
../src/lib/fcitx/icontheme.cpp: In member function 'std::string fcitx::IconThemePrivate::lookupIcon(const string&, int, int, const std::vector<std::__cxx11::basic_string<char> >&) const':
../src/lib/fcitx/icontheme.cpp:535:29: error: 'numeric_limits' is not a member of 'std'
  535 |         auto minSize = std::numeric_limits<int>::max();
      |                             ^~~~~~~~~~~~~~
```

[before](https://koji.fedoraproject.org/koji/taskinfo?taskID=56934740)
[after](https://koji.fedoraproject.org/koji/taskinfo?taskID=56934832)