### PR TITLE
Fix build with ENABLE_KEYBOARD=off.

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -135,13 +135,13 @@ struct InputState : public InputContextProperty {
     }
 
     auto xkbComposeState() { return xkbComposeState_.get(); }
+    void setModsAllReleased() { modsAllReleased_ = true; }
+    bool isModsAllReleased() const { return modsAllReleased_; }
 #endif
 
     bool isActive() const { return active_; }
     void setActive(bool active);
     void setLocalIM(const std::string &localIM);
-    void setModsAllReleased() { modsAllReleased_ = true; }
-    bool isModsAllReleased() const { return modsAllReleased_; }
 
     CheckInputMethodChanged *imChanged_ = nullptr;
     int keyReleased_ = -1;


### PR DESCRIPTION
55bf888 defines variable `modsAllReleased_` inside `#ifdef ENABLE_KEYBOARD`, but it's used by method `{is,set}ModsAllReleased()` outside `#ifdef` section.