### PR TITLE
The input method mode should be OnScreenKeyboard when toggling first

### DIFF
--- a/src/ui/virtualkeyboard/virtualkeyboard.cpp
+++ b/src/ui/virtualkeyboard/virtualkeyboard.cpp
@@ -37,15 +37,7 @@ public:
 
     ~VirtualKeyboardService() = default;
 
-    void showVirtualKeyboard() {
-        if (!parent_->available()) {
-            return;
-        }
-        parent_->instance()->setInputMethodMode(
-            InputMethodMode::OnScreenKeyboard);
-
-        parent_->showVirtualKeyboard();
-    }
+    void showVirtualKeyboard() { parent_->showVirtualKeyboardForcibly(); }
 
     void hideVirtualKeyboard() { parent_->hideVirtualKeyboard(); }
 
@@ -325,6 +317,16 @@ void VirtualKeyboard::hideVirtualKeyboard() {
     msg.send();
 }
 
+void VirtualKeyboard::showVirtualKeyboardForcibly() {
+    if (!available_) {
+        return;
+    }
+
+    instance_->setInputMethodMode(InputMethodMode::OnScreenKeyboard);
+
+    showVirtualKeyboard();
+}
+
 void VirtualKeyboard::toggleVirtualKeyboard() {
     if (!available_) {
         return;
@@ -333,7 +335,7 @@ void VirtualKeyboard::toggleVirtualKeyboard() {
     if (visible_) {
         hideVirtualKeyboard();
     } else {
-        showVirtualKeyboard();
+        showVirtualKeyboardForcibly();
     }
 }
 

--- a/src/ui/virtualkeyboard/virtualkeyboard.h
+++ b/src/ui/virtualkeyboard/virtualkeyboard.h
@@ -42,6 +42,7 @@ public:
     void showVirtualKeyboard() override;
     void hideVirtualKeyboard() override;
 
+    void showVirtualKeyboardForcibly();
     void toggleVirtualKeyboard();
 
     void updateInputPanel(InputContext *inputContext);


### PR DESCRIPTION
If the input method mode is PhysicalKeyboard, when we call the function VirtualKeyboardService::toggleVirtualKeyboard, we expect that it has the same effect as we call the function VirtualKeyboardService::showVirtualKeyboard. That is, the input method mode will be OnScreenKeyboard and the virtual keyboard will be visible.