### PR TITLE
Override locale dir by environment variable.

### DIFF
--- a/src/lib/fcitx-utils/i18n.cpp
+++ b/src/lib/fcitx-utils/i18n.cpp
@@ -22,8 +22,11 @@ public:
         if (domains_.count(domain)) {
             return;
         }
-        const auto *localedir = StandardPath::fcitxPath("localedir");
         if (!dir) {
+            const auto *localedir = getenv("FCITX_LOCALE_DIR");
+            if (!localedir) {
+                localedir = StandardPath::fcitxPath("localedir");
+            }
             dir = localedir;
         }
         bindtextdomain(domain, dir);

--- a/src/lib/fcitx-utils/i18n.cpp
+++ b/src/lib/fcitx-utils/i18n.cpp
@@ -23,11 +23,7 @@ public:
             return;
         }
         if (!dir) {
-            const auto *localedir = getenv("FCITX_LOCALE_DIR");
-            if (!localedir) {
-                localedir = StandardPath::fcitxPath("localedir");
-            }
-            dir = localedir;
+            dir = StandardPath::fcitxPath("localedir");
         }
         bindtextdomain(domain, dir);
         bind_textdomain_codeset(domain, "UTF-8");
@@ -92,6 +88,10 @@ translateDomainCtx(const char *domain, const char *ctx, const char *s) {
 }
 
 FCITXUTILS_EXPORT void registerDomain(const char *domain, const char *dir) {
+    const char *localedir = getenv("FCITX_LOCALE_DIR");
+    if (localedir) {
+        dir = localedir;
+    }
     gettextManager.addDomain(domain, dir);
 }
 } // namespace fcitx


### PR DESCRIPTION
Able to override locale path by environment variable `FCITX_LOCALE_DIR`, in case locale files cannot be located by compile-time variable `FCITX_INSTALL_LOCALEDIR` (namely Android).