### PR TITLE
Allow overriding iso-codes and xkb paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,8 @@ if (ENABLE_KEYBOARD)
     pkg_check_modules(JsonC REQUIRED IMPORTED_TARGET "json-c")
 
     set(DEFAULT_XKB_RULES_FILES "${XKEYBOARDCONFIG_XKBBASE}/rules/${DEFAULT_XKB_RULES}.xml")
-    if (NOT EXISTS "${DEFAULT_XKB_RULES_FILES}")
-    message(FATAL_ERROR "Could not find default xkb rules file: ${DEFAULT_XKB_RULES_FILES}")
+    if (NOT EXISTS "${DEFAULT_XKB_RULES_FILES}" AND NOT APPLE)
+        message(WARNING "Could not find default xkb rules file: ${DEFAULT_XKB_RULES_FILES}")
     endif()
 endif()
 

--- a/cmake/FindIsoCodes.cmake
+++ b/cmake/FindIsoCodes.cmake
@@ -18,13 +18,17 @@ endif(ISOCODES_INCLUDE_DIR AND ISOCODES_LIBRARIES)
 find_package(PkgConfig)
 pkg_check_modules(PC_ISOCODES iso-codes)
 
-find_file(ISOCODES_ISO639_JSON iso_639-3.json
-          HINTS "${PC_ISOCODES_PREFIX}/share/iso-codes/json/"
-          )
+if(NOT DEFINED ISOCODES_ISO639_JSON)
+    find_file(ISOCODES_ISO639_JSON iso_639-3.json
+              HINTS "${PC_ISOCODES_PREFIX}/share/iso-codes/json/"
+            )
+endif()
 
-find_file(ISOCODES_ISO3166_JSON iso_3166-1.json
-          HINTS "${PC_ISOCODES_PREFIX}/share/iso-codes/json/"
-          )
+if(NOT DEFINED ISOCODES_ISO3166_JSON)
+    find_file(ISOCODES_ISO3166_JSON iso_3166-1.json
+              HINTS "${PC_ISOCODES_PREFIX}/share/iso-codes/json/"
+            )
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(IsoCodes  DEFAULT_MSG  ISOCODES_ISO639_JSON ISOCODES_ISO3166_JSON)

--- a/cmake/FindXKeyboardConfig.cmake
+++ b/cmake/FindXKeyboardConfig.cmake
@@ -2,8 +2,12 @@ find_package(PkgConfig)
 
 pkg_check_modules(PKG_XKEYBOARDCONFIG QUIET xkeyboard-config)
 
-pkg_get_variable(XKEYBOARDCONFIG_XKBBASE xkeyboard-config xkb_base)
-pkg_get_variable(XKEYBOARDCONFIG_DATADIR xkeyboard-config datadir)
+if(NOT DEFINED XKEYBOARDCONFIG_XKBBASE)
+    pkg_get_variable(XKEYBOARDCONFIG_XKBBASE xkeyboard-config xkb_base)
+endif()
+if(NOT DEFINED XKEYBOARDCONFIG_DATADIR)
+    pkg_get_variable(XKEYBOARDCONFIG_DATADIR xkeyboard-config datadir)
+endif()
 
 set(XKEYBOARDCONFIG_VERSION ${PKG_XKEYBOARDCONFIG_VERSION})
 mark_as_advanced(XKEYBOARDCONFIG_VERSION)


### PR DESCRIPTION
Allow overriding `ISOCODES_ISO639_JSON` `ISOCODES_ISO3166_JSON` `XKEYBOARDCONFIG_XKBBASE` and `XKEYBOARDCONFIG_DATADIR`.

Since the default rules file may be unavailable during build, the `FATAL_ERROR` loglevel is changed to `WARNING` as well.