### PR TITLE
Fix comparison warning

### DIFF
--- a/src/modules/spell/spell-enchant.cpp
+++ b/src/modules/spell/spell-enchant.cpp
@@ -46,7 +46,7 @@ std::vector<std::string> SpellEnchant::hint(const std::string &language,
     std::vector<std::string> result;
     number = number > limit ? limit : number;
     result.reserve(number);
-    for (auto i = 0; i < number; i++) {
+    for (size_t i = 0; i < number; i++) {
         result.push_back(suggestions[i]);
     }
 


### PR DESCRIPTION
I'm sorry.
The fix of https://github.com/fcitx/fcitx5/pull/417 causes a comparison warning.

```
warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’
```

I have fixed this.
