### PR TITLE
Enable KeyboardEngine to use hint by default

### DIFF
--- a/src/im/keyboard/keyboard.cpp
+++ b/src/im/keyboard/keyboard.cpp
@@ -327,6 +327,16 @@ std::vector<InputMethodEntry> KeyboardEngine::listInputMethods() {
     return result;
 }
 
+void KeyboardEngine::activate(const InputMethodEntry &entry,
+                              InputContextEvent &event) {
+    if (config_.enableHintByDefault.value() &&
+        supportHint(entry.languageCode())) {
+        auto *inputContext = event.inputContext();
+        auto *state = inputContext->propertyFor(&factory_);
+        state->enableWordHint_ = true;
+    }
+}
+
 void KeyboardEngine::reloadConfig() {
     readAsIni(config_, "conf/keyboard.conf");
     selectionKeys_.clear();

--- a/src/im/keyboard/keyboard.cpp
+++ b/src/im/keyboard/keyboard.cpp
@@ -197,6 +197,10 @@ private:
 
 } // namespace
 
+KeyboardEngineState::KeyboardEngineState(KeyboardEngine *engine) {
+    enableWordHint_ = engine->config().enableHintByDefault.value();
+}
+
 KeyboardEngine::KeyboardEngine(Instance *instance) : instance_(instance) {
     setupDefaultLongPressConfig(longPressConfig_);
     registerDomain("xkeyboard-config", XKEYBOARDCONFIG_DATADIR "/locale");
@@ -325,16 +329,6 @@ std::vector<InputMethodEntry> KeyboardEngine::listInputMethods() {
                 .setConfigurable(true)));
     }
     return result;
-}
-
-void KeyboardEngine::activate(const InputMethodEntry &entry,
-                              InputContextEvent &event) {
-    if (config_.enableHintByDefault.value() &&
-        supportHint(entry.languageCode())) {
-        auto *inputContext = event.inputContext();
-        auto *state = inputContext->propertyFor(&factory_);
-        state->enableWordHint_ = true;
-    }
 }
 
 void KeyboardEngine::reloadConfig() {

--- a/src/im/keyboard/keyboard.h
+++ b/src/im/keyboard/keyboard.h
@@ -84,6 +84,7 @@ class KeyboardEngine;
 enum class CandidateMode { Hint, LongPress };
 
 struct KeyboardEngineState : public InputContextProperty {
+    KeyboardEngineState(KeyboardEngine *engine);
     bool enableWordHint_ = false;
     bool oneTimeEnableWordHint_ = false;
     InputBuffer buffer_;
@@ -112,11 +113,10 @@ public:
     ~KeyboardEngine();
     Instance *instance() { return instance_; }
     void keyEvent(const InputMethodEntry &entry, KeyEvent &keyEvent) override;
-    void activate(const InputMethodEntry &entry,
-                  InputContextEvent &event) override;
     std::vector<InputMethodEntry> listInputMethods() override;
     void reloadConfig() override;
 
+    const KeyboardEngineConfig &config() { return config_; }
     const Configuration *getConfig() const override { return &config_; }
     void setConfig(const RawConfig &config) override {
         config_.load(config, true);
@@ -188,7 +188,7 @@ private:
         quickphraseHandler_;
 
     FactoryFor<KeyboardEngineState> factory_{
-        [](InputContext &) { return new KeyboardEngineState; }};
+        [this](InputContext &) { return new KeyboardEngineState(this); }};
 
     std::unordered_set<std::string> longPressBlocklistSet_;
 

--- a/src/im/keyboard/keyboard.h
+++ b/src/im/keyboard/keyboard.h
@@ -56,6 +56,8 @@ FCITX_CONFIGURATION(
     OptionWithAnnotation<ChooseModifier, ChooseModifierI18NAnnotation>
         chooseModifier{this, "Choose Modifier", _("Choose key modifier"),
                        ChooseModifier::Alt};
+    Option<bool> enableHintByDefault{this, "EnableHintByDefault",
+                                     _("Enable hint by default"), false};
     KeyListOption hintTrigger{this,
                               "Hint Trigger",
                               _("Trigger hint mode"),
@@ -110,6 +112,8 @@ public:
     ~KeyboardEngine();
     Instance *instance() { return instance_; }
     void keyEvent(const InputMethodEntry &entry, KeyEvent &keyEvent) override;
+    void activate(const InputMethodEntry &entry,
+                  InputContextEvent &event) override;
     std::vector<InputMethodEntry> listInputMethods() override;
     void reloadConfig() override;
 


### PR DESCRIPTION
Currently, we have to input `Control+Alt+H` to enable hint in KeyboardEngine.
I think it would be more useful if we could use hint by default in KeyboardEngine.

This fix adds `EnableHintByDefault` parameter to keyboard.conf.
By setting this parameter to `True`, we can use hint by default in KeyboardEngine.

~/.config/fcitx5/conf/keyboard.conf
```ini
EnableHintByDefault=True
```

I have confirmed this works correctly in keyboard-us.
