### PR TITLE
Fix group enumerating

### DIFF
--- a/src/lib/fcitx/inputmethodmanager.cpp
+++ b/src/lib/fcitx/inputmethodmanager.cpp
@@ -276,6 +276,28 @@ const InputMethodGroup &InputMethodManager::currentGroup() const {
     return d->groups_.find(d->groupOrder_.front())->second;
 }
 
+void InputMethodManager::enumerateGroup(bool forward) {
+    FCITX_D();
+    if (groupCount() < 2) {
+        return;
+    }
+    emit<InputMethodManager::CurrentGroupAboutToChange>(d->groupOrder_.front());
+    if (forward) {
+        d->groupOrder_.splice(
+            d->groupOrder_.end(),
+            d->groupOrder_,
+            d->groupOrder_.begin()
+        );
+    } else {
+        d->groupOrder_.splice(
+            d->groupOrder_.begin(),
+            d->groupOrder_,
+            --(d->groupOrder_.end())
+        );
+    }
+    emit<InputMethodManager::CurrentGroupChanged>(d->groupOrder_.front());
+}
+
 void InputMethodManager::setDefaultInputMethod(const std::string &name) {
     FCITX_D();
     auto &currentGroup = d->groups_.find(d->groupOrder_.front())->second;

--- a/src/lib/fcitx/inputmethodmanager.h
+++ b/src/lib/fcitx/inputmethodmanager.h
@@ -84,6 +84,9 @@ public:
     /// Return the current group.
     const InputMethodGroup &currentGroup() const;
 
+    /// Enumerate input method groups.
+    void enumerateGroup(bool forward);
+
     /**
      * Set default input method for current group.
      *

--- a/src/modules/xcb/xcbconnection.h
+++ b/src/modules/xcb/xcbconnection.h
@@ -106,7 +106,8 @@ private:
     std::unique_ptr<XCBKeyboard> keyboard_;
 
     UniqueCPtr<xcb_key_symbols_t, xcb_key_symbols_free> syms_;
-    size_t groupIndex_ = 0;
+    bool pendingGroupEnumeration_ = false;
+    bool isPendingGroupEnumerationForward_ = true;
     KeyList forwardGroup_, backwardGroup_;
     bool doGrab_ = false;
     bool keyboardGrabbed_ = false;


### PR DESCRIPTION
For simplification, the following describes the case where `forwarding` is `true`.

There is the problem where `Instance::enumerateGroup` and `InstancePrivate::navigateGroup` can't select the third and later groups.

In `navigateGroup`, `inputState->pendingGroupIndex_` is always `1` because every time `acceptGroupChange` is called, it goes back to `0`.
`InputMethodManager::setCurrentGroup` swaps the currently selected group with the newly selected one.
So the current group enumerating logic just swaps the first group and the second group, and can't select the third and later groups.

This PR fixes this problem.

I have deleted the notification logic in `navigateGroup`.
This is because this notification is executed at the following logic after all.

https://github.com/fcitx/fcitx5/blob/e537bc9e2f6158a0873656a4f6d4be1230cff850/src/lib/fcitx/instance.cpp#L796-L818

Note: Changing groups freeze my environment because of #430, so I have tested this fix with the following fix.

```diff
--- a/src/ui/classic/waylandinputwindow.cpp
+++ b/src/ui/classic/waylandinputwindow.cpp
@@ -115,7 +115,7 @@ void WaylandInputWindow::update(fcitx::InputContext *ic) {
             panelSurfaceV2_.reset(im->getInputPopupSurface(window_->surface()));
         }
     } else if (ic->frontend() == std::string_view("wayland")) {
-        panelSurface_->setOverlayPanel();
+        // panelSurface_->setOverlayPanel();
     }
     if (!panelSurface_ && !panelSurfaceV2_) {
         return;
```
