### PR TITLE
move FCITXUTILS_EXPORT to headers

### DIFF
--- a/src/lib/fcitx-utils/cutf8.cpp
+++ b/src/lib/fcitx-utils/cutf8.cpp
@@ -8,7 +8,6 @@
 #include "cutf8.h"
 #include <cstdint>
 #include <cstring>
-#include "fcitxutils_export.h"
 #include "utf8.h"
 
 /** check utf8 character */
@@ -31,7 +30,6 @@
     ((Char) < 0x110000 && (((Char)&0xFFFFF800) != 0xD800) &&                   \
      ((Char) < 0xFDD0 || (Char) > 0xFDEF) && ((Char)&0xFFFE) != 0xFFFE)
 
-FCITXUTILS_EXPORT
 size_t fcitx_utf8_strlen(const char *s) {
     size_t l = 0;
 
@@ -45,7 +43,6 @@ size_t fcitx_utf8_strlen(const char *s) {
     return l;
 }
 
-FCITXUTILS_EXPORT
 unsigned int fcitx_utf8_char_len(const char *in) {
     if (!(in[0] & 0x80)) {
         return 1;
@@ -80,7 +77,6 @@ unsigned int fcitx_utf8_char_len(const char *in) {
     return 1;
 }
 
-FCITXUTILS_EXPORT
 int fcitx_ucs4_char_len(uint32_t c) {
     if (c < 0x00080) {
         return 1;
@@ -101,7 +97,6 @@ int fcitx_ucs4_char_len(uint32_t c) {
     return 6;
 }
 
-FCITXUTILS_EXPORT
 int fcitx_ucs4_to_utf8(uint32_t c, char *output) {
     if (c < 0x00080) {
         output[0] = (char)(c & 0xFF);
@@ -149,7 +144,6 @@ int fcitx_ucs4_to_utf8(uint32_t c, char *output) {
     return 6;
 }
 
-FCITXUTILS_EXPORT
 char *fcitx_utf8_get_char(const char *i, uint32_t *chr) {
     const auto *in = reinterpret_cast<const unsigned char *>(i);
     if (!(in[0] & 0x80)) {
@@ -195,7 +189,6 @@ char *fcitx_utf8_get_char(const char *i, uint32_t *chr) {
     return (char *)in + 1;
 }
 
-FCITXUTILS_EXPORT
 char *fcitx_utf8_get_nth_char(const char *s, uint32_t n) {
     size_t l = 0;
 
@@ -279,7 +272,6 @@ static uint32_t fcitx_utf8_get_char_extended(const char *s, int max_len,
     return wc;
 }
 
-FCITXUTILS_EXPORT
 uint32_t fcitx_utf8_get_char_validated(const char *p, int max_len, int *plen) {
     uint32_t result;
 
@@ -303,7 +295,6 @@ uint32_t fcitx_utf8_get_char_validated(const char *p, int max_len, int *plen) {
     return result;
 }
 
-FCITXUTILS_EXPORT
 bool fcitx_utf8_check_string(const char *s) {
     while (*s) {
         uint32_t chr;
@@ -321,7 +312,6 @@ bool fcitx_utf8_check_string(const char *s) {
     return true;
 }
 
-FCITXUTILS_EXPORT
 void fcitx_utf8_strncpy(char *str, const char *s, size_t byte) {
     while (*s) {
         uint32_t chr;
@@ -344,7 +334,6 @@ void fcitx_utf8_strncpy(char *str, const char *s, size_t byte) {
     }
 }
 
-FCITXUTILS_EXPORT
 size_t fcitx_utf8_strnlen_validated(const char *str, size_t byte) {
     size_t len = 0;
     while (byte && *str) {
@@ -363,7 +352,6 @@ size_t fcitx_utf8_strnlen_validated(const char *str, size_t byte) {
     return len;
 }
 
-FCITXUTILS_EXPORT
 size_t fcitx_utf8_strnlen(const char *str, size_t byte) {
     size_t len = 0;
     // if byte is zero no need to go further.

--- a/src/lib/fcitx-utils/cutf8.h
+++ b/src/lib/fcitx-utils/cutf8.h
@@ -15,47 +15,59 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include "fcitxutils_export.h"
 
 //// Max length of a utf8 character
 #define FCITX_UTF8_MAX_LENGTH 6
 
 /// \brief Get utf8 string length
+FCITXUTILS_EXPORT
 size_t fcitx_utf8_strlen(const char *s);
 
 /// \brief Get UCS-4 char in the utf8 string
+FCITXUTILS_EXPORT
 char *fcitx_utf8_get_char(const char *in, uint32_t *chr);
 
 /// \brief Get the number of bytes of next character.
+FCITXUTILS_EXPORT
 unsigned int fcitx_utf8_char_len(const char *in);
 
 /// \brief Get the pointer to the nth character.
 ///
 /// This function will not touch the content for s, so const pointer
 /// can be safely passed and converted.
+FCITXUTILS_EXPORT
 char *fcitx_utf8_get_nth_char(const char *s, uint32_t n);
 
 /// \brief Check if the string is valid utf8 string.
+FCITXUTILS_EXPORT
 bool fcitx_utf8_check_string(const char *s);
 
 /// \brief Get validated character.
 ///
 /// Returns the UCS-4 value if its valid character. Returns (uint32_t) -1 if
 /// it is not a valid char, (uint32_t)-2 if length is not enough.
+FCITXUTILS_EXPORT
 uint32_t fcitx_utf8_get_char_validated(const char *p, int max_len, int *plen);
 
 /// \brief Copy most byte length, but keep utf8 valid.
+FCITXUTILS_EXPORT
 void fcitx_utf8_strncpy(char *str, const char *s, size_t byte);
 
 /// \brief Count most byte length, utf8 string length.
+FCITXUTILS_EXPORT
 size_t fcitx_utf8_strnlen(const char *str, size_t byte);
 
 /// \brief Count most byte length, utf8 string length and validates the string
+FCITXUTILS_EXPORT
 size_t fcitx_utf8_strnlen_validated(const char *str, size_t byte);
 
 /// \brief Return the utf8 bytes of a UCS4 char.
+FCITXUTILS_EXPORT
 int fcitx_ucs4_char_len(uint32_t c);
 
 /// \brief Convert ucs4 char to utf8, need to have enough memory for it.
+FCITXUTILS_EXPORT
 int fcitx_ucs4_to_utf8(uint32_t c, char *output);
 
 #endif

--- a/src/lib/fcitx-utils/i18n.cpp
+++ b/src/lib/fcitx-utils/i18n.cpp
@@ -9,7 +9,6 @@
 #include <string>
 #include <unordered_set>
 #include <libintl.h>
-#include "fcitxutils_export.h"
 #include "log.h"
 #include "standardpath.h"
 
@@ -39,18 +38,15 @@ private:
 
 static GettextManager gettextManager;
 
-FCITXUTILS_EXPORT std::string translate(const std::string &s) {
-    return translate(s.c_str());
-}
+std::string translate(const std::string &s) { return translate(s.c_str()); }
 
-FCITXUTILS_EXPORT const char *translate(const char *s) { return ::gettext(s); }
+const char *translate(const char *s) { return ::gettext(s); }
 
-FCITXUTILS_EXPORT std::string translateCtx(const char *ctx,
-                                           const std::string &s) {
+std::string translateCtx(const char *ctx, const std::string &s) {
     return translateCtx(ctx, s.c_str());
 }
 
-FCITXUTILS_EXPORT const char *translateCtx(const char *ctx, const char *s) {
+const char *translateCtx(const char *ctx, const char *s) {
     auto str = stringutils::concat(ctx, "\004", s);
     const auto *p = str.c_str();
     const auto *result = ::gettext(str.c_str());
@@ -60,24 +56,22 @@ FCITXUTILS_EXPORT const char *translateCtx(const char *ctx, const char *s) {
     return result;
 }
 
-FCITXUTILS_EXPORT std::string translateDomain(const char *domain,
-                                              const std::string &s) {
+std::string translateDomain(const char *domain, const std::string &s) {
     return translateDomain(domain, s.c_str());
 }
 
-FCITXUTILS_EXPORT const char *translateDomain(const char *domain,
-                                              const char *s) {
+const char *translateDomain(const char *domain, const char *s) {
     gettextManager.addDomain(domain);
     return ::dgettext(domain, s);
 }
 
-FCITXUTILS_EXPORT std::string
-translateDomainCtx(const char *domain, const char *ctx, const std::string &s) {
+std::string translateDomainCtx(const char *domain, const char *ctx,
+                               const std::string &s) {
     return translateDomainCtx(domain, ctx, s.c_str());
 }
 
-FCITXUTILS_EXPORT const char *
-translateDomainCtx(const char *domain, const char *ctx, const char *s) {
+const char *translateDomainCtx(const char *domain, const char *ctx,
+                               const char *s) {
     gettextManager.addDomain(domain);
     auto str = stringutils::concat(ctx, "\004", s);
     const auto *p = str.c_str();
@@ -88,7 +82,7 @@ translateDomainCtx(const char *domain, const char *ctx, const char *s) {
     return result;
 }
 
-FCITXUTILS_EXPORT void registerDomain(const char *domain, const char *dir) {
+void registerDomain(const char *domain, const char *dir) {
     gettextManager.addDomain(domain, dir);
 }
 } // namespace fcitx

--- a/src/lib/fcitx-utils/i18n.h
+++ b/src/lib/fcitx-utils/i18n.h
@@ -8,21 +8,31 @@
 #define _FCITX_UTILS_I18N_H_
 
 #include <string>
+#include "fcitxutils_export.h"
 
 namespace fcitx {
 
+FCITXUTILS_EXPORT
 std::string translate(const std::string &s);
+FCITXUTILS_EXPORT
 const char *translate(const char *s);
+FCITXUTILS_EXPORT
 std::string translateCtx(const char *ctx, const std::string &s);
+FCITXUTILS_EXPORT
 const char *translateCtx(const char *ctx, const char *s);
 
+FCITXUTILS_EXPORT
 std::string translateDomain(const char *domain, const std::string &s);
+FCITXUTILS_EXPORT
 const char *translateDomain(const char *domain, const char *s);
+FCITXUTILS_EXPORT
 std::string translateDomainCtx(const char *domain, const char *ctx,
                                const std::string &s);
 
+FCITXUTILS_EXPORT
 const char *translateDomainCtx(const char *domain, const char *ctx,
                                const char *s);
+FCITXUTILS_EXPORT
 void registerDomain(const char *domain, const char *dir);
 } // namespace fcitx
 


### PR DESCRIPTION
```
C:/Users/liumeo/github/fcitx5-windows/fcitx5/src/lib/fcitx-utils/cutf8.cpp:153:7: error: redeclaration of 'fcitx_utf8_get_char' cannot add 'dllexport' attribute
char *fcitx_utf8_get_char(const char *i, uint32_t *chr) {
      ^
C:/Users/liumeo/github/fcitx5-windows/fcitx5/src/lib/fcitx-utils/cutf8.h:26:7: note: previous declaration is here
char *fcitx_utf8_get_char(const char *in, uint32_t *chr);
      ^
```