### PR TITLE
Do not start key repeat timer if event is redirected back to wayland client

### DIFF
--- a/src/frontend/waylandim/waylandimserver.cpp
+++ b/src/frontend/waylandim/waylandimserver.cpp
@@ -149,8 +149,7 @@ void WaylandIMInputContextV1::repeat() {
         false, repeatTime_);
     if (!keyEvent(event)) {
         ic_->keysym(serial_, repeatTime_, event.rawKey().sym(),
-                    event.isRelease() ? WL_KEYBOARD_KEY_STATE_RELEASED
-                                      : WL_KEYBOARD_KEY_STATE_PRESSED,
+                    WL_KEYBOARD_KEY_STATE_PRESSED,
                     event.rawKey().states());
     }
 

--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -198,8 +198,7 @@ void WaylandIMInputContextV2::repeat() {
         false, repeatTime_);
     if (!keyEvent(event)) {
         vk_->key(repeatTime_, event.rawKey().code() - 8,
-                 event.isRelease() ? WL_KEYBOARD_KEY_STATE_RELEASED
-                                   : WL_KEYBOARD_KEY_STATE_PRESSED);
+                 WL_KEYBOARD_KEY_STATE_PRESSED);
     }
 
     timeEvent_->setNextInterval(1000000 / repeatRate_);

--- a/src/frontend/waylandim/waylandimserverv2.h
+++ b/src/frontend/waylandim/waylandimserverv2.h
@@ -140,6 +140,7 @@ private:
     uint32_t repeatKey_ = 0;
     uint32_t repeatTime_ = 0;
     KeySym repeatSym_ = FcitxKey_None;
+    bool lastPressedSentToVk_ = false;
 
     int32_t repeatRate_ = 40, repeatDelay_ = 400;
 };


### PR DESCRIPTION
While debugging sway/wlroot issue, I noticed key repeat events are duplicated.
The event came from fcitx5 restarts the client-side repeat timer, which
actually slows down the key-repeat interval. Since key repeating should be
handled by client on Wayland, IM shouldn't emulate it if the event isn't
consumed by IM and sent back to the client through virtual keyboard.

I've tested the V2 server on Sway. I also found a similar code in V1, so
applied a similar fix assuming that the returned keysym would be processed
as a key event by client.

Because I'm not sure if the event variable can be modified by keyEvent(event),
I've added timeEvent_->setEnabled(false). If the event variable can be
considered a constant, it's probably better to postpone the timer configuration
at all.