### PR TITLE
Allow processComposeString when keyboard disabled.

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1712,7 +1712,7 @@ std::optional<std::string> Instance::processComposeString(InputContext *ic,
 #else
     FCITX_UNUSED(ic);
     FCITX_UNUSED(keysym);
-    return std::nullopt;
+    return std::string();
 #endif
 }
 


### PR DESCRIPTION
Always return empty string when keyboard inputmethod is disabled, makes quickphrase and unicode addon works on Android.