### PR TITLE
Read FCITX_LOCALE env for system locale on Android.

### DIFF
--- a/src/lib/fcitx-utils/i18nstring.cpp
+++ b/src/lib/fcitx-utils/i18nstring.cpp
@@ -12,7 +12,13 @@ namespace fcitx {
 const std::string &I18NString::match(const std::string &locale_) const {
     std::string locale = locale_;
     if (locale == "system") {
+#ifdef ANDROID
+        // bionic doesn't recognize locale other than C or C.UTF-8
+        // https://android.googlesource.com/platform/bionic/+/refs/tags/android-11.0.0_r48/libc/bionic/locale.cpp#175
+        char *lc = getenv("FCITX_LOCALE");
+#else
         char *lc = setlocale(LC_MESSAGES, nullptr);
+#endif
         if (lc) {
             locale = lc;
         } else {


### PR DESCRIPTION
Android's bionic only supports 2 locales, `C` (aka `POSIX`) and `C.UTF-8` (aka `en_US.UTF-8`)
https://android.googlesource.com/platform/bionic/+/refs/tags/android-11.0.0_r48/libc/bionic/locale.cpp#50

... and would always return `C` or `C.UTF-8` when `setlocale(LC_*, nullptr)` is called.
https://android.googlesource.com/platform/bionic/+/refs/tags/android-11.0.0_r48/libc/bionic/locale.cpp#175

Here we override the value with env `FCITX_LOCALE`.