### PR TITLE
Some changes regarding macOS build

### DIFF
--- a/cmake/Fcitx5CompilerSettings.cmake
+++ b/cmake/Fcitx5CompilerSettings.cmake
@@ -7,8 +7,11 @@ set(CMAKE_C_STANDARD 99)
 
 set(CMAKE_C_FLAGS "-Wall -Wextra ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "-Wall -Wextra ${CMAKE_CXX_FLAGS}")
-set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined -Wl,--as-needed ${CMAKE_SHARED_LINKER_FLAGS}")
-set(CMAKE_MODULE_LINKER_FLAGS "-Wl,--no-undefined -Wl,--as-needed ${CMAKE_MODULE_LINKER_FLAGS}")
+
+if(NOT APPLE)
+    set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined -Wl,--as-needed ${CMAKE_SHARED_LINKER_FLAGS}")
+    set(CMAKE_MODULE_LINKER_FLAGS "-Wl,--no-undefined -Wl,--as-needed ${CMAKE_MODULE_LINKER_FLAGS}")
+endif()
 
 set(CMAKE_C_VISIBILITY_PRESET hidden)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_subdirectory(xim)
+if (ENABLE_X11)
+    add_subdirectory(xim)
+endif()
 
 if (WAYLAND_FOUND)
     add_subdirectory(waylandim)

--- a/src/frontend/xim/CMakeLists.txt
+++ b/src/frontend/xim/CMakeLists.txt
@@ -1,10 +1,8 @@
-if (ENABLE_X11)
 add_library(xim MODULE xim.cpp)
 target_link_libraries(xim Fcitx5::Core XCBImdkit::XCBImdkit XCB::XCB XCB::AUX XCB::EWMH XKBCommon::XKBCommon Fcitx5::Module::XCB)
 install(TARGETS xim DESTINATION "${FCITX_INSTALL_ADDONDIR}")
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/xim.conf" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/addon"
         COMPONENT config)
-endif()
 
 configure_file(xim.conf.in.in xim.conf.in @ONLY)
 fcitx5_translate_desktop_file(${CMAKE_CURRENT_BINARY_DIR}/xim.conf.in xim.conf)

--- a/test/addon/CMakeLists.txt
+++ b/test/addon/CMakeLists.txt
@@ -1,10 +1,15 @@
 add_library(dummyaddon MODULE dummyaddon.cpp)
 target_link_libraries(dummyaddon Fcitx5::Core)
 
-add_custom_target(copy-addon DEPENDS unicode.conf.in-fmt quickphrase.conf.in-fmt xim.conf.in-fmt xcb.conf.in-fmt)
+set(COPY_ADDON_DEPENDS unicode.conf.in-fmt quickphrase.conf.in-fmt xcb.conf.in-fmt)
+
+if (ENABLE_X11)
+    list(APPEND COPY_ADDON_DEPENDS xim.conf.in-fmt)
+endif()
+
+add_custom_target(copy-addon DEPENDS ${COPY_ADDON_DEPENDS})
 add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/src/modules/unicode/unicode.conf ${CMAKE_CURRENT_BINARY_DIR}/unicode.conf)
 add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/src/modules/quickphrase/quickphrase.conf ${CMAKE_CURRENT_BINARY_DIR}/quickphrase.conf)
-add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/src/frontend/xim/xim.conf ${CMAKE_CURRENT_BINARY_DIR}/xim.conf)
 add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/src/modules/xcb/xcb.conf ${CMAKE_CURRENT_BINARY_DIR}/xcb.conf)
 add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/src/modules/spell/spell.conf ${CMAKE_CURRENT_BINARY_DIR}/spell.conf)
 add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/src/im/keyboard/keyboard.conf ${CMAKE_CURRENT_BINARY_DIR}/keyboard.conf)
@@ -12,3 +17,6 @@ add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_
 add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/testing/testim/testim.conf ${CMAKE_CURRENT_BINARY_DIR}/testim.conf)
 add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/testing/testui/testui.conf ${CMAKE_CURRENT_BINARY_DIR}/testui.conf)
 
+if (ENABLE_X11)
+    add_custom_command(TARGET copy-addon COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/src/frontend/xim/xim.conf ${CMAKE_CURRENT_BINARY_DIR}/xim.conf)
+endif()


### PR DESCRIPTION
* The linker options are not supported by the linker. Related: https://github.com/neovim/neovim/pull/23263
* Move `ENABLE_X11` to outer level as it makes no sense to generate `xim.conf`