### PR TITLE
Bugfix: guard against disabled xcb module

### DIFF
--- a/src/ui/classic/classicui.cpp
+++ b/src/ui/classic/classicui.cpp
@@ -278,10 +278,12 @@ void ClassicUI::update(UserInterfaceComponent component,
         // unfortunately, hopefully main display is X wayland.
         // The position will be wrong anyway.
 #ifdef ENABLE_X11
-        auto mainX11Display = xcb()->call<IXCBModule::mainDisplay>();
-        if (!mainX11Display.empty()) {
-            if (auto *uiPtr = findValue(uis_, "x11:" + mainX11Display)) {
-                ui = uiPtr->get();
+        if (auto *xcbAddon = xcb()) {
+            auto mainX11Display = xcbAddon->call<IXCBModule::mainDisplay>();
+            if (!mainX11Display.empty()) {
+                if (auto *uiPtr = findValue(uis_, "x11:" + mainX11Display)) {
+                    ui = uiPtr->get();
+                }
             }
         }
 #endif


### PR DESCRIPTION
If XCB module is disabled here, the fcitx5 server will SEGV.

It can be easily reproduced by:
1. disable XCB addon from fcitx5-configtool
2. use wayland and run sth like GTK_IM_MODULE=fcitx5 firefox
3. toggle the im, the fcitx5 server will crash