### PR TITLE
Improve logging for addon loading.

### DIFF
--- a/src/lib/fcitx/addonloader.cpp
+++ b/src/lib/fcitx/addonloader.cpp
@@ -26,8 +26,12 @@ AddonInstance *SharedLibraryLoader::load(const AddonInfo &info,
             libname = libname.substr(7);
             flag |= LibraryLoadHint::ExportExternalSymbolsHint;
         }
-        auto libs = standardPath_.locateAll(StandardPath::Type::Addon,
-                                            libname + FCITX_LIBRARY_SUFFIX);
+        auto file = libname + FCITX_LIBRARY_SUFFIX;
+        auto libs = standardPath_.locateAll(StandardPath::Type::Addon, file);
+        if (libs.empty()) {
+            FCITX_ERROR() << "Could not locate library " << file
+                          << " for addon " << info.uniqueName() << ".";
+        }
         for (const auto &libraryPath : libs) {
             Library lib(libraryPath);
             if (!lib.load(flag)) {

--- a/src/lib/fcitx/addonmanager.cpp
+++ b/src/lib/fcitx/addonmanager.cpp
@@ -185,6 +185,7 @@ public:
         }
         if (!addon.instance_) {
             addon.setFailed(true);
+            FCITX_INFO() << "Could not load addon " << addon.info().uniqueName();
         } else {
             FCITX_INFO() << "Loaded addon " << addon.info().uniqueName();
         }


### PR DESCRIPTION
Addon authors can know if they made typo in their configure files, or packagers can know if they've forget to include some library files.

dummy.conf
```ini
[Addon]
Name=Dummy Addon
Type=SharedLibrary
Library=libdummy
Category=UI
Version=0.0.1
```

logs
```
E2021-11-18 19:56:34.028113 addonloader.cpp:32] Could not locate library libdummy.so for addon dummy.
I2021-11-18 19:56:34.028154 addonmanager.cpp:188] Could not load addon dummy
```