### PR TITLE
Link to `XKBCommon::XKBCommon` to fix build

### DIFF
--- a/src/im/keyboard/CMakeLists.txt
+++ b/src/im/keyboard/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_library(keyboard STATIC keyboard.cpp isocodes.cpp xkbrules.cpp xmlparser.cpp longpress.cpp compose.cpp)
 target_link_libraries(keyboard Fcitx5::Core Expat::Expat LibIntl::LibIntl Fcitx5::Module::Spell Fcitx5::Module::Notifications  Fcitx5::Module::QuickPhrase PkgConfig::JsonC ${FMT_TARGET})
 if (ENABLE_X11)
-    target_link_libraries(keyboard Fcitx5::Module::XCB)
+    target_link_libraries(keyboard Fcitx5::Module::XCB XKBCommon::XKBCommon)
 endif()
 if (TARGET Fcitx5::Module::Emoji)
     target_link_libraries(keyboard Fcitx5::Module::Emoji)


### PR DESCRIPTION
This fixes a build error on openSUSE.

/home/abuild/rpmbuild/BUILD/fcitx5-5.0.18/src/im/keyboard/keyboard.h:10:10: fatal error: xkbcommon/xkbcommon-compose.h: No such file or directory