### PR TITLE
Fix build with ENABLE_KEYBOARD=off.

### DIFF
--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -151,19 +151,30 @@ FCITX_CONFIGURATION(
                                               _("Default page size"), 5,
                                               IntConstrain(1, 10)};
 #ifdef ENABLE_KEYBOARD
-    OptionWithAnnotation<bool, ToolTipAnnotation> overrideXkbOption{
+    OptionWithAnnotation<bool, ToolTipAnnotation>
+#else
+    HiddenOption<bool>
+#endif
+    overrideXkbOption{
         this,
         "OverrideXkbOption",
         _("Override Xkb Option"),
+#ifdef ENABLE_KEYBOARD
         false,
         {},
         {},
         {_("Whether to override the xkb option from display server. It will "
            "not affect the xkb option send to display, but just the xkb "
-           "options for custom xkb layout.")}};
-    Option<std::string> customXkbOption{this, "CustomXkbOption",
-                                        _("Custom Xkb Option"), ""};
+           "options for custom xkb layout.")}
 #endif
+    };
+#ifdef ENABLE_KEYBOARD
+    Option<std::string>
+#else
+    HiddenOption<std::string>
+#endif
+    customXkbOption{this, "CustomXkbOption",
+                                        _("Custom Xkb Option"), ""};
     HiddenOption<std::vector<std::string>> enabledAddons{
         this, "EnabledAddons", "Force Enabled Addons"};
     HiddenOption<std::vector<std::string>> disabledAddons{
@@ -314,7 +325,6 @@ int GlobalConfig::defaultPageSize() const {
     return d->behavior->defaultPageSize.value();
 }
 
-#ifdef ENABLE_KEYBOARD
 bool GlobalConfig::overrideXkbOption() const {
     FCITX_D();
     return d->behavior->overrideXkbOption.value();
@@ -324,7 +334,6 @@ const std::string &GlobalConfig::customXkbOption() const {
     FCITX_D();
     return d->behavior->customXkbOption.value();
 }
-#endif
 
 const std::vector<std::string> &GlobalConfig::enabledAddons() const {
     FCITX_D();

--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -150,6 +150,7 @@ FCITX_CONFIGURATION(
     Option<int, IntConstrain> defaultPageSize{this, "DefaultPageSize",
                                               _("Default page size"), 5,
                                               IntConstrain(1, 10)};
+#ifdef ENABLE_KEYBOARD
     OptionWithAnnotation<bool, ToolTipAnnotation> overrideXkbOption{
         this,
         "OverrideXkbOption",
@@ -162,6 +163,7 @@ FCITX_CONFIGURATION(
            "options for custom xkb layout.")}};
     Option<std::string> customXkbOption{this, "CustomXkbOption",
                                         _("Custom Xkb Option"), ""};
+#endif
     HiddenOption<std::vector<std::string>> enabledAddons{
         this, "EnabledAddons", "Force Enabled Addons"};
     HiddenOption<std::vector<std::string>> disabledAddons{
@@ -312,6 +314,7 @@ int GlobalConfig::defaultPageSize() const {
     return d->behavior->defaultPageSize.value();
 }
 
+#ifdef ENABLE_KEYBOARD
 bool GlobalConfig::overrideXkbOption() const {
     FCITX_D();
     return d->behavior->overrideXkbOption.value();
@@ -321,6 +324,7 @@ const std::string &GlobalConfig::customXkbOption() const {
     FCITX_D();
     return d->behavior->customXkbOption.value();
 }
+#endif
 
 const std::vector<std::string> &GlobalConfig::enabledAddons() const {
     FCITX_D();

--- a/src/lib/fcitx/globalconfig.h
+++ b/src/lib/fcitx/globalconfig.h
@@ -51,7 +51,6 @@ public:
     const KeyList &defaultNextCandidate() const;
     int defaultPageSize() const;
 
-#ifdef ENABLE_KEYBOARD
     /**
      * Override the xkb option from display.
      *
@@ -76,7 +75,6 @@ public:
      * @since 5.0.14
      */
     const std::string &customXkbOption() const;
-#endif
 
     const std::vector<std::string> &enabledAddons() const;
     const std::vector<std::string> &disabledAddons() const;

--- a/src/lib/fcitx/globalconfig.h
+++ b/src/lib/fcitx/globalconfig.h
@@ -51,6 +51,7 @@ public:
     const KeyList &defaultNextCandidate() const;
     int defaultPageSize() const;
 
+#ifdef ENABLE_KEYBOARD
     /**
      * Override the xkb option from display.
      *
@@ -75,6 +76,7 @@ public:
      * @since 5.0.14
      */
     const std::string &customXkbOption() const;
+#endif
 
     const std::vector<std::string> &enabledAddons() const;
     const std::vector<std::string> &disabledAddons() const;

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1907,12 +1907,14 @@ void Instance::reloadConfig() {
             return true;
         });
     }
+#ifdef ENABLE_KEYBOARD
     d->keymapCache_.clear();
     d->icManager_.foreach([d](InputContext *ic) {
         auto *inputState = ic->propertyFor(&d->inputStateFactory_);
         inputState->resetXkbState();
         return true;
     });
+#endif
 }
 
 void Instance::resetInputMethodList() {


### PR DESCRIPTION
Changes below

https://github.com/fcitx/fcitx5/blob/09969b0982cca27a892c7bab17a1c33df435280f/src/lib/fcitx/instance.cpp#L1910-L1915

added in 217593a breaks building with `ENABLE_KEYBOARD=off` (namely on Android). Also those options seems useless without XKB.