### PR TITLE
Add touch event to WaylandWindow

### DIFF
--- a/src/ui/classic/waylandinputwindow.cpp
+++ b/src/ui/classic/waylandinputwindow.cpp
@@ -47,6 +47,12 @@ WaylandInputWindow::WaylandInputWindow(WaylandUI *ui)
             repaint();
         }
     });
+    window_->touchDown().connect([this](int x, int y) {
+        click(x, y);
+    });
+    window_->touchUp().connect([this](int, int) {
+        // do nothing
+    });
     window_->axis().connect([this](int, int, uint32_t axis, wl_fixed_t value) {
         if (axis != WL_POINTER_AXIS_VERTICAL_SCROLL) {
             return;

--- a/src/ui/classic/waylandpointer.cpp
+++ b/src/ui/classic/waylandpointer.cpp
@@ -23,7 +23,7 @@ WaylandPointer::WaylandPointer(wayland::WlSeat *seat) {
         if ((caps & WL_SEAT_CAPABILITY_TOUCH) && !touch_) {
             touch_.reset(seat->getTouch());
             initTouch();
-        } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && touch_) {
+        } else if (!(caps & WL_SEAT_CAPABILITY_TOUCH) && touch_) {
             touch_.reset();
         }
     });

--- a/src/ui/classic/waylandpointer.cpp
+++ b/src/ui/classic/waylandpointer.cpp
@@ -36,35 +36,35 @@ void WaylandPointer::initPointer() {
         if (!window) {
             return;
         }
-        focus_ = window->watch();
-        focusX_ = wl_fixed_to_int(sx);
-        focusY_ = wl_fixed_to_int(sy);
-        window->hover()(focusX_, focusY_);
+        pointerFocus_ = window->watch();
+        pointerFocusX_ = wl_fixed_to_int(sx);
+        pointerFocusY_ = wl_fixed_to_int(sy);
+        window->hover()(pointerFocusX_, pointerFocusY_);
     });
     pointer_->leave().connect([this](uint32_t, wayland::WlSurface *surface) {
-        if (auto *window = focus_.get()) {
+        if (auto *window = pointerFocus_.get()) {
             if (window->surface() == surface) {
-                focus_.unwatch();
+                pointerFocus_.unwatch();
                 window->leave()();
             }
         }
     });
     pointer_->motion().connect([this](uint32_t, wl_fixed_t sx, wl_fixed_t sy) {
-        if (auto *window = focus_.get()) {
-            focusX_ = wl_fixed_to_int(sx);
-            focusY_ = wl_fixed_to_int(sy);
-            window->hover()(focusX_, focusY_);
+        if (auto *window = pointerFocus_.get()) {
+            pointerFocusX_ = wl_fixed_to_int(sx);
+            pointerFocusY_ = wl_fixed_to_int(sy);
+            window->hover()(pointerFocusX_, pointerFocusY_);
         }
     });
     pointer_->button().connect(
         [this](uint32_t, uint32_t, uint32_t button, uint32_t state) {
-            if (auto *window = focus_.get()) {
-                window->click()(focusX_, focusY_, button, state);
+            if (auto *window = pointerFocus_.get()) {
+                window->click()(pointerFocusX_, pointerFocusY_, button, state);
             }
         });
     pointer_->axis().connect([this](uint32_t, uint32_t axis, wl_fixed_t value) {
-        if (auto *window = focus_.get()) {
-            window->axis()(focusX_, focusY_, axis, value);
+        if (auto *window = pointerFocus_.get()) {
+            window->axis()(pointerFocusX_, pointerFocusY_, axis, value);
         }
     });
 }
@@ -77,17 +77,17 @@ void WaylandPointer::initTouch() {
             if (!window) {
                 return;
             }
-            focus_ = window->watch();
-            focusX_ = wl_fixed_to_int(sx);
-            focusY_ = wl_fixed_to_int(sy);
-            window->touchDown()(focusX_, focusY_);
+            touchFocus_ = window->watch();
+            touchFocusX_ = wl_fixed_to_int(sx);
+            touchFocusY_ = wl_fixed_to_int(sy);
+            window->touchDown()(touchFocusX_, touchFocusY_);
         });
     touch_->up().connect(
         [this](uint32_t, uint32_t, int) {
             // TODO handle id for multiple touch
-            if (auto *window = focus_.get()) {
-                window->touchUp()(focusX_, focusY_);
-                focus_.unwatch();
+            if (auto *window = touchFocus_.get()) {
+                window->touchUp()(touchFocusX_, touchFocusY_);
+                touchFocus_.unwatch();
                 window->leave()();
             }
         });

--- a/src/ui/classic/waylandpointer.cpp
+++ b/src/ui/classic/waylandpointer.cpp
@@ -19,6 +19,13 @@ WaylandPointer::WaylandPointer(wayland::WlSeat *seat) {
         } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && pointer_) {
             pointer_.reset();
         }
+
+        if ((caps & WL_SEAT_CAPABILITY_TOUCH) && !touch_) {
+            touch_.reset(seat->getTouch());
+            initTouch();
+        } else if (!(caps & WL_SEAT_CAPABILITY_POINTER) && touch_) {
+            touch_.reset();
+        }
     });
 }
 
@@ -60,6 +67,30 @@ void WaylandPointer::initPointer() {
             window->axis()(focusX_, focusY_, axis, value);
         }
     });
+}
+
+void WaylandPointer::initTouch() {
+    touch_->down().connect(
+        [this](uint32_t, uint32_t, wayland::WlSurface *surface, int, wl_fixed_t sx, wl_fixed_t sy) {
+            // TODO handle id for multiple touch
+            auto *window = static_cast<WaylandWindow *>(surface->userData());
+            if (!window) {
+                return;
+            }
+            focus_ = window->watch();
+            focusX_ = wl_fixed_to_int(sx);
+            focusY_ = wl_fixed_to_int(sy);
+            window->touchDown()(focusX_, focusY_);
+        });
+    touch_->up().connect(
+        [this](uint32_t, uint32_t, int) {
+            // TODO handle id for multiple touch
+            if (auto *window = focus_.get()) {
+                window->touchUp()(focusX_, focusY_);
+                focus_.unwatch();
+                window->leave()();
+            }
+        });
 }
 
 } // namespace fcitx::classicui

--- a/src/ui/classic/waylandpointer.h
+++ b/src/ui/classic/waylandpointer.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include "wl_pointer.h"
+#include "wl_touch.h"
 #include "wl_seat.h"
 
 namespace fcitx {
@@ -22,7 +23,9 @@ public:
 
 private:
     void initPointer();
+    void initTouch();
     std::unique_ptr<wayland::WlPointer> pointer_;
+    std::unique_ptr<wayland::WlTouch> touch_;
     TrackableObjectReference<WaylandWindow> focus_;
     int focusX_ = 0, focusY_ = 0;
     ScopedConnection capConn_;

--- a/src/ui/classic/waylandpointer.h
+++ b/src/ui/classic/waylandpointer.h
@@ -25,9 +25,11 @@ private:
     void initPointer();
     void initTouch();
     std::unique_ptr<wayland::WlPointer> pointer_;
+    TrackableObjectReference<WaylandWindow> pointerFocus_;
+    int pointerFocusX_ = 0, pointerFocusY_ = 0;
     std::unique_ptr<wayland::WlTouch> touch_;
-    TrackableObjectReference<WaylandWindow> focus_;
-    int focusX_ = 0, focusY_ = 0;
+    TrackableObjectReference<WaylandWindow> touchFocus_;
+    int touchFocusX_ = 0, touchFocusY_ = 0;
     ScopedConnection capConn_;
 };
 

--- a/src/ui/classic/waylandwindow.h
+++ b/src/ui/classic/waylandwindow.h
@@ -35,6 +35,9 @@ public:
     auto &axis() { return axis_; }
     auto &leave() { return leave_; }
 
+    auto &touchDown() { return touchDown_; }
+    auto &touchUp() { return touchUp_; }
+
 protected:
     WaylandUI *ui_;
     std::unique_ptr<wayland::WlSurface> surface_;
@@ -44,6 +47,9 @@ protected:
     Signal<void(int, int, uint32_t, uint32_t)> click_;
     Signal<void(int, int, uint32_t, wl_fixed_t)> axis_;
     Signal<void()> leave_;
+
+    Signal<void(int, int)> touchDown_;
+    Signal<void(int, int)> touchUp_;
 
     Rect serverAllocation_;
     Rect allocation_;


### PR DESCRIPTION
`WaylandWindow` has `click` event, but doesn't have `touch` event.
It is possible to add the event by using `WlSeat::getTouch`.

I understand that more implementation is needed to manage touch events in earnest,
but I think these modifications are necessary to make touch event work at least first.
