### PR TITLE
add /app/share to XDG_DATA_DIRS in standardpath.cpp.

### DIFF
--- a/src/lib/fcitx-utils/standardpath.cpp
+++ b/src/lib/fcitx-utils/standardpath.cpp
@@ -102,7 +102,7 @@ public:
         pkgdataHome_ =
             defaultPath((isFcitx ? "FCITX_DATA_HOME" : nullptr),
                         constructPath(dataHome_, packageName).c_str());
-        dataDirs_ = defaultPaths("XDG_DATA_DIRS", "/usr/local/share:/usr/share",
+        dataDirs_ = defaultPaths("XDG_DATA_DIRS", "/usr/local/share:/usr/share:/app/share",
                                  builtInPathMap,
                                  skipBuiltInPath_ ? nullptr : "datadir");
         auto pkgdataDirFallback = dataDirs_;


### PR DESCRIPTION
To display icons in flatpak, add /app/share to XDG_DATA_DIRS in standardpath.cpp.