### PR TITLE
Implement cursor movement in quickphrase.

### DIFF
--- a/src/modules/quickphrase/quickphrase.cpp
+++ b/src/modules/quickphrase/quickphrase.cpp
@@ -224,6 +224,47 @@ QuickPhrase::QuickPhrase(Instance *instance)
                 keyEvent.accept();
                 return;
             }
+            if (keyEvent.key().check(FcitxKey_Delete)) {
+                if (state->buffer_.empty()) {
+                    state->reset(inputContext);
+                } else {
+                    if (state->buffer_.del()) {
+                        if (state->buffer_.empty()) {
+                            state->reset(inputContext);
+                        } else {
+                            updateUI(inputContext);
+                        }
+                    }
+                }
+                keyEvent.accept();
+                return;
+            }
+            if (!state->buffer_.empty()) {
+                const Key &key = keyEvent.key();
+                if (key.check(FcitxKey_Home) || key.check(FcitxKey_KP_Home)) {
+                    state->buffer_.setCursor(0);
+                    keyEvent.accept();
+                    return updateUI(inputContext);
+                } else if (key.check(FcitxKey_End) || key.check(FcitxKey_KP_End)) {
+                    state->buffer_.setCursor(state->buffer_.size());
+                    keyEvent.accept();
+                    return updateUI(inputContext);
+                } else if (key.check(FcitxKey_Left) || key.check(FcitxKey_KP_Left)) {
+                    auto cursor = state->buffer_.cursor();
+                    if (cursor > 0) {
+                        state->buffer_.setCursor(cursor - 1);
+                    }
+                    keyEvent.accept();
+                    return updateUI(inputContext);
+                } else if (key.check(FcitxKey_Right) || key.check(FcitxKey_KP_Right)) {
+                    auto cursor = state->buffer_.cursor();
+                    if (cursor < state->buffer_.size()) {
+                        state->buffer_.setCursor(cursor + 1);
+                    }
+                    keyEvent.accept();
+                    return updateUI(inputContext);
+                }
+            }
             if (!state->typed_ && !state->str_.empty() &&
                 state->buffer_.empty() && keyEvent.key().check(state->key_)) {
                 keyEvent.accept();
@@ -251,6 +292,27 @@ QuickPhrase::QuickPhrase(Instance *instance)
 
             updateUI(inputContext);
         }));
+    eventHandlers_.emplace_back(instance_->watchEvent(
+        EventType::InputContextInvokeAction, EventWatcherPhase::PreInputMethod,
+        [this](Event &event) {
+            auto &invokeActionEvent = static_cast<InvokeActionEvent &>(event);
+            auto *inputContext = invokeActionEvent.inputContext();
+            auto *state = inputContext->propertyFor(&factory_);
+            if (!state->enabled_) {
+                return;
+            }
+            invokeActionEvent.filter();
+            int cursor = invokeActionEvent.cursor() - static_cast<int>(state->prefix_.size());
+            if (cursor < 0 ||
+                invokeActionEvent.action() != InvokeActionEvent::Action::LeftClick ||
+                !inputContext->capabilityFlags().test(CapabilityFlag::Preedit)) {
+                state->reset(inputContext);
+                return;
+            }
+            state->buffer_.setCursor(cursor);
+            invokeActionEvent.accept();
+            updateUI(inputContext);
+        }));
 
     reloadConfig();
 }
@@ -273,12 +335,8 @@ public:
 
             q_->updateUI(inputContext);
         } else if (action_ == QuickPhraseAction::Commit) {
-            state->reset(inputContext);
-            inputContext->inputPanel().reset();
-            inputContext->updatePreedit();
-            inputContext->updateUserInterface(
-                UserInterfaceComponent::InputPanel, true);
             inputContext->commitString(commit_);
+            state->reset(inputContext);
         }
         // DoNothing and other values are also handled here.
     }


### PR DESCRIPTION
Support InputContext::invokeAction and Home/End/Left/Right keys.

Since `state->reset(inputContext)` does reset `inputPanel` and `updateUserInterface`, duplicate operations were removed to reduce UI flicker.

Move `commitString` before `reset` also helps reduce flicker on Android, because [InputConnection#commitText](https://developer.android.com/reference/android/view/inputmethod/InputConnection#commitText(java.lang.CharSequence,%20int)) would replace any composing span on Android.