### PR TITLE
Fix CMake version warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6.0)
+cmake_minimum_required(VERSION 3.16.0)
 project(fcitx VERSION 5.0.22)
 set(FCITX_VERSION ${PROJECT_VERSION})
 


### PR DESCRIPTION
This fixes CMake warnings with multiple packages on Ubuntu 22.10. The affected parts are FindXCB, FindXCBCommon, FindWayland, and FindWaylandScanner.

# Before

```
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11") 
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2") 
-- Found Systemd: /usr/lib/x86_64-linux-gnu/libsystemd.so (found version "251") 
-- Looking for dlmopen
-- Looking for dlmopen - found
-- Found DL: /usr/include  
-- Looking for dgettext
-- Looking for dgettext - found
-- Found LibIntl: /usr/include  
-- Found LibUUID: /usr/lib/x86_64-linux-gnu/libuuid.so (found version "2.38.0") 
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Pthread: /usr/include  
-- Looking for backtrace
-- Looking for backtrace - found
-- Found Execinfo: /usr/include  
-- Found Gettext: /usr/bin/msgmerge (found version "0.21") 
CMake Warning (dev) at /usr/share/ECM/modules/ECMFindModuleHelpers.cmake:113 (message):
  Your project should require at least CMake 3.16.0 to use FindXCB.cmake
Call Stack (most recent call first):
  /usr/share/ECM/find-modules/FindXCB.cmake:67 (ecm_find_package_version_check)
  CMakeLists.txt:113 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- XCB: XFIXES requires XCB;RENDER;SHAPE
-- XCB: XFIXES requires XCB;RENDER;SHAPE
-- Found XCB_XCB: /usr/lib/x86_64-linux-gnu/libxcb.so (found version "1.15") 
-- Found XCB_RENDER: /usr/lib/x86_64-linux-gnu/libxcb-render.so (found version "1.15") 
-- Found XCB_SHAPE: /usr/lib/x86_64-linux-gnu/libxcb-shape.so (found version "1.15") 
-- Found XCB_XFIXES: /usr/lib/x86_64-linux-gnu/libxcb-xfixes.so (found version "1.15") 
-- Found XCB_AUX: /usr/lib/x86_64-linux-gnu/libxcb-util.so (found version "0.4.0") 
-- Found XCB_EWMH: /usr/lib/x86_64-linux-gnu/libxcb-ewmh.so (found version "0.4.1") 
-- Found XCB_ICCCM: /usr/lib/x86_64-linux-gnu/libxcb-icccm.so (found version "0.4.1") 
-- Found XCB_KEYSYMS: /usr/lib/x86_64-linux-gnu/libxcb-keysyms.so (found version "0.4.0") 
-- Found XCB_RANDR: /usr/lib/x86_64-linux-gnu/libxcb-randr.so (found version "1.15") 
-- Found XCB_XINERAMA: /usr/lib/x86_64-linux-gnu/libxcb-xinerama.so (found version "1.15") 
-- Found XCB_XKB: /usr/lib/x86_64-linux-gnu/libxcb-xkb.so (found version "1.15") 
-- Found XCB: /usr/lib/x86_64-linux-gnu/libxcb.so;/usr/lib/x86_64-linux-gnu/libxcb-render.so;/usr/lib/x86_64-linux-gnu/libxcb-shape.so;/usr/lib/x86_64-linux-gnu/libxcb-xfixes.so;/usr/lib/x86_64-linux-gnu/libxcb-util.so;/usr/lib/x86_64-linux-gnu/libxcb-ewmh.so;/usr/lib/x86_64-linux-gnu/libxcb-icccm.so;/usr/lib/x86_64-linux-gnu/libxcb-keysyms.so;/usr/lib/x86_64-linux-gnu/libxcb-randr.so;/usr/lib/x86_64-linux-gnu/libxcb-xinerama.so;/usr/lib/x86_64-linux-gnu/libxcb-xkb.so (found version "1.15") found components: XCB AUX XKB XFIXES ICCCM XINERAMA RANDR EWMH KEYSYMS 
-- Checking for module 'cairo-xcb'
--   Found cairo-xcb, version 1.16.0
-- Checking for module 'xkbfile'
--   Found xkbfile, version 1.1.0
-- Found Expat: /usr/lib/x86_64-linux-gnu/libexpat.so (found version "2.4.8") 
CMake Warning (dev) at /usr/share/ECM/modules/ECMFindModuleHelpers.cmake:113 (message):
  Your project should require at least CMake 3.16.0 to use
  FindXKBCommon.cmake
Call Stack (most recent call first):
  cmake/FindXKBCommon.cmake:4 (ecm_find_package_version_check)
  CMakeLists.txt:124 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found XKBCommon_XKBCommon: /usr/lib/x86_64-linux-gnu/libxkbcommon.so (found version "1.4.1") 
-- Found XKBCommon_X11: /usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so (found version "1.4.1") 
-- Found XKBCommon: /usr/lib/x86_64-linux-gnu/libxkbcommon.so;/usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so (found version "1.4.1") found components: XKBCommon X11 
-- Checking for module 'iso-codes'
--   Found iso-codes, version 4.11.0
-- Found IsoCodes: /usr/share/iso-codes/json/iso_639-3.json  
-- Found XKeyboardConfig: /usr/share/X11/xkb (found version "2.35.1") 
-- Checking for module 'json-c'
--   Found json-c, version 0.16
-- Checking for module 'cairo'
--   Found cairo, version 1.16.0
-- Checking for modules 'pango;pangocairo'
--   Found pango, version 1.50.10
--   Found pangocairo, version 1.50.10
-- Checking for module 'gdk-pixbuf-2.0'
--   Found gdk-pixbuf-2.0, version 2.42.9
-- Checking for module 'gio-unix-2.0'
--   Found gio-unix-2.0, version 2.74.3
CMake Warning (dev) at /usr/share/ECM/modules/ECMFindModuleHelpers.cmake:113 (message):
  Your project should require at least CMake 3.16.0 to use FindWayland.cmake
Call Stack (most recent call first):
  /usr/share/ECM/find-modules/FindWayland.cmake:61 (ecm_find_package_version_check)
  CMakeLists.txt:145 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found Wayland_Client: /usr/lib/x86_64-linux-gnu/libwayland-client.so (found version "1.21.0") 
-- Found Wayland: /usr/lib/x86_64-linux-gnu/libwayland-client.so (found version "1.21.0") found components: Client 
CMake Warning (dev) at /usr/share/ECM/modules/ECMFindModuleHelpers.cmake:113 (message):
  Your project should require at least CMake 3.16.0 to use
  FindWaylandScanner.cmake
Call Stack (most recent call first):
  /usr/share/ECM/find-modules/FindWaylandScanner.cmake:68 (ecm_find_package_version_check)
  CMakeLists.txt:146 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Found WaylandScanner: /usr/bin/wayland-scanner  
-- Found WaylandProtocols: //usr/share/wayland-protocols (found version "")  
-- Checking for module 'gio-2.0'
--   Found gio-2.0, version 2.74.3
-- Checking for module 'enchant-2'
--   Found enchant-2, version 2.3.3
-- Looking for pipe2
-- Looking for pipe2 - found
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- The following OPTIONAL packages have been found:

 * Systemd, A system and service manager for Linux, <http://www.freedesktop.org/wiki/Software/systemd>
 * Execinfo

-- The following REQUIRED packages have been found:

 * ECM
 * ZLIB
 * DL
 * LibIntl
 * LibUUID, uuid library in util-linux, <http://www.kernel.org/pub/linux/utils/util-linux/>
 * Pthread
 * Gettext
 * fmt
 * XCB, X protocol C-language Binding, <https://xcb.freedesktop.org/>
 * XCBImdkit (required version >= 1.0.3)
 * Expat
 * XKBCommon, Keyboard handling library using XKB data, <http://xkbcommon.org>
 * IsoCodes
 * XKeyboardConfig
 * Wayland, C library implementation of the Wayland protocol: a protocol for a compositor to talk to its clients, <https://wayland.freedesktop.org/>
 * WaylandScanner, Executable that converts XML protocol files to C code, <https://wayland.freedesktop.org/>
 * PkgConfig
 * WaylandProtocols

-- Configuring done
-- Generating done
-- Build files have been written to: /home/home/CLionProjects/fcitx5
```

# After

```
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11") 
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.2") 
-- Found Systemd: /usr/lib/x86_64-linux-gnu/libsystemd.so (found version "251") 
-- Looking for dlmopen
-- Looking for dlmopen - found
-- Found DL: /usr/include  
-- Looking for dgettext
-- Looking for dgettext - found
-- Found LibIntl: /usr/include  
-- Found LibUUID: /usr/lib/x86_64-linux-gnu/libuuid.so (found version "2.38.0") 
-- Looking for pthread_create
-- Looking for pthread_create - found
-- Found Pthread: /usr/include  
-- Looking for backtrace
-- Looking for backtrace - found
-- Found Execinfo: /usr/include  
-- Found Gettext: /usr/bin/msgmerge (found version "0.21") 
-- XCB: XFIXES requires XCB;RENDER;SHAPE
-- XCB: XFIXES requires XCB;RENDER;SHAPE
-- Found XCB_XCB: /usr/lib/x86_64-linux-gnu/libxcb.so (found version "1.15") 
-- Found XCB_RENDER: /usr/lib/x86_64-linux-gnu/libxcb-render.so (found version "1.15") 
-- Found XCB_SHAPE: /usr/lib/x86_64-linux-gnu/libxcb-shape.so (found version "1.15") 
-- Found XCB_XFIXES: /usr/lib/x86_64-linux-gnu/libxcb-xfixes.so (found version "1.15") 
-- Found XCB_AUX: /usr/lib/x86_64-linux-gnu/libxcb-util.so (found version "0.4.0") 
-- Found XCB_EWMH: /usr/lib/x86_64-linux-gnu/libxcb-ewmh.so (found version "0.4.1") 
-- Found XCB_ICCCM: /usr/lib/x86_64-linux-gnu/libxcb-icccm.so (found version "0.4.1") 
-- Found XCB_KEYSYMS: /usr/lib/x86_64-linux-gnu/libxcb-keysyms.so (found version "0.4.0") 
-- Found XCB_RANDR: /usr/lib/x86_64-linux-gnu/libxcb-randr.so (found version "1.15") 
-- Found XCB_XINERAMA: /usr/lib/x86_64-linux-gnu/libxcb-xinerama.so (found version "1.15") 
-- Found XCB_XKB: /usr/lib/x86_64-linux-gnu/libxcb-xkb.so (found version "1.15") 
-- Found XCB: /usr/lib/x86_64-linux-gnu/libxcb.so;/usr/lib/x86_64-linux-gnu/libxcb-render.so;/usr/lib/x86_64-linux-gnu/libxcb-shape.so;/usr/lib/x86_64-linux-gnu/libxcb-xfixes.so;/usr/lib/x86_64-linux-gnu/libxcb-util.so;/usr/lib/x86_64-linux-gnu/libxcb-ewmh.so;/usr/lib/x86_64-linux-gnu/libxcb-icccm.so;/usr/lib/x86_64-linux-gnu/libxcb-keysyms.so;/usr/lib/x86_64-linux-gnu/libxcb-randr.so;/usr/lib/x86_64-linux-gnu/libxcb-xinerama.so;/usr/lib/x86_64-linux-gnu/libxcb-xkb.so (found version "1.15") found components: XCB AUX XKB XFIXES ICCCM XINERAMA RANDR EWMH KEYSYMS 
-- Checking for module 'cairo-xcb'
--   Found cairo-xcb, version 1.16.0
-- Checking for module 'xkbfile'
--   Found xkbfile, version 1.1.0
-- Found Expat: /usr/lib/x86_64-linux-gnu/libexpat.so (found version "2.4.8") 
-- Found XKBCommon_XKBCommon: /usr/lib/x86_64-linux-gnu/libxkbcommon.so (found version "1.4.1") 
-- Found XKBCommon_X11: /usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so (found version "1.4.1") 
-- Found XKBCommon: /usr/lib/x86_64-linux-gnu/libxkbcommon.so;/usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so (found version "1.4.1") found components: XKBCommon X11 
-- Checking for module 'iso-codes'
--   Found iso-codes, version 4.11.0
-- Found IsoCodes: /usr/share/iso-codes/json/iso_639-3.json  
-- Found XKeyboardConfig: /usr/share/X11/xkb (found version "2.35.1") 
-- Checking for module 'json-c'
--   Found json-c, version 0.16
-- Checking for module 'cairo'
--   Found cairo, version 1.16.0
-- Checking for modules 'pango;pangocairo'
--   Found pango, version 1.50.10
--   Found pangocairo, version 1.50.10
-- Checking for module 'gdk-pixbuf-2.0'
--   Found gdk-pixbuf-2.0, version 2.42.9
-- Checking for module 'gio-unix-2.0'
--   Found gio-unix-2.0, version 2.74.3
-- Found Wayland_Client: /usr/lib/x86_64-linux-gnu/libwayland-client.so (found version "1.21.0") 
-- Found Wayland: /usr/lib/x86_64-linux-gnu/libwayland-client.so (found version "1.21.0") found components: Client 
-- Found WaylandScanner: /usr/bin/wayland-scanner  
-- Found WaylandProtocols: //usr/share/wayland-protocols (found version "")  
-- Checking for module 'gio-2.0'
--   Found gio-2.0, version 2.74.3
-- Checking for module 'enchant-2'
--   Found enchant-2, version 2.3.3
-- Looking for pipe2
-- Looking for pipe2 - found
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- The following OPTIONAL packages have been found:

 * Systemd, A system and service manager for Linux, <http://www.freedesktop.org/wiki/Software/systemd>
 * Execinfo

-- The following REQUIRED packages have been found:

 * ECM
 * ZLIB
 * DL
 * LibIntl
 * LibUUID, uuid library in util-linux, <http://www.kernel.org/pub/linux/utils/util-linux/>
 * Pthread
 * Gettext
 * fmt
 * XCB, X protocol C-language Binding, <https://xcb.freedesktop.org/>
 * XCBImdkit (required version >= 1.0.3)
 * Expat
 * XKBCommon, Keyboard handling library using XKB data, <http://xkbcommon.org>
 * IsoCodes
 * XKeyboardConfig
 * Wayland, C library implementation of the Wayland protocol: a protocol for a compositor to talk to its clients, <https://wayland.freedesktop.org/>
 * WaylandScanner, Executable that converts XML protocol files to C code, <https://wayland.freedesktop.org/>
 * PkgConfig
 * WaylandProtocols

-- Configuring done
-- Generating done
-- Build files have been written to: /home/home/CLionProjects/fcitx5
```