### PR TITLE
Control the behavior of virtual keyboard when the object gets focus or loses focus

### DIFF
--- a/src/lib/fcitx/inputcontext.cpp
+++ b/src/lib/fcitx/inputcontext.cpp
@@ -163,6 +163,16 @@ void InputContext::hideVirtualKeyboard() const {
     return instance->userInterfaceManager().hideVirtualKeyboard();
 }
 
+bool InputContext::clientControlVirtualkeyboardVisibility() const {
+    FCITX_D();
+    return d->clientControlVirtualkeyboardVisibility_;
+}
+
+void InputContext::setClientControlVirtualkeyboardVisibility(bool show) {
+    FCITX_D();
+    d->clientControlVirtualkeyboardVisibility_ = show;
+}
+
 CapabilityFlags calculateFlags(CapabilityFlags flag, bool isPreeditEnabled) {
     if (!isPreeditEnabled) {
         flag = flag.unset(CapabilityFlag::Preedit)

--- a/src/lib/fcitx/inputcontext.h
+++ b/src/lib/fcitx/inputcontext.h
@@ -267,6 +267,10 @@ public:
 
     void hideVirtualKeyboard() const;
 
+    bool clientControlVirtualkeyboardVisibility() const;
+
+    void setClientControlVirtualkeyboardVisibility(bool show);
+
 protected:
     /**
      * Send the committed string to client

--- a/src/lib/fcitx/inputcontext_p.h
+++ b/src/lib/fcitx/inputcontext_p.h
@@ -137,6 +137,7 @@ public:
     InputPanel inputPanel_;
     StatusArea statusArea_;
     bool hasFocus_ = false;
+    bool clientControlVirtualkeyboardVisibility_ = false;
     std::string program_;
     CapabilityFlags capabilityFlags_;
     bool isPreeditEnabled_ = true;

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -984,7 +984,9 @@ Instance::Instance(int argc, char **argv) {
 
             if (virtualKeyboardAutoShow()) {
                 auto *inputContext = icEvent.inputContext();
-                inputContext->showVirtualKeyboard();
+                if (!inputContext->clientControlVirtualkeyboardVisibility()) {
+                    inputContext->showVirtualKeyboard();
+                }
             }
 
             if (!d->globalConfig_.showInputMethodInformationWhenFocusIn()) {
@@ -1022,7 +1024,9 @@ Instance::Instance(int argc, char **argv) {
             deactivateInputMethod(icEvent);
             if (virtualKeyboardAutoHide()) {
                 auto *inputContext = icEvent.inputContext();
-                inputContext->hideVirtualKeyboard();
+                if (!inputContext->clientControlVirtualkeyboardVisibility()) {
+                    inputContext->hideVirtualKeyboard();
+                }
             }
         }));
     d->eventWatchers_.emplace_back(d->watchEvent(

--- a/src/ui/virtualkeyboard/virtualkeyboard.cpp
+++ b/src/ui/virtualkeyboard/virtualkeyboard.cpp
@@ -347,8 +347,7 @@ void VirtualKeyboard::updateCandidateArea(
     msg.send();
 }
 
-void VirtualKeyboard::updateCandidate(InputContext *inputContext)
-{
+void VirtualKeyboard::updateCandidate(InputContext *inputContext) {
     auto &inputPanel = inputContext->inputPanel();
 
     if (inputPanel.candidateList() == nullptr ||


### PR DESCRIPTION
    1. In some GUI frameworks like Qt, it provides good support for virtual keyboard.
    So Qt IM module has the need to disable the default behavior of virtual keyboard
    when the object get focus or loses focus. Qt can decide if it should show virtual
    keyboard when the object gets focus or hide virtual keyboard when the object loses
    focus.
    
    2. However, In some GUI frameworks like GTK, it provides poor support for virtual
    keyboard. So It's necessary to show or hide virtual keyboard when the object get focus
    or loses focus and this is the default behavior provided by fcitx5. Maybe in the future,
    GTK may provide good support for virtual keyboard just as Qt does.
