### PR TITLE
`CMAKE_PREFIX_PATH` should have higer priority than hard codeded paths

### DIFF
--- a/src/lib/fcitx-utils/standardpath.cpp
+++ b/src/lib/fcitx-utils/standardpath.cpp
@@ -190,10 +190,11 @@ private:
 
     static std::vector<std::string> defaultPaths(const char *env,
                                                  const char *defaultPath,
-                                                 const char *fcitxPath) {
+                                                 const char *fcitxPathType) {
         std::vector<std::string> dirs;
 
-        const char *dir = getenv(env);
+        const char *envDir = getenv(env);
+        const char *dir = envDir;
         if (!dir) {
             dir = defaultPath;
         }
@@ -202,18 +203,22 @@ private:
         std::unordered_set<std::string> uniqueDirs(rawDirs.begin(),
                                                    rawDirs.end());
 
+        auto path = StandardPath::fcitxPath(fcitxPathType);
+        std::string fcitxPath(path ? path : "");
+        if (!fcitxPath.empty()) {
+            if (envDir) {
+                rawDirs.push_back(fcitxPath);
+            } else {
+                rawDirs.insert(rawDirs.begin(), fcitxPath);
+            }
+            uniqueDirs.insert(fcitxPath);
+        }
+
         for (auto &s : rawDirs) {
             auto iter = uniqueDirs.find(s);
             if (iter != uniqueDirs.end()) {
                 uniqueDirs.erase(iter);
                 dirs.push_back(s);
-            }
-        }
-        if (fcitxPath) {
-            std::string path = StandardPath::fcitxPath(fcitxPath);
-            if (!path.empty() &&
-                std::find(dirs.begin(), dirs.end(), path) == dirs.end()) {
-                dirs.push_back(path);
             }
         }
 


### PR DESCRIPTION
In the current inmplementation, hard codeded addon config directories
(/usr/local/share/fcitx5/addon:/usr/share/fcitx5/addon) have higher
priority than the directory specified by `CMAKE_PREFIX_PATH` on loading
addon configs. As a result fcitx5 installed in non-regular paths such
as `/opt/fcitx5` fails to load addons when the file name described in
`Library` in an addon config file is different with the one described
in /usr/share/fcitx5/addon/*.conf.
Because fcitx5 v5.0.11 adds `lib` prefix to each bundled addons, it will
occur when distrubution's fcitx5 is v5.0.10 or former.