### PR TITLE
 Optimize the support for virtual keyboard

### DIFF
--- a/src/lib/fcitx/event.cpp
+++ b/src/lib/fcitx/event.cpp
@@ -11,9 +11,11 @@ namespace fcitx {
 
 class VirtualKeyboardEventPrivate {
 public:
-    VirtualKeyboardEventPrivate(int time) : time_(time) {}
+    VirtualKeyboardEventPrivate(bool isRelease, int time)
+        : isRelease_(isRelease), time_(time) {}
 
     Key key_;
+    bool isRelease_ = false;
     int time_ = 0;
     uint64_t userAction_ = 0;
     std::string text_;
@@ -28,9 +30,10 @@ KeyEventBase::KeyEventBase(EventType type, InputContext *context, Key rawKey,
     : InputContextEvent(context, type), key_(rawKey.normalize()),
       origKey_(rawKey), rawKey_(rawKey), isRelease_(isRelease), time_(time) {}
 
-VirtualKeyboardEvent::VirtualKeyboardEvent(InputContext *context, int time)
+VirtualKeyboardEvent::VirtualKeyboardEvent(InputContext *context,
+                                           bool isRelease, int time)
     : InputContextEvent(context, EventType::InputContextVirtualKeyboardEvent),
-      d_ptr(std::make_unique<VirtualKeyboardEventPrivate>(time)) {}
+      d_ptr(std::make_unique<VirtualKeyboardEventPrivate>(isRelease, time)) {}
 
 FCITX_DEFINE_DEFAULT_DTOR(VirtualKeyboardEvent);
 
@@ -58,7 +61,8 @@ std::unique_ptr<KeyEvent> fcitx::VirtualKeyboardEvent::toKeyEvent() const {
 
     Key key{d->key_.sym(), d->key_.states() | KeyState::Virtual,
             d->key_.code()};
-    return std::make_unique<KeyEvent>(inputContext(), key, false, time());
+    return std::make_unique<KeyEvent>(inputContext(), key, d->isRelease_,
+                                      time());
 }
 
 } // namespace fcitx

--- a/src/lib/fcitx/event.h
+++ b/src/lib/fcitx/event.h
@@ -339,7 +339,7 @@ class VirtualKeyboardEventPrivate;
 
 class FCITXCORE_EXPORT VirtualKeyboardEvent : public InputContextEvent {
 public:
-    VirtualKeyboardEvent(InputContext *context, int time = 0);
+    VirtualKeyboardEvent(InputContext *context, bool isRelease, int time = 0);
     ~VirtualKeyboardEvent();
 
     int time() const;

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1407,6 +1407,17 @@ void Instance::setVirtualKeyboardAutoHide(bool autoHide) {
     d->virtualKeyboardAutoHide_ = autoHide;
 }
 
+VirtualKeyboardFunctionMode Instance::virtualKeyboardFunctionMode() const {
+    FCITX_D();
+    return d->virtualKeyboardFunctionMode_;
+}
+
+void Instance::setVirtualKeyboardFunctionMode(
+    VirtualKeyboardFunctionMode mode) {
+    FCITX_D();
+    d->virtualKeyboardFunctionMode_ = mode;
+}
+
 InstancePrivate *Instance::privateData() {
     FCITX_D();
     return d;

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -36,6 +36,11 @@ class FocusGroup;
 typedef std::function<void(Event &event)> EventHandler;
 
 /**
+ * The function mode of virtual keyboard.
+ */
+enum class VirtualKeyboardFunctionMode : uint32_t { Full = 1, Limited = 2 };
+
+/**
  * The event handling phase of event pipeline.
  */
 enum class EventWatcherPhase {
@@ -497,6 +502,10 @@ public:
     bool virtualKeyboardAutoHide() const;
 
     void setVirtualKeyboardAutoHide(bool autoHide);
+
+    VirtualKeyboardFunctionMode virtualKeyboardFunctionMode() const;
+
+    void setVirtualKeyboardFunctionMode(VirtualKeyboardFunctionMode mode);
 
 protected:
     // For testing purpose

--- a/src/lib/fcitx/instance_p.h
+++ b/src/lib/fcitx/instance_p.h
@@ -223,6 +223,9 @@ public:
     bool virtualKeyboardAutoShow_ = false;
 
     bool virtualKeyboardAutoHide_ = true;
+
+    VirtualKeyboardFunctionMode virtualKeyboardFunctionMode_ =
+        VirtualKeyboardFunctionMode::Full;
 };
 
 } // namespace fcitx

--- a/src/ui/virtualkeyboard/virtualkeyboard.cpp
+++ b/src/ui/virtualkeyboard/virtualkeyboard.cpp
@@ -130,7 +130,7 @@ void VirtualKeyboardBackend::processKeyEvent(uint32_t keyval, uint32_t keycode,
         return;
     }
 
-    VirtualKeyboardEvent event(inputContext, time);
+    VirtualKeyboardEvent event(inputContext, isRelease, time);
     event.setKey(Key(static_cast<KeySym>(keyval), KeyStates(state), keycode));
 
     auto eventConsumed = inputContext->virtualKeyboardEvent(event);

--- a/src/ui/virtualkeyboard/virtualkeyboard.cpp
+++ b/src/ui/virtualkeyboard/virtualkeyboard.cpp
@@ -74,6 +74,8 @@ public:
 
     ~VirtualKeyboardBackend() = default;
 
+    void setVirtualKeyboardFunctionMode(uint32_t mode);
+
     void processKeyEvent(uint32_t keyval, uint32_t keycode, uint32_t state,
                          bool isRelease, uint32_t time);
 
@@ -106,6 +108,9 @@ private:
     PageableCandidateList *getPageableCandidateList();
 
 private:
+    FCITX_OBJECT_VTABLE_METHOD(setVirtualKeyboardFunctionMode,
+                               "SetVirtualKeyboardFunctionMode", "u", "");
+
     FCITX_OBJECT_VTABLE_METHOD(processKeyEvent, "ProcessKeyEvent", "uuubu", "");
 
     FCITX_OBJECT_VTABLE_METHOD(processVisibilityEvent, "ProcessVisibilityEvent",
@@ -120,6 +125,17 @@ private:
     VirtualKeyboard *parent_;
 };
 
+void VirtualKeyboardBackend::setVirtualKeyboardFunctionMode(uint32_t mode) {
+    if (mode != static_cast<uint32_t>(VirtualKeyboardFunctionMode::Full) &&
+        mode != static_cast<uint32_t>(VirtualKeyboardFunctionMode::Limited)) {
+        throw dbus::MethodCallError("org.freedesktop.DBus.Error.InvalidArgs",
+                                    "The argument mode is invalid.");
+    }
+
+    parent_->instance()->setVirtualKeyboardFunctionMode(
+        static_cast<VirtualKeyboardFunctionMode>(mode));
+}
+
 void VirtualKeyboardBackend::processKeyEvent(uint32_t keyval, uint32_t keycode,
                                              uint32_t state, bool isRelease,
                                              uint32_t time) {
@@ -133,7 +149,14 @@ void VirtualKeyboardBackend::processKeyEvent(uint32_t keyval, uint32_t keycode,
     VirtualKeyboardEvent event(inputContext, isRelease, time);
     event.setKey(Key(static_cast<KeySym>(keyval), KeyStates(state), keycode));
 
-    auto eventConsumed = inputContext->virtualKeyboardEvent(event);
+    auto eventConsumed = false;
+    if (parent_->instance()->virtualKeyboardFunctionMode() ==
+        VirtualKeyboardFunctionMode::Limited) {
+        eventConsumed = inputContext->virtualKeyboardEvent(event);
+    } else {
+        eventConsumed = inputContext->keyEvent(*event.toKeyEvent());
+    }
+
     if (eventConsumed) {
         return;
     }
@@ -247,7 +270,12 @@ void VirtualKeyboard::resume() {
         }));
     eventHandlers_.emplace_back(instance_->watchEvent(
         EventType::InputContextKeyEvent, EventWatcherPhase::PreInputMethod,
-        [this](Event &) {
+        [this](Event &event) {
+            const auto &keyEvent = static_cast<KeyEvent &>(event);
+            if (keyEvent.origKey().states().test(KeyState::Virtual)) {
+                return;
+            }
+
             instance_->setInputMethodMode(InputMethodMode::PhysicalKeyboard);
         }));
 }


### PR DESCRIPTION
1. There are two kinds of virtual keyboard at least.
    
2. The input method engine may support one or two function mode: full or limited.
   a) The full function mode is the default function mode. All the input method engine
   which does not implement InputMethodEngineV4 or its ascendants supports the full
   function mode.
   b) The limited function mode is a dedicated function mode which is used for the true
   virtual keyboard. The input method engine which implements InputMethodEngineV4 or its
   ascendants should tell fcitx which function mode it supports. That is, it may support
   full function mode or limited function mode or both.
    
3. The two different virtual keyboard use different function mode of input method engine.
   The virtual keyboard should tell fcitx which function mode it needs. Fcitx will decide
   which function mode is used. For example, if the virtual keyboard tells fcitx that it
   needs limited function mode, but the input method engine does not support that mode,
   then fcitx will use full function mode for compitibility reason.
