### PR TITLE
Fix wrong usage of std::clamp.

### DIFF
--- a/src/frontend/waylandim/waylandimserver.cpp
+++ b/src/frontend/waylandim/waylandimserver.cpp
@@ -490,7 +490,7 @@ void WaylandIMInputContextV1::keyCallback(uint32_t serial, uint32_t time,
         WAYLANDIM_DEBUG() << "Engine handling speed can not keep up with key "
                              "repetition rate.";
         timeEvent_->setNextInterval(
-            std::clamp(0, repeatDelay() * 1000 - repeatHackDelay, 1000));
+            std::clamp(repeatDelay() * 1000 - repeatHackDelay, 0, 1000));
     }
 }
 void WaylandIMInputContextV1::modifiersCallback(uint32_t serial,

--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -482,7 +482,7 @@ void WaylandIMInputContextV2::keyCallback(uint32_t serial, uint32_t time,
         WAYLANDIM_DEBUG() << "Engine handling speed can not keep up with key "
                              "repetition rate.";
         timeEvent_->setNextInterval(
-            std::clamp(0, repeatDelay() * 1000 - repeatHackDelay, 1000));
+            std::clamp(repeatDelay() * 1000 - repeatHackDelay, 0, 1000));
     }
 }
 void WaylandIMInputContextV2::modifiersCallback(uint32_t /*serial*/,


### PR DESCRIPTION
Prototype of std::clamp is (val, lo, hi) while I assume it to be (lo, val, hi). This may trigger assertion if assertion is enabled.