### PR TITLE
Fix a problem where spellhint by enchant does not work

### DIFF
--- a/src/modules/spell/spell-enchant.cpp
+++ b/src/modules/spell/spell-enchant.cpp
@@ -46,7 +46,7 @@ std::vector<std::string> SpellEnchant::hint(const std::string &language,
     std::vector<std::string> result;
     number = number > limit ? limit : number;
     result.reserve(number);
-    for (auto i = number; i < number; i++) {
+    for (auto i = 0; i < number; i++) {
         result.push_back(suggestions[i]);
     }
 


### PR DESCRIPTION
It's a simple bug.
Because of this bug, the prediction candidates by `enchant` did not show up.
This fix makes the candidates to show up correctly.
