### PR TITLE
Fix a bug that wayland module cannot input text to weston-editor

### DIFF
--- a/src/frontend/waylandim/waylandimserver.cpp
+++ b/src/frontend/waylandim/waylandimserver.cpp
@@ -350,10 +350,7 @@ void WaylandIMInputContextV1::keyCallback(uint32_t serial, uint32_t time,
     WAYLANDIM_DEBUG() << event.key().toString()
                       << " IsRelease=" << event.isRelease();
     if (!keyEvent(event)) {
-        ic_->keysym(serial, time, event.rawKey().sym(),
-                    event.isRelease() ? WL_KEYBOARD_KEY_STATE_RELEASED
-                                      : WL_KEYBOARD_KEY_STATE_PRESSED,
-                    event.rawKey().states());
+        ic_->key(serial, time, key, state);
     }
     server_->display_->flush();
 }


### PR DESCRIPTION
According to the protocol specification,
`zwp_input_method_context_v1::key` has to be used for unhandled key
events:

  https://github.com/wayland-project/wayland-protocols/blob/7dffa6f346ae32f7888177d74a45459997059767/unstable/input-method/input-method-unstable-v1.xml#L171-L176

But fcitx5 uses `zwp_input_method_context_v1::keysym` instead. So that it
cannot input text to weston-editor when IM is disabled.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>