### PR TITLE
Implement Wayland xcb layout options

### DIFF
--- a/src/lib/fcitx/inputmethodconfig_p.h
+++ b/src/lib/fcitx/inputmethodconfig_p.h
@@ -23,6 +23,7 @@ FCITX_CONFIGURATION(
     Option<std::vector<InputMethodGroupItemConfig>> items{this, "Items",
                                                           "Items"};
     Option<std::string> defaultLayout{this, "Default Layout", "Layout"};
+    Option<std::string> defaultLayoutOptions{this, "Default Layout Options", "XKB Layout Options"};
     Option<std::string> defaultInputMethod{this, "DefaultIM",
                                            "Default Input Method"};);
 

--- a/src/lib/fcitx/inputmethodgroup.cpp
+++ b/src/lib/fcitx/inputmethodgroup.cpp
@@ -32,6 +32,7 @@ public:
     std::vector<InputMethodGroupItem> inputMethodList_;
     std::string defaultInputMethod_;
     std::string defaultLayout_;
+    std::string defaultLayoutOptions_;
 };
 
 InputMethodGroupItem::InputMethodGroupItem(const std::string &name)
@@ -131,5 +132,16 @@ void InputMethodGroup::setDefaultLayout(const std::string &layout) {
 const std::string &InputMethodGroup::defaultLayout() const {
     FCITX_D();
     return d->defaultLayout_;
+}
+
+void InputMethodGroup::setDefaultLayoutOptions(
+    const std::string &layoutOptions) {
+    FCITX_D();
+    d->defaultLayoutOptions_ = layoutOptions;
+}
+
+const std::string &InputMethodGroup::defaultLayoutOptions() const {
+    FCITX_D();
+    return d->defaultLayoutOptions_;
 }
 } // namespace fcitx

--- a/src/lib/fcitx/inputmethodgroup.h
+++ b/src/lib/fcitx/inputmethodgroup.h
@@ -45,6 +45,8 @@ public:
     const std::string &name() const;
     void setDefaultLayout(const std::string &layout);
     const std::string &defaultLayout() const;
+    void setDefaultLayoutOptions(const std::string &layoutOptions);
+    const std::string &defaultLayoutOptions() const;
     std::vector<InputMethodGroupItem> &inputMethodList();
     const std::vector<InputMethodGroupItem> &inputMethodList() const;
     const std::string &defaultInputMethod() const;

--- a/src/lib/fcitx/inputmethodmanager.cpp
+++ b/src/lib/fcitx/inputmethodmanager.cpp
@@ -90,6 +90,8 @@ void InputMethodManagerPrivate::loadConfig(
             tempOrder.push_back(groupConfig.name.value());
             auto &group = result.first->second;
             group.setDefaultLayout(groupConfig.defaultLayout.value());
+            group.setDefaultLayoutOptions(
+                groupConfig.defaultLayoutOptions.value());
             const auto &items = groupConfig.items.value();
             for (const auto &item : items) {
                 if (!entries_.count(item.name.value())) {
@@ -406,6 +408,7 @@ void InputMethodManager::save() {
         auto &groupConfig = groups.back();
         groupConfig.name.setValue(group.name());
         groupConfig.defaultLayout.setValue(group.defaultLayout());
+        groupConfig.defaultLayoutOptions.setValue(group.defaultLayoutOptions());
         groupConfig.defaultInputMethod.setValue(group.defaultInputMethod());
         std::vector<InputMethodGroupItemConfig> itemsConfig;
         for (auto &item : group.inputMethodList()) {

--- a/src/modules/wayland/waylandmodule.cpp
+++ b/src/modules/wayland/waylandmodule.cpp
@@ -201,8 +201,8 @@ WaylandModule::WaylandModule(fcitx::Instance *instance)
                 return;
             }
 
-            auto layoutAndVariant = parseLayout(
-                instance_->inputMethodManager().currentGroup().defaultLayout());
+            auto group = instance_->inputMethodManager().currentGroup();
+            auto layoutAndVariant = parseLayout(group.defaultLayout());
 
             if (layoutAndVariant.first.empty()) {
                 return;
@@ -213,6 +213,8 @@ WaylandModule::WaylandModule(fcitx::Instance *instance)
             config.setValueByPath("Layout/LayoutList", layoutAndVariant.first);
             config.setValueByPath("Layout/VariantList",
                                   layoutAndVariant.second);
+            config.setValueByPath("Layout/Options",
+                                  group.defaultLayoutOptions());
             config.setValueByPath("Layout/DisplayNames", "");
             config.setValueByPath("Layout/Use", "true");
 


### PR DESCRIPTION
Closes #705.

This feature allows uses to have fcitx5 manage their KDE Wayland XKB layout options when switching groups.

# Disadvantages

- X11 is not implemented as it is more complicated
- Migration from kxkbrc is not implemented, and users may be shocked that their layout options are reset when they update fcitx, and be confused until they find this feature

# Before

I wanted to have a French Dvorak layout to type accents with RALT/AltGr level3, and a Japanese Kana layout with RALT mapped to Henkan.
 
I could have fcitx5 have one of them working automatically when switching between them. I had to change the "3rd level shortcuts" in "KDE System Settings > Input Devices > Keyboards > Layouts." When level3 was enabled, the French worked but the Japanese didn't as the level3 option overrode my custom definition of RALT as Henkan. When level3 was disabled, the French obviously didn't work as it was not enabled, but my custom Japanese RALT Henkan worked as the level3 options was no longer overriding it.

 # After

I put `Default Layout Options=lv3:ralt_switch_multikey` in my French group in `~/.config/fcitx5/profile`, and `Default Layout Options=` in my Japanese group. Now fcitx5 automatically controls my xcb keyboard layout so I can switch between languages conveniently.

# After

I can now 