### PR TITLE
Upgrade wl_output to v4

### DIFF
--- a/src/lib/fcitx-wayland/core/wl_output.cpp
+++ b/src/lib/fcitx-wayland/core/wl_output.cpp
@@ -28,6 +28,16 @@ const struct wl_output_listener WlOutput::listener = {
         assert(*obj == wldata);
         { return obj->scale()(factor); }
     },
+    [](void *data, wl_output *wldata, const char *name) {
+      auto *obj = static_cast<WlOutput *>(data);
+      assert(*obj == wldata);
+      { return obj->name()(name); }
+    },
+    [](void *data, wl_output *wldata, const char *description) {
+      auto *obj = static_cast<WlOutput *>(data);
+      assert(*obj == wldata);
+      { return obj->description()(description); }
+    },
 };
 WlOutput::WlOutput(wl_output *data)
     : version_(wl_output_get_version(data)), data_(data) {

--- a/src/lib/fcitx-wayland/core/wl_output.h
+++ b/src/lib/fcitx-wayland/core/wl_output.h
@@ -22,6 +22,8 @@ public:
     auto &mode() { return modeSignal_; }
     auto &done() { return doneSignal_; }
     auto &scale() { return scaleSignal_; }
+    auto &name() { return nameSignal_; }
+    auto &description() { return descriptionSignal_; }
 
 private:
     static void destructor(wl_output *);
@@ -32,6 +34,8 @@ private:
     fcitx::Signal<void(uint32_t, int32_t, int32_t, int32_t)> modeSignal_;
     fcitx::Signal<void()> doneSignal_;
     fcitx::Signal<void(int32_t)> scaleSignal_;
+    fcitx::Signal<void(const char *)> nameSignal_;
+    fcitx::Signal<void(const char *)> descriptionSignal_;
     uint32_t version_;
     void *userData_ = nullptr;
     UniqueCPtr<wl_output, &destructor> data_;


### PR DESCRIPTION
Fcitx5 crashed due to
```
listener function for opcode 4 of wl_output is NULL
```
so I copy-pasted code and changed some variable names to make it fit to wl_output v4.

See https://gitlab.freedesktop.org/wayland/wayland/-/blob/main/protocol/wayland.xml