### PR TITLE
Hidden desktop file for dbus service

### DIFF
--- a/data/org.fcitx.Fcitx5.desktop.in.in
+++ b/data/org.fcitx.Fcitx5.desktop.in.in
@@ -8,6 +8,7 @@ Terminal=false
 Type=Application
 Categories=System;Utility;
 StartupNotify=false
+Hidden=true
 X-GNOME-AutoRestart=false
 X-GNOME-Autostart-Notify=false
 X-KDE-autostart-after=panel


### PR DESCRIPTION
I don't get the reason why this desktop file should show in launcher.

It seems that nobody will start the non-GUI dbus service from launcher.

Close #812

Signed-off-by: black-desk <me@black-desk.cn>
