### PR TITLE
Export unicode addon's trigger function.

### DIFF
--- a/src/modules/unicode/CMakeLists.txt
+++ b/src/modules/unicode/CMakeLists.txt
@@ -4,6 +4,7 @@ install(TARGETS unicode DESTINATION "${FCITX_INSTALL_ADDONDIR}")
 configure_file(unicode.conf.in.in unicode.conf.in @ONLY)
 fcitx5_translate_desktop_file(${CMAKE_CURRENT_BINARY_DIR}/unicode.conf.in unicode.conf)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/unicode.conf" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/addon")
+fcitx5_export_module(Unicode TARGET unicode BUILD_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}" HEADERS unicode_public.h INSTALL)
 
 install(FILES charselectdata DESTINATION "${FCITX_INSTALL_PKGDATADIR}/unicode")
 

--- a/src/modules/unicode/unicode.cpp
+++ b/src/modules/unicode/unicode.cpp
@@ -78,7 +78,9 @@ Unicode::Unicode(Instance *instance)
                 return;
             }
             if (keyEvent.key().checkKeyList(*config_.triggerKey)) {
-                trigger(keyEvent.inputContext());
+                if (!trigger(keyEvent.inputContext())) {
+                    return;
+                }
                 keyEvent.filterAndAccept();
                 return;
             }
@@ -229,11 +231,12 @@ Unicode::Unicode(Instance *instance)
 
 Unicode::~Unicode() {}
 
-void Unicode::trigger(InputContext *inputContext) {
-    if (!data_.load()) return;
+bool Unicode::trigger(InputContext *inputContext) {
+    if (!data_.load()) return false;
     auto *state = inputContext->propertyFor(&factory_);
     state->enabled_ = true;
     updateUI(inputContext, true);
+    return true;
 }
 void Unicode::updateUI(InputContext *inputContext, bool trigger) {
     auto *state = inputContext->propertyFor(&factory_);

--- a/src/modules/unicode/unicode.cpp
+++ b/src/modules/unicode/unicode.cpp
@@ -77,10 +77,8 @@ Unicode::Unicode(Instance *instance)
             if (keyEvent.isRelease()) {
                 return;
             }
-            if (keyEvent.key().checkKeyList(*config_.triggerKey)) {
-                if (!trigger(keyEvent.inputContext())) {
-                    return;
-                }
+            if (keyEvent.key().checkKeyList(*config_.triggerKey) &&
+                trigger(keyEvent.inputContext())) {
                 keyEvent.filterAndAccept();
                 return;
             }

--- a/src/modules/unicode/unicode.cpp
+++ b/src/modules/unicode/unicode.cpp
@@ -77,8 +77,7 @@ Unicode::Unicode(Instance *instance)
             if (keyEvent.isRelease()) {
                 return;
             }
-            if (keyEvent.key().checkKeyList(*config_.triggerKey) &&
-                data_.load()) {
+            if (keyEvent.key().checkKeyList(*config_.triggerKey)) {
                 trigger(keyEvent.inputContext());
                 keyEvent.filterAndAccept();
                 return;
@@ -231,6 +230,7 @@ Unicode::Unicode(Instance *instance)
 Unicode::~Unicode() {}
 
 void Unicode::trigger(InputContext *inputContext) {
+    if (!data_.load()) return;
     auto *state = inputContext->propertyFor(&factory_);
     state->enabled_ = true;
     updateUI(inputContext, true);

--- a/src/modules/unicode/unicode.h
+++ b/src/modules/unicode/unicode.h
@@ -21,6 +21,7 @@
 #include "fcitx/instance.h"
 #include "charselectdata.h"
 #include "clipboard_public.h"
+#include "unicode_public.h"
 
 namespace fcitx {
 
@@ -58,6 +59,7 @@ public:
     FCITX_ADDON_DEPENDENCY_LOADER(clipboard, instance_->addonManager());
 
 private:
+    FCITX_ADDON_EXPORT_FUNCTION(Unicode, trigger);
     Instance *instance_;
     UnicodeConfig config_;
     CharSelectData data_;

--- a/src/modules/unicode/unicode.h
+++ b/src/modules/unicode/unicode.h
@@ -42,7 +42,7 @@ public:
 
     Instance *instance() { return instance_; }
 
-    void trigger(InputContext *inputContext);
+    bool trigger(InputContext *inputContext);
     void updateUI(InputContext *inputContext, bool trigger = false);
     auto &factory() { return factory_; }
 

--- a/src/modules/unicode/unicode_public.h
+++ b/src/modules/unicode/unicode_public.h
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: 2021-2021 CSSlayer <wengxt@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+#ifndef _FCITX_MODULES_UNICODE_UNICODE_PUBLIC_H_
+#define _FCITX_MODULES_UNICODE_UNICODE_PUBLIC_H_
+
+#include <functional>
+#include <fcitx/addoninstance.h>
+#include <fcitx/inputcontext.h>
+
+FCITX_ADDON_DECLARE_FUNCTION(Unicode, trigger,
+                             void(InputContext *ic));
+
+#endif // _FCITX_MODULES_UNICODE_UNICODE_PUBLIC_H_

--- a/src/modules/unicode/unicode_public.h
+++ b/src/modules/unicode/unicode_public.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021-2021 CSSlayer <wengxt@gmail.com>
+ * SPDX-FileCopyrightText: 2021-2021 Rocket Aaron <i@rocka.me>
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -12,6 +12,6 @@
 #include <fcitx/inputcontext.h>
 
 FCITX_ADDON_DECLARE_FUNCTION(Unicode, trigger,
-                             void(InputContext *ic));
+                             bool(InputContext *ic));
 
 #endif // _FCITX_MODULES_UNICODE_UNICODE_PUBLIC_H_


### PR DESCRIPTION
Allow triggering unicode input mode in other addons, for more convenient usage (namely on Android).