### PR TITLE
Fix crash due to undefined behaviours

### DIFF
--- a/src/lib/fcitx-utils/connectableobject.h
+++ b/src/lib/fcitx-utils/connectableobject.h
@@ -48,20 +48,6 @@
 #define FCITX_DEFINE_SIGNAL_PRIVATE(CLASS_NAME, NAME)                          \
     ::fcitx::SignalAdaptor<CLASS_NAME::NAME> CLASS_NAME##NAME##Adaptor { q_ptr }
 
-/// \brief Declare a signal in pimpl class.
-#define FCITX_DEFINE_SIGNAL_WITH_COMBINER(CLASS_NAME, NAME, COMBINER)          \
-    ::fcitx::SignalAdaptor<CLASS_NAME::NAME, COMBINER>                         \
-        CLASS_NAME##NAME##Adaptor {                                            \
-        this                                                                   \
-    }
-
-/// \brief Declare a signal in pimpl class.
-#define FCITX_DEFINE_SIGNAL_PRIVATE_WITH_COMBINER(CLASS_NAME, NAME, COMBINER)  \
-    ::fcitx::SignalAdaptor<CLASS_NAME::NAME, COMBINER>                         \
-        CLASS_NAME##NAME##Adaptor {                                            \
-        q_ptr                                                                  \
-    }
-
 namespace fcitx {
 
 class ConnectableObject;

--- a/src/lib/fcitx-utils/connectableobject.h
+++ b/src/lib/fcitx-utils/connectableobject.h
@@ -69,6 +69,8 @@ class ConnectableObject;
 /// \brief Helper class to register class.
 template <typename T, typename Combiner = typename T::combinerType>
 class SignalAdaptor {
+    // FIXME remove Combiner when we can break ABI.
+    static_assert(std::is_same<Combiner, typename T::combinerType>::value);
 public:
     SignalAdaptor(ConnectableObject *d);
     ~SignalAdaptor();
@@ -132,6 +134,8 @@ protected:
     template <typename SignalType,
               typename Combiner = typename SignalType::combinerType>
     void registerSignal() {
+        // FIXME remove Combiner when we can break ABI.
+        static_assert(std::is_same<Combiner, typename SignalType::combinerType>::value);
         _registerSignal(
             SignalType::signature::data(),
             std::make_unique<

--- a/src/lib/fcitx-utils/connectableobject.h
+++ b/src/lib/fcitx-utils/connectableobject.h
@@ -28,6 +28,18 @@
         using signature = fcitxMakeMetaString(#CLASS_NAME "::" #NAME);                   \
     }
 
+/// \brief Declare signal by type with combiner.
+///
+/// This macro is intended to be used outside of class declaration,
+/// because the custom combiner is an implementation detail,
+/// thus it'll be put in source files.
+#define FCITX_DECLARE_SIGNAL_WITH_COMBINER(CLASS_NAME, NAME, COMBINER, ...)    \
+    struct CLASS_NAME::NAME {                                                  \
+        using signalType = __VA_ARGS__;                                        \
+        using combinerType = COMBINER;                                         \
+        using signature = fcitxMakeMetaString(#CLASS_NAME "::" #NAME);         \
+    }
+
 /// \brief Declare a signal.
 #define FCITX_DEFINE_SIGNAL(CLASS_NAME, NAME)                                  \
     ::fcitx::SignalAdaptor<CLASS_NAME::NAME> CLASS_NAME##NAME##Adaptor { this }

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1,5 +1,6 @@
 /*
  * SPDX-FileCopyrightText: 2016-2016 CSSlayer <wengxt@gmail.com>
+ * SPDX-FileCopyrightText: 2021-2021 Danh Doan <congdanhqx@gmail.com>
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -125,6 +126,8 @@ std::string stripLanguage(const std::string &lc) {
 }
 
 } // namespace
+
+FCITX_DECLARE_SIGNAL_WITH_COMBINER(Instance, CheckUpdate, CheckUpdateResult, bool());
 
 class CheckInputMethodChanged;
 
@@ -455,8 +458,7 @@ public:
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, CommitFilter);
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, OutputFilter);
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, KeyEventResult);
-    FCITX_DEFINE_SIGNAL_PRIVATE_WITH_COMBINER(Instance, CheckUpdate,
-                                              CheckUpdateResult);
+    FCITX_DEFINE_SIGNAL_PRIVATE(Instance, CheckUpdate);
 
     FactoryFor<InputState> inputStateFactory_{
         [this](InputContext &ic) { return new InputState(this, &ic); }};

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -127,7 +127,7 @@ public:
                          void(InputContext *inputContext, Text &orig));
     FCITX_DECLARE_SIGNAL(Instance, KeyEventResult,
                          void(const KeyEvent &keyEvent));
-    FCITX_DECLARE_SIGNAL(Instance, CheckUpdate, bool());
+    struct CheckUpdate;
 
     /// Return a focused input context.
     InputContext *lastFocusedInputContext();


### PR DESCRIPTION
I discovered this problem when running `fcitx5-config-qt`, `fcitx5` crashes as soon as the config tool is launched.

I have gcc 10.2.1 (pre-version), fcitx5 (5.0.8), dbus 1.12.20.

-----

As of it's now, we're downcasting from SignalBase to
Signal<SignalType> (which is the same type with
Signal<SignalType, LastValue<...>>) in its member functions.

The downcast is incorrect if its Combiner is NOT LastValue, fcitx5 will
run into undefined behaviours with this kind of casting.

In my local machine, this result in indeterminated value in
CheckUpdateResult, then fcitx5 will crash because of DBus' assertion.

When compiling with: `-fsanitize=undefined`, this problem is being
reported:

```
../src/lib/fcitx/../fcitx-utils/connectableobject.h:115:18: runtime error: downcast of address 0x559bd4a2a5b0 which does not point to an object of type 'Signal'
0x559bd4a2a5b0: note: object is of type '*N5fcitx6SignalIFbvENS_12_GLOBAL__N_117CheckUpdateResultEEE'
 00 00 00 00  40 25 21 2e f7 7f 00 00  e0 f5 a2 d4 9b 55 00 00  20 70 61 67 65 00 00 00  41 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for '*N5fcitx6SignalIFbvENS_12_GLOBAL__N_117CheckUpdateResultEEE'
../src/lib/fcitx/../fcitx-utils/connectableobject.h:116:21: runtime error: member call on address 0x559bd4a2a5b0 which does not point to an object of type 'Signal'
0x559bd4a2a5b0: note: object is of type '*N5fcitx6SignalIFbvENS_12_GLOBAL__N_117CheckUpdateResultEEE'
 00 00 00 00  40 25 21 2e f7 7f 00 00  e0 f5 a2 d4 9b 55 00 00  20 70 61 67 65 00 00 00  41 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for '*N5fcitx6SignalIFbvENS_12_GLOBAL__N_117CheckUpdateResultEEE'
```


