### PR TITLE
Consider non-character as valid unicode

### DIFF
--- a/src/lib/fcitx-utils/cutf8.cpp
+++ b/src/lib/fcitx-utils/cutf8.cpp
@@ -27,8 +27,7 @@
                                             : ((Char) < 0x4000000 ? 5 : 6)))))
 
 #define UNICODE_VALID(Char)                                                    \
-    ((Char) < 0x110000 && (((Char) & 0xFFFFF800) != 0xD800) &&                 \
-     ((Char) < 0xFDD0 || (Char) > 0xFDEF) && ((Char) & 0xFFFE) != 0xFFFE)
+    ((Char) < 0x110000 && (((Char) & 0xFFFFF800) != 0xD800))
 
 size_t fcitx_utf8_strlen(const char *s) {
     size_t l = 0;

--- a/src/lib/fcitx-utils/utf8.cpp
+++ b/src/lib/fcitx-utils/utf8.cpp
@@ -11,9 +11,7 @@
 namespace fcitx::utf8 {
 
 bool UCS4IsValid(uint32_t code) {
-    return ((code) < 0x110000 && (((code) & 0xFFFFF800) != 0xD800) &&
-            ((code) < 0xFDD0 || (code) > 0xFDEF) &&
-            ((code) & 0xFFFE) != 0xFFFE);
+    return ((code) < 0x110000 && (((code) & 0xFFFFF800) != 0xD800));
 }
 
 std::string UCS4ToUTF8(uint32_t code) {

--- a/test/testkey.cpp
+++ b/test/testkey.cpp
@@ -150,7 +150,9 @@ int main() {
     FCITX_INFO() << fcitx::Key::keySymToString(
         FcitxKey_Insert, fcitx::KeyStringFormat::Localized);
     FCITX_ASSERT(fcitx::Key::keySymToUnicode(
-                     static_cast<fcitx::KeySym>(0x100fdd7)) == 0);
+                     static_cast<fcitx::KeySym>(0x100fdd7)) == 0xfdd7);
+    FCITX_ASSERT(fcitx::Key::keySymToUnicode(
+                     static_cast<fcitx::KeySym>(0x120fdd7)) == 0);
 
     return 0;
 }

--- a/test/testutf8.cpp
+++ b/test/testutf8.cpp
@@ -85,7 +85,9 @@ int main() {
 
     FCITX_ASSERT(counter == 7);
 
-    FCITX_ASSERT(!fcitx::utf8::UCS4IsValid(0xfdd7));
+    FCITX_ASSERT(fcitx::utf8::UCS4IsValid(0xfdd7));
+    FCITX_ASSERT(fcitx::utf8::UCS4IsValid(0xffff));
+    FCITX_ASSERT(!fcitx::utf8::UCS4IsValid(0x200000));
 
     return 0;
 }


### PR DESCRIPTION
Fix #1045