### PR TITLE
fix npe: switch between wayland gnome-terminal in debug mode

### DIFF
--- a/src/ui/classic/waylandinputwindow.cpp
+++ b/src/ui/classic/waylandinputwindow.cpp
@@ -139,8 +139,9 @@ void WaylandInputWindow::update(fcitx::InputContext *ic) {
     const auto oldVisible = visible();
     auto [width, height] = InputWindow::update(ic);
     CLASSICUI_DEBUG() << "Wayland Input Window visible:" << visible()
-                      << " for IC program:" << ic->program()
-                      << " frontend:" << ic->frontend();
+                      << " for IC program:"
+                      << (ic ? ic->program() : std::string("-")) << " frontend:"
+                      << (ic ? ic->frontend() : std::string("-"));
     if (!oldVisible && !visible()) {
         CLASSICUI_DEBUG() << "Wayland Input Window has been hidden.";
         return;


### PR DESCRIPTION
Env: Ubuntu server 22.04 with gdm3 installed, running in VirtualBox.
Step to reproduce:
* Build and install fcitx5 as debug.
* Open 2 gnome-terminal.
* In one terminal, `fcitx5 --verbose *=5`
* When fcitx5 is ready, click the other terminal.
* Segfault.

[diagnose.txt](https://github.com/fcitx/fcitx5/files/12775477/diagnose.txt)
