### PR TITLE
Fix icon name mapping in flatpak

### DIFF
--- a/src/lib/fcitx/icontheme.cpp
+++ b/src/lib/fcitx/icontheme.cpp
@@ -797,7 +797,13 @@ std::string IconTheme::defaultIconThemeName() {
 
 /// Rename fcitx-* icon to org.fcitx.Fcitx5.fcitx-* if in flatpak
 std::string IconTheme::iconName(const std::string &icon, bool inFlatpak) {
-    if (inFlatpak && stringutils::startsWith(icon, "fcitx-")) {
+    constexpr std::string_view fcitxIconPrefix = "fcitx";
+    if (inFlatpak && stringutils::startsWith(icon, fcitxIconPrefix)) {
+        // Map "fcitx" to org.fcitx.Fcitx5
+        // And map fcitx* to org.fcitx.Fcitx5.fcitx*
+        if (icon.size() == fcitxIconPrefix.size()) {
+            return "org.fcitx.Fcitx5";
+        }
         return stringutils::concat("org.fcitx.Fcitx5.", icon);
     }
     return icon;

--- a/test/testicontheme.cpp
+++ b/test/testicontheme.cpp
@@ -21,6 +21,9 @@ int main() {
     FCITX_ASSERT(IconTheme::iconName("fcitx-pinyin", false) == "fcitx-pinyin");
     FCITX_ASSERT(IconTheme::iconName("fcitx-pinyin", true) ==
                  "org.fcitx.Fcitx5.fcitx-pinyin");
+    FCITX_ASSERT(IconTheme::iconName("fcitx_mozc", true) ==
+                 "org.fcitx.Fcitx5.fcitx_mozc");
+    FCITX_ASSERT(IconTheme::iconName("fcitx", true) == "org.fcitx.Fcitx5");
 
     for (const auto &inheritTheme : theme.inherits()) {
         FCITX_INFO() << inheritTheme.name().match();


### PR DESCRIPTION
Now we have a much of icons that uses "fcitx_" as the name, including mozc, skk, kkc, rime, to avoid xdg icon spec based fallback.

But we missed the flatpak naming mapping for those icons. Update the condition here, and also handle the special name "fcitx" (I don't think we do have code that uses "fcitx" as icon, but well.. )

https://github.com/fcitx/mozc/issues/53#issuecomment-2105739015