### PR TITLE
add comment property to CandidateWord

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6.0)
-project(fcitx VERSION 5.1.8)
+project(fcitx VERSION 5.1.9)
 set(FCITX_VERSION ${PROJECT_VERSION})
 
 find_package(ECM REQUIRED 1.0.0)

--- a/src/frontend/dbusfrontend/dbusfrontend.cpp
+++ b/src/frontend/dbusfrontend/dbusfrontend.cpp
@@ -221,13 +221,7 @@ public:
                                      : candidateList->label(i);
                 labelText = instance->outputFilter(this, labelText);
                 Text candidateText =
-                    instance->outputFilter(this, candidate.text());
-                auto comment =
-                    instance->outputFilter(this, candidate.comment());
-                if (!comment.empty()) {
-                    candidateText.append(" ");
-                    candidateText.append(comment);
-                }
+                    instance->outputFilter(this, candidate.textWithComment());
                 candidates.emplace_back(std::make_tuple(
                     labelText.toString(), candidateText.toString()));
             }

--- a/src/frontend/dbusfrontend/dbusfrontend.cpp
+++ b/src/frontend/dbusfrontend/dbusfrontend.cpp
@@ -194,11 +194,10 @@ public:
     }
 
     void updateClientSideUIImpl() override {
-        auto preedit =
-            im_->instance()->outputFilter(this, inputPanel().preedit());
-        auto auxUp = im_->instance()->outputFilter(this, inputPanel().auxUp());
-        auto auxDown =
-            im_->instance()->outputFilter(this, inputPanel().auxDown());
+        auto instance = im_->instance();
+        auto preedit = instance->outputFilter(this, inputPanel().preedit());
+        auto auxUp = instance->outputFilter(this, inputPanel().auxUp());
+        auto auxDown = instance->outputFilter(this, inputPanel().auxDown());
         auto candidateList = inputPanel().candidateList();
         int cursorIndex = 0;
 
@@ -220,9 +219,15 @@ public:
                 Text labelText = candidate.hasCustomLabel()
                                      ? candidate.customLabel()
                                      : candidateList->label(i);
-                labelText = im_->instance()->outputFilter(this, labelText);
+                labelText = instance->outputFilter(this, labelText);
                 Text candidateText =
-                    im_->instance()->outputFilter(this, candidate.text());
+                    instance->outputFilter(this, candidate.text());
+                auto comment =
+                    instance->outputFilter(this, candidate.comment());
+                if (!comment.empty()) {
+                    candidateText.append(" ");
+                    candidateText.append(comment);
+                }
                 candidates.emplace_back(std::make_tuple(
                     labelText.toString(), candidateText.toString()));
             }

--- a/src/lib/fcitx/candidatelist.cpp
+++ b/src/lib/fcitx/candidatelist.cpp
@@ -93,6 +93,7 @@ public:
     bool isPlaceHolder_ = false;
     Text customLabel_;
     bool hasCustomLabel_ = false;
+    Text comment_;
 };
 
 CandidateWord::CandidateWord(Text text)
@@ -108,6 +109,16 @@ const Text &CandidateWord::text() const {
 void CandidateWord::setText(Text text) {
     FCITX_D();
     d->text_ = std::move(text);
+}
+
+const Text &CandidateWord::comment() const {
+    FCITX_D();
+    return d->comment_;
+}
+
+void CandidateWord::setComment(Text comment) {
+    FCITX_D();
+    d->comment_ = std::move(comment);
 }
 
 bool CandidateWord::isPlaceHolder() const {

--- a/src/lib/fcitx/candidatelist.cpp
+++ b/src/lib/fcitx/candidatelist.cpp
@@ -125,7 +125,7 @@ Text CandidateWord::textWithComment(std::string separator) const {
     FCITX_D();
     auto text = d->text_;
     if (!d->comment_.empty()) {
-        text.append(separator);
+        text.append(std::move(separator));
         text.append(d->comment_);
     }
     return text;

--- a/src/lib/fcitx/candidatelist.cpp
+++ b/src/lib/fcitx/candidatelist.cpp
@@ -121,6 +121,16 @@ void CandidateWord::setComment(Text comment) {
     d->comment_ = std::move(comment);
 }
 
+Text CandidateWord::textWithComment(std::string separator) const {
+    FCITX_D();
+    auto text = d->text_;
+    if (!d->comment_.empty()) {
+        text.append(separator);
+        text.append(d->comment_);
+    }
+    return text;
+}
+
 bool CandidateWord::isPlaceHolder() const {
     FCITX_D();
     return d->isPlaceHolder_;

--- a/src/lib/fcitx/candidatelist.h
+++ b/src/lib/fcitx/candidatelist.h
@@ -53,6 +53,14 @@ public:
      * @since 5.1.9
      */
     const Text &comment() const;
+    /**
+     * Return text with comment.
+     *
+     * @param separator separator between text and comment.
+     * @return value of comment.
+     * @since 5.1.9
+     */
+    Text textWithComment(std::string separator = " ") const;
 
 protected:
     void setText(Text text);

--- a/src/lib/fcitx/candidatelist.h
+++ b/src/lib/fcitx/candidatelist.h
@@ -46,12 +46,20 @@ public:
     bool isPlaceHolder() const;
     bool hasCustomLabel() const;
     const Text &customLabel() const;
+    /**
+     * Return comment corresponding to the candidate.
+     *
+     * @return value of comment.
+     * @since 5.1.9
+     */
+    const Text &comment() const;
 
 protected:
     void setText(Text text);
     void setPlaceHolder(bool placeHolder);
     void resetCustomLabel();
     void setCustomLabel(Text text);
+    void setComment(Text comment);
 
 private:
     std::unique_ptr<CandidateWordPrivate> d_ptr;

--- a/src/lib/fcitx/text.cpp
+++ b/src/lib/fcitx/text.cpp
@@ -55,6 +55,14 @@ void Text::append(std::string str, TextFormatFlags flag) {
     d->texts_.emplace_back(std::move(str), flag);
 }
 
+void Text::append(const Text &text) {
+    FCITX_D();
+    for (const auto &p : text.d_ptr->texts_) {
+        d->texts_.emplace_back(std::get<std::string>(p),
+                               std::get<TextFormatFlags>(p));
+    }
+}
+
 const std::string &Text::stringAt(int idx) const {
     FCITX_D();
     return std::get<std::string>(d->texts_[idx]);

--- a/src/lib/fcitx/text.cpp
+++ b/src/lib/fcitx/text.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "text.h"
+#include <iterator>
 #include <stdexcept>
 #include <tuple>
 #include <vector>
@@ -55,12 +56,11 @@ void Text::append(std::string str, TextFormatFlags flag) {
     d->texts_.emplace_back(std::move(str), flag);
 }
 
-void Text::append(const Text &text) {
+void Text::append(Text text) {
     FCITX_D();
-    for (const auto &p : text.d_ptr->texts_) {
-        d->texts_.emplace_back(std::get<std::string>(p),
-                               std::get<TextFormatFlags>(p));
-    }
+    std::copy(std::make_move_iterator(text.d_ptr->texts_.begin()),
+              std::make_move_iterator(text.d_ptr->texts_.end()),
+              std::back_inserter(d->texts_));
 }
 
 const std::string &Text::stringAt(int idx) const {

--- a/src/lib/fcitx/text.h
+++ b/src/lib/fcitx/text.h
@@ -37,6 +37,12 @@ public:
     void setCursor(int pos = -1);
     void clear();
     void append(std::string str, TextFormatFlags flag = TextFormatFlag::NoFlag);
+    /**
+     * Append another text.
+     *
+     * @since 5.1.9
+     */
+    void append(const Text &text);
     const std::string &stringAt(int idx) const;
     TextFormatFlags formatAt(int idx) const;
     size_t size() const;

--- a/src/lib/fcitx/text.h
+++ b/src/lib/fcitx/text.h
@@ -40,9 +40,10 @@ public:
     /**
      * Append another text.
      *
+     * @param text text to append
      * @since 5.1.9
      */
-    void append(const Text &text);
+    void append(Text text);
     const std::string &stringAt(int idx) const;
     TextFormatFlags formatAt(int idx) const;
     size_t size() const;

--- a/src/ui/classic/inputwindow.cpp
+++ b/src/ui/classic/inputwindow.cpp
@@ -341,6 +341,12 @@ std::pair<int, int> InputWindow::update(InputContext *inputContext) {
                                      labelText);
             auto candidateText =
                 instance->outputFilter(inputContext, candidate.text());
+            auto comment =
+                instance->outputFilter(inputContext, candidate.comment());
+            if (!comment.empty()) {
+                candidateText.append(" ");
+                candidateText.append(comment);
+            }
             setTextToMultilineLayout(
                 inputContext, candidateLayouts_[localIndex], candidateText);
             localIndex++;

--- a/src/ui/classic/inputwindow.cpp
+++ b/src/ui/classic/inputwindow.cpp
@@ -339,14 +339,8 @@ std::pair<int, int> InputWindow::update(InputContext *inputContext) {
             labelText = instance->outputFilter(inputContext, labelText);
             setTextToMultilineLayout(inputContext, labelLayouts_[localIndex],
                                      labelText);
-            auto candidateText =
-                instance->outputFilter(inputContext, candidate.text());
-            auto comment =
-                instance->outputFilter(inputContext, candidate.comment());
-            if (!comment.empty()) {
-                candidateText.append(" ");
-                candidateText.append(comment);
-            }
+            auto candidateText = instance->outputFilter(
+                inputContext, candidate.textWithComment());
             setTextToMultilineLayout(
                 inputContext, candidateLayouts_[localIndex], candidateText);
             localIndex++;

--- a/src/ui/kimpanel/kimpanel.cpp
+++ b/src/ui/kimpanel/kimpanel.cpp
@@ -361,6 +361,12 @@ void Kimpanel::updateInputPanel(InputContext *inputContext) {
                 labels.push_back(labelText.toString());
                 auto candidateText =
                     instance->outputFilter(inputContext, candidate.text());
+                auto comment =
+                    instance->outputFilter(inputContext, candidate.comment());
+                if (!comment.empty()) {
+                    candidateText.append(" ");
+                    candidateText.append(comment);
+                }
                 texts.push_back(candidateText.toString());
                 attrs.emplace_back("");
             }

--- a/src/ui/kimpanel/kimpanel.cpp
+++ b/src/ui/kimpanel/kimpanel.cpp
@@ -359,14 +359,8 @@ void Kimpanel::updateInputPanel(InputContext *inputContext) {
 
                 labelText = instance->outputFilter(inputContext, labelText);
                 labels.push_back(labelText.toString());
-                auto candidateText =
-                    instance->outputFilter(inputContext, candidate.text());
-                auto comment =
-                    instance->outputFilter(inputContext, candidate.comment());
-                if (!comment.empty()) {
-                    candidateText.append(" ");
-                    candidateText.append(comment);
-                }
+                auto candidateText = instance->outputFilter(
+                    inputContext, candidate.textWithComment());
                 texts.push_back(candidateText.toString());
                 attrs.emplace_back("");
             }

--- a/src/ui/virtualkeyboard/virtualkeyboard.cpp
+++ b/src/ui/virtualkeyboard/virtualkeyboard.cpp
@@ -421,6 +421,12 @@ std::vector<std::string> VirtualKeyboard::makeCandidateTextList(
 
         auto candidateText =
             instance_->outputFilter(inputContext, candidate.text());
+        auto comment =
+            instance_->outputFilter(inputContext, candidate.comment());
+        if (!comment.empty()) {
+            candidateText.append(" ");
+            candidateText.append(comment);
+        }
         candidateTextList.push_back(candidateText.toString());
     }
 
@@ -439,6 +445,7 @@ std::vector<std::string> VirtualKeyboard::makeBulkCandidateTextList(
     auto totalSize = bulkCandidateList->totalSize();
     for (int index = 0; (totalSize < 0) || (index < totalSize); index++) {
         Text candidateText;
+        Text comment;
         try {
             const auto &candidate = bulkCandidateList->candidateFromAll(index);
             if (candidate.isPlaceHolder()) {
@@ -447,10 +454,16 @@ std::vector<std::string> VirtualKeyboard::makeBulkCandidateTextList(
             }
 
             candidateText = candidate.text();
+            comment = candidate.comment();
         } catch (...) {
             break;
         }
         candidateText = instance_->outputFilter(inputContext, candidateText);
+        comment = instance_->outputFilter(inputContext, comment);
+        if (!comment.empty()) {
+            candidateText.append(" ");
+            candidateText.append(comment);
+        }
         candidateTextList.push_back(candidateText.toString());
     }
 

--- a/src/ui/virtualkeyboard/virtualkeyboard.cpp
+++ b/src/ui/virtualkeyboard/virtualkeyboard.cpp
@@ -420,13 +420,7 @@ std::vector<std::string> VirtualKeyboard::makeCandidateTextList(
         }
 
         auto candidateText =
-            instance_->outputFilter(inputContext, candidate.text());
-        auto comment =
-            instance_->outputFilter(inputContext, candidate.comment());
-        if (!comment.empty()) {
-            candidateText.append(" ");
-            candidateText.append(comment);
-        }
+            instance_->outputFilter(inputContext, candidate.textWithComment());
         candidateTextList.push_back(candidateText.toString());
     }
 
@@ -445,7 +439,6 @@ std::vector<std::string> VirtualKeyboard::makeBulkCandidateTextList(
     auto totalSize = bulkCandidateList->totalSize();
     for (int index = 0; (totalSize < 0) || (index < totalSize); index++) {
         Text candidateText;
-        Text comment;
         try {
             const auto &candidate = bulkCandidateList->candidateFromAll(index);
             if (candidate.isPlaceHolder()) {
@@ -453,17 +446,11 @@ std::vector<std::string> VirtualKeyboard::makeBulkCandidateTextList(
                 continue;
             }
 
-            candidateText = candidate.text();
-            comment = candidate.comment();
+            candidateText = candidate.textWithComment();
         } catch (...) {
             break;
         }
         candidateText = instance_->outputFilter(inputContext, candidateText);
-        comment = instance_->outputFilter(inputContext, comment);
-        if (!comment.empty()) {
-            candidateText.append(" ");
-            candidateText.append(comment);
-        }
         candidateTextList.push_back(candidateText.toString());
     }
 

--- a/test/testcandidatelist.cpp
+++ b/test/testcandidatelist.cpp
@@ -14,8 +14,10 @@ int selected = 0;
 
 class TestCandidateWord : public CandidateWord {
 public:
-    TestCandidateWord(int number)
-        : CandidateWord(Text(std::to_string(number))), number_(number) {}
+    TestCandidateWord(int number, Text comment = {})
+        : CandidateWord(Text(std::to_string(number))), number_(number) {
+        setComment(std::move(comment));
+    }
     void select(InputContext *) const override { selected = number_; }
 
 private:
@@ -303,9 +305,17 @@ void test_label() {
     FCITX_ASSERT(candidatelist.label(9).toString() == ",. ");
 }
 
+void test_comment() {
+    TestCandidateWord candidate(1, Text("comment"));
+    FCITX_ASSERT(candidate.text().toString() == "1");
+    FCITX_ASSERT(candidate.comment().toString() == "comment");
+    FCITX_ASSERT(candidate.textWithComment().toString() == "1 comment");
+}
+
 int main() {
     test_basic();
     test_faulty_placeholder();
     test_label();
+    test_comment();
     return 0;
 }

--- a/test/testtext.cpp
+++ b/test/testtext.cpp
@@ -6,6 +6,7 @@
  */
 #include <fcitx-utils/log.h>
 #include <fcitx/text.h>
+#include "fcitx-utils/textformatflags.h"
 using namespace fcitx;
 
 void test_basic() {
@@ -33,6 +34,14 @@ void test_basic() {
     FCITX_ASSERT(lines[2].toStringForCommit() == "");
     FCITX_ASSERT(lines[3].toStringForCommit() == "Z");
     FCITX_ASSERT(lines[4].toStringForCommit() == "1");
+
+    text = Text("ABC");
+    Text another = Text("DEF", TextFormatFlag::Bold);
+    another.append("GHI", TextFormatFlag::Italic);
+    text.append(another);
+    FCITX_ASSERT(text.toString() == "ABCDEFGHI");
+    FCITX_ASSERT(text.formatAt(1) == TextFormatFlag::Bold);
+    FCITX_ASSERT(text.formatAt(2) == TextFormatFlag::Italic);
 }
 
 void test_normalize() {

--- a/test/testtext.cpp
+++ b/test/testtext.cpp
@@ -6,7 +6,7 @@
  */
 #include <fcitx-utils/log.h>
 #include <fcitx/text.h>
-#include "fcitx-utils/textformatflags.h"
+#include <fcitx-utils/textformatflags.h>
 using namespace fcitx;
 
 void test_basic() {


### PR DESCRIPTION
Currently comment of a rime candidate is [appended](https://github.com/fcitx/fcitx5-rime/blob/92a4410cfbcefd3782ec6b8efd54f9a071274f62/src/rimecandidate.cpp#L24-L27) into candidate in engine level, so it's hard to distinguish and apply different style.
The PR adds a new property to CandidateWord and preserves the behavior in 3 UI implementations (classicui and kimpanel tested, virtualkeyboard not tested).