### PR TITLE
Add text icon support for Kimpanel

### DIFF
--- a/src/ui/kimpanel/kimpanel.conf.in.in
+++ b/src/ui/kimpanel/kimpanel.conf.in.in
@@ -6,6 +6,7 @@ Category=UI
 Version=@PROJECT_VERSION@
 UIPriority=50
 OnDemand=True
+Configurable=True
 
 [Addon/Dependencies]
 0=dbus

--- a/src/ui/kimpanel/kimpanel.cpp
+++ b/src/ui/kimpanel/kimpanel.cpp
@@ -106,6 +106,7 @@ private:
 Kimpanel::Kimpanel(Instance *instance)
     : instance_(instance), bus_(dbus()->call<IDBusModule::bus>()),
       watcher_(*bus_) {
+    reloadConfig();
     entry_ = watcher_.watchService(
         "org.kde.impanel", [this](const std::string &, const std::string &,
                                   const std::string &newOwner) {
@@ -116,12 +117,20 @@ Kimpanel::Kimpanel(Instance *instance)
 
 Kimpanel::~Kimpanel() {}
 
+void Kimpanel::reloadConfig() {
+    readAsIni(config_, "conf/kimpanel.conf");
+}
+
 void Kimpanel::suspend() {
     eventHandlers_.clear();
     proxy_.reset();
     bus_->releaseName("org.kde.kimpanel.inputmethod");
     hasRelative_ = false;
     hasRelativeV2_ = false;
+}
+
+const Configuration *Kimpanel::getConfig() const {
+    return &config_;
 }
 
 void Kimpanel::registerAllProperties(InputContext *ic) {
@@ -399,7 +408,10 @@ std::string Kimpanel::inputMethodStatus(InputContext *ic) {
     label = extractTextForLabel(label);
 
     static const bool preferSymbolic = !isKDE();
-    if (preferSymbolic && icon == "input-keyboard") {
+    if (*config_.preferTextIcon) {
+        icon = "";
+        description = label;
+    } else if (preferSymbolic && icon == "input-keyboard") {
         icon = "input-keyboard-symbolic";
     }
 

--- a/src/ui/kimpanel/kimpanel.cpp
+++ b/src/ui/kimpanel/kimpanel.cpp
@@ -410,6 +410,7 @@ std::string Kimpanel::inputMethodStatus(InputContext *ic) {
     static const bool preferSymbolic = !isKDE();
     if (*config_.preferTextIcon) {
         icon = "";
+        altDescription = description;
         description = label;
     } else if (preferSymbolic && icon == "input-keyboard") {
         icon = "input-keyboard-symbolic";

--- a/src/ui/kimpanel/kimpanel.h
+++ b/src/ui/kimpanel/kimpanel.h
@@ -7,6 +7,9 @@
 #ifndef _FCITX_UI_KIMPANEL_KIMPANEL_H_
 #define _FCITX_UI_KIMPANEL_KIMPANEL_H_
 
+#include "fcitx-config/configuration.h"
+#include "fcitx-config/iniparser.h"
+#include "fcitx-utils/i18n.h"
 #include "fcitx-utils/dbus/bus.h"
 #include "fcitx-utils/dbus/servicewatcher.h"
 #include "fcitx-utils/event.h"
@@ -25,12 +28,24 @@ namespace fcitx {
 class KimpanelProxy;
 class Action;
 
+
+FCITX_CONFIGURATION(
+    KimpanelConfig,
+    Option<bool> preferTextIcon{this, "PreferTextIcon", _("Prefer Text Icon"),
+                                false};);
+
 class Kimpanel : public UserInterface {
 public:
     Kimpanel(Instance *instance);
     ~Kimpanel();
 
     Instance *instance() { return instance_; }
+    const Configuration *getConfig() const override;
+    void setConfig(const RawConfig &config) override {
+        config_.load(config, true);
+        safeSaveAsIni(config_, "conf/kimpanel.conf");
+    }
+    auto &config() const { return config_; }
     void suspend() override;
     void resume() override;
     bool available() override { return available_; }
@@ -38,6 +53,7 @@ public:
                 InputContext *inputContext) override;
     void updateInputPanel(InputContext *inputContext);
     void updateCurrentInputMethod(InputContext *ic);
+    void reloadConfig() override;
 
     void msgV1Handler(dbus::Message &msg);
     void msgV2Handler(dbus::Message &msg);
@@ -65,6 +81,7 @@ private:
     std::unique_ptr<dbus::Slot> relativeQuery_;
     bool hasRelative_ = false;
     bool hasRelativeV2_ = false;
+    KimpanelConfig config_;
 };
 } // namespace fcitx
 


### PR DESCRIPTION
Hello everyone!

One thing I didn't like about the Kimpanel support was the use of the generic keyboard icons. So, as with the Classic User Inferface addon, I added an option to prefer text icons. Feedback is welcome!