### PR TITLE
Add simple group enumerating function for addons

### DIFF
--- a/src/lib/fcitx/inputmethodmanager.cpp
+++ b/src/lib/fcitx/inputmethodmanager.cpp
@@ -276,6 +276,28 @@ const InputMethodGroup &InputMethodManager::currentGroup() const {
     return d->groups_.find(d->groupOrder_.front())->second;
 }
 
+void InputMethodManager::enumerateGroup(bool forward) {
+    FCITX_D();
+    if (groupCount() < 2) {
+        return;
+    }
+    emit<InputMethodManager::CurrentGroupAboutToChange>(d->groupOrder_.front());
+    if (forward) {
+        d->groupOrder_.splice(
+            d->groupOrder_.end(),
+            d->groupOrder_,
+            d->groupOrder_.begin()
+        );
+    } else {
+        d->groupOrder_.splice(
+            d->groupOrder_.begin(),
+            d->groupOrder_,
+            --(d->groupOrder_.end())
+        );
+    }
+    emit<InputMethodManager::CurrentGroupChanged>(d->groupOrder_.front());
+}
+
 void InputMethodManager::setDefaultInputMethod(const std::string &name) {
     FCITX_D();
     auto &currentGroup = d->groups_.find(d->groupOrder_.front())->second;

--- a/src/lib/fcitx/inputmethodmanager.cpp
+++ b/src/lib/fcitx/inputmethodmanager.cpp
@@ -292,7 +292,7 @@ void InputMethodManager::enumerateGroup(bool forward) {
         d->groupOrder_.splice(
             d->groupOrder_.begin(),
             d->groupOrder_,
-            --(d->groupOrder_.end())
+            std::prev(d->groupOrder_.end())
         );
     }
     emit<InputMethodManager::CurrentGroupChanged>(d->groupOrder_.front());

--- a/src/lib/fcitx/inputmethodmanager.h
+++ b/src/lib/fcitx/inputmethodmanager.h
@@ -84,6 +84,9 @@ public:
     /// Return the current group.
     const InputMethodGroup &currentGroup() const;
 
+    /// Simply enumerate input method groups.
+    void enumerateGroup(bool forward);
+
     /**
      * Set default input method for current group.
      *


### PR DESCRIPTION
Our virtual keyboard addon needs to simply enumerate the current IM group.
There is a switching language button, and we would like to enumerate the current IM group by pressing it.

I've sent a similar PR before: https://github.com/fcitx/fcitx5/pull/431
and I understand Fcitx5 has its own stacking style switching function to control the current IM group.

But how about just adding a function of simple enumeration to `InputMethodManager` for addons?
