### PR TITLE
Fix build on Android

### DIFF
--- a/src/modules/spell/spell-custom-dict.cpp
+++ b/src/modules/spell/spell-custom-dict.cpp
@@ -12,6 +12,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include "fcitx-utils/cutf8.h"
+#include "fcitx-utils/endian_p.h"
 #include "fcitx-utils/fs.h"
 #include "fcitx-utils/standardpath.h"
 


### PR DESCRIPTION
Include `fcitx-utils/endian_p.h` where uses `le32toh`

https://github.com/fcitx/fcitx5/blob/2a9f7011a6b9eb01d66f50bcc8cfa41d2f732aef/src/modules/spell/spell-custom-dict.cpp#L93-L95

Closes #962 