### PR TITLE
Enable virtualkeyboard ui only when dbus enabled

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -2,6 +2,5 @@ add_subdirectory(classic)
 
 if (ENABLE_DBUS)
     add_subdirectory(kimpanel)
+    add_subdirectory(virtualkeyboard)
 endif()
-
-add_subdirectory(virtualkeyboard)


### PR DESCRIPTION
Fixes build on Android