### PR TITLE
Use two separate options to control the behavior of virtual keyboard when the object gets focus or loses focus

### DIFF
--- a/src/frontend/dbusfrontend/dbusfrontend.cpp
+++ b/src/frontend/dbusfrontend/dbusfrontend.cpp
@@ -122,10 +122,12 @@ public:
                 return method(std::move(message));
             });
 
-        setClientControlVirtualkeyboardVisibility(
-            getArgument(args, "clientControlVirtualkeyboardVisibility",
+        setClientControlVirtualkeyboardShow(
+            getArgument(args, "clientControlVirtualkeyboardShow",
                         "false") == "true");
-
+        setClientControlVirtualkeyboardHide(
+            getArgument(args, "clientControlVirtualkeyboardHide",
+                        "false") == "true");
         created();
 
         setFocusGroup(

--- a/src/lib/fcitx/inputcontext.cpp
+++ b/src/lib/fcitx/inputcontext.cpp
@@ -163,14 +163,24 @@ void InputContext::hideVirtualKeyboard() const {
     return instance->userInterfaceManager().hideVirtualKeyboard();
 }
 
-bool InputContext::clientControlVirtualkeyboardVisibility() const {
+bool InputContext::clientControlVirtualkeyboardShow() const {
     FCITX_D();
-    return d->clientControlVirtualkeyboardVisibility_;
+    return d->clientControlVirtualkeyboardShow_;
 }
 
-void InputContext::setClientControlVirtualkeyboardVisibility(bool show) {
+void InputContext::setClientControlVirtualkeyboardShow(bool show) {
     FCITX_D();
-    d->clientControlVirtualkeyboardVisibility_ = show;
+    d->clientControlVirtualkeyboardShow_ = show;
+}
+
+bool InputContext::clientControlVirtualkeyboardHide() const {
+    FCITX_D();
+    return d->clientControlVirtualkeyboardHide_;
+}
+
+void InputContext::setClientControlVirtualkeyboardHide(bool hide) {
+    FCITX_D();
+    d->clientControlVirtualkeyboardHide_ = hide;
 }
 
 CapabilityFlags calculateFlags(CapabilityFlags flag, bool isPreeditEnabled) {

--- a/src/lib/fcitx/inputcontext.h
+++ b/src/lib/fcitx/inputcontext.h
@@ -267,9 +267,13 @@ public:
 
     void hideVirtualKeyboard() const;
 
-    bool clientControlVirtualkeyboardVisibility() const;
+    bool clientControlVirtualkeyboardShow() const;
 
-    void setClientControlVirtualkeyboardVisibility(bool show);
+    void setClientControlVirtualkeyboardShow(bool show);
+
+    bool clientControlVirtualkeyboardHide() const;
+
+    void setClientControlVirtualkeyboardHide(bool show);
 
 protected:
     /**

--- a/src/lib/fcitx/inputcontext_p.h
+++ b/src/lib/fcitx/inputcontext_p.h
@@ -137,7 +137,8 @@ public:
     InputPanel inputPanel_;
     StatusArea statusArea_;
     bool hasFocus_ = false;
-    bool clientControlVirtualkeyboardVisibility_ = false;
+    bool clientControlVirtualkeyboardShow_ = false;
+    bool clientControlVirtualkeyboardHide_ = false;
     std::string program_;
     CapabilityFlags capabilityFlags_;
     bool isPreeditEnabled_ = true;

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -984,7 +984,7 @@ Instance::Instance(int argc, char **argv) {
 
             if (virtualKeyboardAutoShow()) {
                 auto *inputContext = icEvent.inputContext();
-                if (!inputContext->clientControlVirtualkeyboardVisibility()) {
+                if (!inputContext->clientControlVirtualkeyboardShow()) {
                     inputContext->showVirtualKeyboard();
                 }
             }
@@ -1024,7 +1024,7 @@ Instance::Instance(int argc, char **argv) {
             deactivateInputMethod(icEvent);
             if (virtualKeyboardAutoHide()) {
                 auto *inputContext = icEvent.inputContext();
-                if (!inputContext->clientControlVirtualkeyboardVisibility()) {
+                if (!inputContext->clientControlVirtualkeyboardHide()) {
                     inputContext->hideVirtualKeyboard();
                 }
             }


### PR DESCRIPTION
Use two separate options to control the behavior of virtual keyboard when the object gets focus or loses focus

In some GUI frameworks like Qt, it provides good support to show virtual keyboard and provides poor support to hide virtual keyboard. So Qt IM module has the need to disable the default behavior of virtual keyboard when the object get focus and enable the default behavior of virtual keyboard when the object loses focus. Qt can decide if it should show virtual keyboard when the object gets focus. However, fcitx will hide virtual keyboard when the object loses focus.