### PR TITLE
define O_ACCMODE on windows

### DIFF
--- a/src/lib/fcitx-utils/standardpath.cpp
+++ b/src/lib/fcitx-utils/standardpath.cpp
@@ -26,7 +26,7 @@
 #include <paths.h>
 #endif
 
-#if defined(_WIN32) && !defined(O_ACCMODE)
+#ifndef O_ACCMODE
 #define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
 #endif
 

--- a/src/lib/fcitx-utils/standardpath.cpp
+++ b/src/lib/fcitx-utils/standardpath.cpp
@@ -26,6 +26,10 @@
 #include <paths.h>
 #endif
 
+#if defined(_WIN32) && !defined(O_ACCMODE)
+#define O_ACCMODE (O_RDONLY | O_WRONLY | O_RDWR)
+#endif
+
 namespace fcitx {
 
 namespace {


### PR DESCRIPTION
```
C:/Users/liumeo/github/fcitx5-windows/fcitx5/src/lib/fcitx-utils/standardpath.cpp:478:18: error: use of undeclared identifier 'O_ACCMODE'
    if ((flags & O_ACCMODE) == O_WRONLY || (flags & O_ACCMODE) == O_RDWR) {
                 ^
C:/Users/liumeo/github/fcitx5-windows/fcitx5/src/lib/fcitx-utils/standardpath.cpp:478:53: error: use of undeclared identifier 'O_ACCMODE'
    if ((flags & O_ACCMODE) == O_WRONLY || (flags & O_ACCMODE) == O_RDWR) {
                                                    ^
```
Some code from C:\Program Files (x86)\Windows Kits\10\Include\10.0.22621.0\ucrt\fcntl.h
```c
#define _O_RDONLY      0x0000  // open for reading only
#define _O_WRONLY      0x0001  // open for writing only
#define _O_RDWR        0x0002  // open for reading and writing
#define _O_APPEND      0x0008  // writes done at eof
...

#if (defined _CRT_DECLARE_NONSTDC_NAMES && _CRT_DECLARE_NONSTDC_NAMES) || (!defined _CRT_DECLARE_NONSTDC_NAMES && !__STDC__)
    #define O_RDONLY     _O_RDONLY
    #define O_WRONLY     _O_WRONLY
    #define O_RDWR       _O_RDWR
    #define O_APPEND     _O_APPEND
```