### PR TITLE
Make Fcitx5::Module::WaylandIM usable from outside addons

### DIFF
--- a/src/frontend/waylandim/CMakeLists.txt
+++ b/src/frontend/waylandim/CMakeLists.txt
@@ -17,4 +17,4 @@ fcitx5_translate_desktop_file(${CMAKE_CURRENT_BINARY_DIR}/waylandim.conf.in wayl
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/waylandim.conf" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/addon"
         COMPONENT config)
 
-fcitx5_export_module(WaylandIM TARGET waylandim BUILD_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}" HEADERS waylandim_public.h)
+fcitx5_export_module(WaylandIM TARGET waylandim BUILD_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}" HEADERS waylandim_public.h INSTALL)


### PR DESCRIPTION
We are creating some addons, and we need to use `Fcitx5::Module::WaylandIM`.

Currently, we can use `Fcitx5::Module::Wayland`, but cannot use `Fcitx5::Module::WaylandIM`.
It is because there are no cmake files of `Fcitx5::Module::WaylandIM` such as `Fcitx5ModuleWaylandIMConfig.cmake`.

Is the reason there is no `INSTALL` to `fcitx5_export_module` of waylandim because it is not supposed to be used from an external addon?
If we have an addon needing to use this, is it possible to have such a modification put in?
