### PR TITLE
AppStream metainfo: Add content_rating tag

### DIFF
--- a/data/org.fcitx.Fcitx5.metainfo.xml.in
+++ b/data/org.fcitx.Fcitx5.metainfo.xml.in
@@ -43,4 +43,5 @@
     <release version="5.0.0" date="2020-10-30"/>
   </releases>
   <launchable type="desktop-id">org.fcitx.Fcitx5.desktop</launchable>
+  <content_rating type="oars-1.1"/>
 </component>


### PR DESCRIPTION
The content_rating tag is needed in order to pass validation with
appstream-util (appstream-glib).
Flathub CI builds are failing without this.
The tag is empty as no age restrictions are needed.