### PR TITLE
fix dbus introspection bug

### DIFF
--- a/src/lib/fcitx-utils/dbus/libdbus/objectvtable_libdbus.cpp
+++ b/src/lib/fcitx-utils/dbus/libdbus/objectvtable_libdbus.cpp
@@ -38,7 +38,7 @@ const std::string &ObjectVTableBasePrivate::getXml(ObjectVTableBase *q) {
                                                type, "\"/>");
             }
             for (auto &type : splitDBusSignature(method->ret())) {
-                p->xml_ += stringutils::concat("<arg direction=\"in\" type=\"",
+                p->xml_ += stringutils::concat("<arg direction=\"out\" type=\"",
                                                type, "\"/>");
             }
             p->xml_ += "</method>";


### PR DESCRIPTION
One of my python script using glib and dbus suddenly stopped working today, complaining that the dbus method `State` of interface `org.fcitx.Fcitx.Controller1`'s signature doesn't match. It turns out that introspection xml is using wrong direction for returning values, and python is trying to validate parameters against the wrong signature.

This patch fixes the problem described above.

Tested on my system (Gentoo Linux, Sway).