### PR TITLE
Correct \bot in latex.mb

### DIFF
--- a/src/modules/quickphrase/quickphrase.d/latex.mb
+++ b/src/modules/quickphrase/quickphrase.d/latex.mb
@@ -299,7 +299,7 @@
 \boxdot ⊡
 \vdash ⊢
 \dashv ⊣
-\bot ⊤
+\bot ⊥
 \perp ⊥
 \vDash ⊧
 \models ⊨

--- a/src/modules/quickphrase/quickphrase.d/latex.mb
+++ b/src/modules/quickphrase/quickphrase.d/latex.mb
@@ -300,6 +300,7 @@
 \vdash ⊢
 \dashv ⊣
 \bot ⊥
+\top ⊤
 \perp ⊥
 \vDash ⊧
 \models ⊨


### PR DESCRIPTION
The correct abbreviation for `⊤` should be `\top`, instead of `\bot`. `\bot` should map to `⊥`.