### PR TITLE
Remove trailing slash from dir paths before checking uniqueness. Fix #519

### DIFF
--- a/src/lib/fcitx-utils/standardpath.cpp
+++ b/src/lib/fcitx-utils/standardpath.cpp
@@ -199,6 +199,9 @@ private:
         }
 
         auto rawDirs = stringutils::split(dir, ":");
+        for (auto &rawDir : rawDirs) {
+            rawDir = fs::cleanPath(rawDir);
+        }
         std::unordered_set<std::string> uniqueDirs(rawDirs.begin(),
                                                    rawDirs.end());
 
@@ -210,7 +213,8 @@ private:
             }
         }
         if (fcitxPath) {
-            std::string path = StandardPath::fcitxPath(fcitxPath);
+            std::string path =
+                fs::cleanPath(StandardPath::fcitxPath(fcitxPath));
             if (!path.empty() &&
                 std::find(dirs.begin(), dirs.end(), path) == dirs.end()) {
                 dirs.push_back(path);

--- a/test/testfs.cpp
+++ b/test/testfs.cpp
@@ -69,6 +69,12 @@ int main() {
     TEST_PATH("./../a/../c/b", "../c/b");
     TEST_PATH("./.../a/../c/b", ".../c/b");
 
+    TEST_PATH("/", "/");
+    TEST_PATH("///", "///");
+    TEST_PATH("/", "/");
+    TEST_PATH("./././.", "");
+    TEST_PATH("/usr/share/", "/usr/share");
+
     TEST_DIRNAME("/usr/lib");
     TEST_DIRNAME("/usr/");
     TEST_DIRNAME("usr");

--- a/test/teststandardpath.cpp
+++ b/test/teststandardpath.cpp
@@ -19,12 +19,15 @@ using namespace fcitx;
 
 void test_basic() {
     FCITX_ASSERT(setenv("XDG_CONFIG_HOME", "/TEST/PATH", 1) == 0);
-    FCITX_ASSERT(setenv("XDG_CONFIG_DIRS", "/TEST/PATH1:/TEST/PATH2", 1) == 0);
+    FCITX_ASSERT(setenv("XDG_CONFIG_DIRS",
+                        "/TEST/PATH1/:/TEST/PATH2:/TEST/PATH2/:/TEST/PATH1",
+                        1) == 0);
     FCITX_ASSERT(setenv("XDG_DATA_DIRS", TEST_ADDON_DIR, 1) == 0);
     StandardPath standardPath(true);
 
     FCITX_ASSERT(standardPath.userDirectory(StandardPath::Type::Config) ==
                  "/TEST/PATH");
+    // The order to the path should be kept for their first appearance.
     FCITX_ASSERT(standardPath.directories(StandardPath::Type::Config) ==
                  std::vector<std::string>({"/TEST/PATH1", "/TEST/PATH2"}));
 


### PR DESCRIPTION
Remove trailing slash from dir paths before checking uniqueness. This fixes fcitx#519