### PR TITLE
Proposal: add option to change wayland ui resolution

### DIFF
--- a/src/ui/classic/classicui.h
+++ b/src/ui/classic/classicui.h
@@ -132,7 +132,22 @@ FCITX_CONFIGURATION(
                "configuration needs to support this to use this feature.")}};
     Option<std::string, NotEmpty, DefaultMarshaller<std::string>,
            ThemeAnnotation>
-        theme{this, "Theme", _("Theme"), "default"};);
+        theme{this, "Theme", _("Theme"), "default"};
+    Option<int, IntConstrain, DefaultMarshaller<int>, ToolTipAnnotation>
+        forceWaylandDPI{
+            this,
+            "ForceWaylandDPI",
+            _("Force font DPI on Wayland"),
+            0,
+            IntConstrain(0),
+            {},
+            {_("Override the font DPI on Wayland. Normally Wayland use just "
+               "use 96 as font DPI in combinition with the screen scale "
+               "factor. This option allows you to override the font DPI value. "
+               "It may be used in conjunction with other text scale options "
+               "for other application to achieve desired font size globally "
+               "on Wayland. If the value is 0, it means this option is "
+               "disabled.")}};);
 
 class ClassicUI final : public UserInterface {
 public:

--- a/src/ui/classic/inputwindow.cpp
+++ b/src/ui/classic/inputwindow.cpp
@@ -694,6 +694,19 @@ void InputWindow::wheel(bool up) {
     }
 }
 
+void InputWindow::setFontDPI(int dpi) {
+    // Unlike pango cairo context, Cairo font map does not accept negative dpi.
+    // Restore to default value instead.
+    if (dpi <= 0) {
+        pango_cairo_font_map_set_resolution(
+            PANGO_CAIRO_FONT_MAP(fontMap_.get()), fontMapDefaultDPI_);
+    } else {
+        pango_cairo_font_map_set_resolution(
+            PANGO_CAIRO_FONT_MAP(fontMap_.get()), dpi);
+    }
+    pango_cairo_context_set_resolution(context_.get(), dpi);
+}
+
 int InputWindow::highlight() const {
     int highlightIndex = (hoverIndex_ >= 0) ? hoverIndex_ : candidateIndex_;
     return highlightIndex;

--- a/src/ui/classic/inputwindow.h
+++ b/src/ui/classic/inputwindow.h
@@ -61,6 +61,9 @@ public:
     void wheel(bool up);
 
 protected:
+    // Override the font DPI in cairo/pango context. If less-equal than zero, it
+    // will restore to font map default dpi.
+    void setFontDPI(int dpi);
     void resizeCandidates(size_t n);
     void appendText(std::string &s, PangoAttrList *attrList,
                     PangoAttrList *highlightAttrList, const Text &text);

--- a/src/ui/classic/waylandinputwindow.cpp
+++ b/src/ui/classic/waylandinputwindow.cpp
@@ -80,8 +80,9 @@ void WaylandInputWindow::initPanel() {
     if (!window_->surface()) {
         window_->createWindow();
         updateBlur();
-        return;
     }
+
+    setFontDPI(*parent_->config().forceWaylandDPI);
 }
 
 void WaylandInputWindow::setBlurManager(

--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -124,16 +124,7 @@ void XCBInputWindow::updateDPI(InputContext *inputContext) {
     dpi_ = ui_->dpiByPosition(inputContext->cursorRect().left(),
                               inputContext->cursorRect().top());
 
-    // Unlike pango cairo context, Cairo font map does not accept negative dpi.
-    // Restore to default value instead.
-    if (dpi_ < 0) {
-        pango_cairo_font_map_set_resolution(
-            PANGO_CAIRO_FONT_MAP(fontMap_.get()), fontMapDefaultDPI_);
-    } else {
-        pango_cairo_font_map_set_resolution(
-            PANGO_CAIRO_FONT_MAP(fontMap_.get()), dpi_);
-    }
-    pango_cairo_context_set_resolution(context_.get(), dpi_);
+    setFontDPI(dpi_);
 }
 
 void XCBInputWindow::update(InputContext *inputContext) {


### PR DESCRIPTION
There's currently DPI detection logic in XCB ui, but wayland applications need to handle DPI themselves, and this option is currently missing. On my 1080p screen, the wayland ui candidate box is too small, as it rendered in the default 96 dpi. I could workaround it by setting a huge font size, but that would also increase the candidate box size in qt & gtk.

This PR add an option to classicui configure section, setting a DPI separately for wayland ui.