### PR TITLE
Stop key repeat timer on wayland keyboard grab cleared

### DIFF
--- a/src/frontend/waylandim/waylandimserver.cpp
+++ b/src/frontend/waylandim/waylandimserver.cpp
@@ -134,6 +134,7 @@ void WaylandIMInputContextV1::deactivate(wayland::ZwpInputMethodContextV1 *ic) {
     if (ic_.get() == ic) {
         ic_.reset();
         keyboard_.reset();
+        timeEvent_->setEnabled(false);
         focusOut();
     } else {
         // This should not happen, but just in case.

--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -132,6 +132,7 @@ WaylandIMInputContextV2::WaylandIMInputContextV2(
         if (pendingDeactivate_) {
             pendingDeactivate_ = false;
             keyboardGrab_.reset();
+            timeEvent_->setEnabled(false);
             server_->display_->sync();
             focusOut();
         }


### PR DESCRIPTION
This should fix one of the unexpected key inputs problem on sway:
https://github.com/swaywm/sway/issues/6193

The problem occurs as follows:

 1. press Ctrl+d to exit from terminal emulator
 2. fcitx captures the key press event and enables repeat timer
 3. terminal emulator exits (while the key is still pressed)
 4. fcitx sends key repeat events indefinitely (since there's no release event)

It's unclear whether this is a bug of the compositor (i.e. sway) or not, but
I think it's better for fcitx to not carry the key-repeat state over to new
keyboard grab.