### PR TITLE
Add virtual key handling to InputContext and WaylandIMInputContextV1

### DIFF
--- a/src/frontend/waylandim/waylandimserver.cpp
+++ b/src/frontend/waylandim/waylandimserver.cpp
@@ -427,13 +427,44 @@ void WaylandIMInputContextV1::keyCallback(uint32_t serial, uint32_t time,
                        server_->modifiers_, code),
                    state == WL_KEYBOARD_KEY_STATE_RELEASED, time);
 
-    if (state == WL_KEYBOARD_KEY_STATE_RELEASED && key == repeatKey_) {
+    processKeyEvent(event, false, serial);
+}
+
+void WaylandIMInputContextV1::virtualKeyEventImpl(KeyEvent &event) {
+    // `mods_locked` value seems to be 16 usually.
+    // If we need to implement behavior such as `capslocked` for virtual key events, 
+    // we will need to manage this `mods_locked` value.
+    if (event.rawKey().hasModifier()) {
+        if (event.rawKey().states().test(KeyState::Shift)) {
+            modifiersCallback(serial_, (uint32_t)KeyState::Shift, 0, 16, 0);
+        }
+    } else {
+        modifiersCallback(serial_, 0, 0, 16, 0);
+    }
+
+    processKeyEvent(event, true, serial_);
+}
+
+void WaylandIMInputContextV1::processKeyEvent(KeyEvent &event,
+                                              bool isVirtualKey,
+                                              uint32_t serial) {
+    const uint32_t key = event.rawKey().code() > 8 ? event.rawKey().code() - 8
+                                                   : 0;
+    const auto state = event.isRelease() ? WL_KEYBOARD_KEY_STATE_RELEASED
+                                         : WL_KEYBOARD_KEY_STATE_PRESSED;
+
+    const auto cancelRepeat = isVirtualKey
+        ? (state == WL_KEYBOARD_KEY_STATE_RELEASED)
+        // Strict condition for physical keys.
+        : (state == WL_KEYBOARD_KEY_STATE_RELEASED && key == repeatKey_);
+
+    if (cancelRepeat) {
         timeEvent_->setEnabled(false);
     } else if (state == WL_KEYBOARD_KEY_STATE_PRESSED &&
-               xkb_keymap_key_repeats(server_->keymap_.get(), code)) {
+               xkb_keymap_key_repeats(server_->keymap_.get(), event.rawKey().code())) {
         if (repeatRate_) {
             repeatKey_ = key;
-            repeatTime_ = time;
+            repeatTime_ = event.time();
             repeatSym_ = event.rawKey().sym();
             // Let's trick the key event system by fake our first.
             // Remove 100 from the initial interval.
@@ -445,10 +476,11 @@ void WaylandIMInputContextV1::keyCallback(uint32_t serial, uint32_t time,
     WAYLANDIM_DEBUG() << event.key().toString()
                       << " IsRelease=" << event.isRelease();
     if (!keyEvent(event)) {
-        ic_->key(serial, time, key, state);
+        ic_->key(serial, event.time(), key, state);
     }
     server_->display_->flush();
 }
+
 void WaylandIMInputContextV1::modifiersCallback(uint32_t serial,
                                                 uint32_t mods_depressed,
                                                 uint32_t mods_latched,

--- a/src/frontend/waylandim/waylandimserver.h
+++ b/src/frontend/waylandim/waylandimserver.h
@@ -84,6 +84,7 @@ public:
     void deactivate(wayland::ZwpInputMethodContextV1 *id);
 
 protected:
+    void virtualKeyEventImpl(KeyEvent &event) override;
     void commitStringImpl(const std::string &text) override {
         if (!ic_) {
             return;
@@ -120,6 +121,7 @@ private:
     void keymapCallback(uint32_t format, int32_t fd, uint32_t size);
     void keyCallback(uint32_t serial, uint32_t time, uint32_t key,
                      uint32_t state);
+    void processKeyEvent(KeyEvent &event, bool isVirtualKey, uint32_t serial);
     void modifiersCallback(uint32_t serial, uint32_t mods_depressed,
                            uint32_t mods_latched, uint32_t mods_locked,
                            uint32_t group);

--- a/src/lib/fcitx/inputcontext.cpp
+++ b/src/lib/fcitx/inputcontext.cpp
@@ -243,6 +243,19 @@ bool InputContext::keyEvent(KeyEvent &event) {
     return result;
 }
 
+void InputContext::virtualKeyEvent(KeyEvent &event) {
+    decltype(std::chrono::steady_clock::now()) start;
+    // Don't query time if we don't want log.
+    if (::keyTrace().checkLogLevel(LogLevel::Debug)) {
+        start = std::chrono::steady_clock::now();
+    }
+    virtualKeyEventImpl(event);
+    FCITX_KEYTRACE() << "KeyEvent handling time: "
+                     << std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::steady_clock::now() - start)
+                            .count();
+}
+
 void InputContext::invokeAction(InvokeActionEvent &event) {
     FCITX_D();
     RETURN_IF_HAS_NO_FOCUS();
@@ -331,6 +344,11 @@ InputPanel &InputContext::inputPanel() {
 StatusArea &InputContext::statusArea() {
     FCITX_D();
     return d->statusArea_;
+}
+
+void InputContext::virtualKeyEventImpl(KeyEvent &event) {
+    FCITX_D();
+    d->postEvent(event);
 }
 
 void InputContext::updateClientSideUIImpl() {}

--- a/src/lib/fcitx/inputcontext.h
+++ b/src/lib/fcitx/inputcontext.h
@@ -133,6 +133,10 @@ public:
     /// Send a key event to current input context.
     bool keyEvent(KeyEvent &event);
 
+    /// Send a virtual key event to current input context.
+    /// This handles the event the same way as physical key events.
+    void virtualKeyEvent(KeyEvent &event);
+
     /// Returns whether the input context holds the input focus. Input context
     /// need to have focus.
     bool hasFocus() const;
@@ -253,6 +257,15 @@ public:
     void updateProperty(const InputContextPropertyFactory *factory);
 
 protected:
+    /**
+     * Process the virtual key event.
+     *
+     * @param event KeyEvent
+     * 
+     * @see virtualKeyEvent
+     */
+    virtual void virtualKeyEventImpl(KeyEvent &event);
+
     /**
      * Send the committed string to client
      *


### PR DESCRIPTION
For a virtual keyboard, we need an interface to convey virtual key inputs to InputContext.

When we were beginning to implement the virtual keyboard, we tried to manage virtual key inputs
using `keyEvent` and `forwardKey` and `commitString` and so on...
It was tough to handle them properly on the virtual keyboard side.

It would be nice if we could pass virtual keys to the same logic as physical keys.

In `WaylandIMInputContextV1`, key inputs are processed in the `keyCallback` method,
but there is no way to pass virtual key inputs to it.

This fix adds new methods `virtualKeyEvent` and `virtualKeyEventImpl` to InputContext.

By default, it works the same as the existing `keyEvent` method,
but `virtualKeyEventImpl` can be overridden to handle virtual key events.

In this fix, core key logic can be shared between physical and virtual key events.
