### PR TITLE
dbusmodule：以dbus signal的形式暴露fcitx5内部events

### DIFF
--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,1 @@
+build/compile_commands.json

--- a/src/modules/dbus/dbusmodule.cpp
+++ b/src/modules/dbus/dbusmodule.cpp
@@ -130,41 +130,43 @@ class Controller1 : public ObjectVTable<Controller1> {
 public:
     Controller1(DBusModule *module, Instance *instance)
         : module_(module), instance_(instance) {
-          eventWatchers_.emplace_back(
-              instance_->watchEvent(EventType::InputContextFocusIn,
-              EventWatcherPhase::PostInputMethod, [this](Event &event) {
-                  auto &icEvent = static_cast<InputContextEvent &>(event);
-                  const auto* ic = icEvent.inputContext();
-                  std::ostringstream ss;
-                  for (auto v : ic->uuid()) {
-                      ss << fmt::format("{:02x}", static_cast<int>(v));
-                  }
-                  this->inputContextFocusIn(ss.str(), ic->program(), ic->frontendName());
-              }));
-          eventWatchers_.emplace_back(
-              instance_->watchEvent(EventType::InputContextFocusOut,
-              EventWatcherPhase::PostInputMethod, [this](Event &event) {
-                  auto &icEvent = static_cast<InputContextEvent &>(event);
-                  const auto* ic = icEvent.inputContext();
-                  std::ostringstream ss;
-                  for (auto v : ic->uuid()) {
-                      ss << fmt::format("{:02x}", static_cast<int>(v));
-                  }
-                  this->inputContextFocusOut(ss.str(), ic->program(), ic->frontendName());
-              }));
-          eventWatchers_.emplace_back(
-              instance_->watchEvent(EventType::InputContextSwitchInputMethod,
-              EventWatcherPhase::PostInputMethod, [this](Event &event) {
-                  auto &icEvent = static_cast<InputContextEvent &>(event);
-                  auto* ic = icEvent.inputContext();
-                  std::ostringstream ss;
-                  for (auto v : ic->uuid()) {
-                      ss << fmt::format("{:02x}", static_cast<int>(v));
-                  }
-                  this->inputContextSwitchInputMethod(
-                      ss.str(), ic->program(), ic->frontendName(),
-                      instance_->inputMethod(ic));
-              }));
+        eventWatchers_.emplace_back(instance_->watchEvent(
+            EventType::InputContextFocusIn, EventWatcherPhase::PostInputMethod,
+            [this](Event &event) {
+                auto &icEvent = static_cast<InputContextEvent &>(event);
+                const auto *ic = icEvent.inputContext();
+                std::ostringstream ss;
+                for (auto v : ic->uuid()) {
+                    ss << fmt::format("{:02x}", static_cast<int>(v));
+                }
+                this->inputContextFocusIn(ss.str(), ic->program(),
+                                          ic->frontendName());
+            }));
+        eventWatchers_.emplace_back(instance_->watchEvent(
+            EventType::InputContextFocusOut, EventWatcherPhase::PostInputMethod,
+            [this](Event &event) {
+                auto &icEvent = static_cast<InputContextEvent &>(event);
+                const auto *ic = icEvent.inputContext();
+                std::ostringstream ss;
+                for (auto v : ic->uuid()) {
+                    ss << fmt::format("{:02x}", static_cast<int>(v));
+                }
+                this->inputContextFocusOut(ss.str(), ic->program(),
+                                           ic->frontendName());
+            }));
+        eventWatchers_.emplace_back(instance_->watchEvent(
+            EventType::InputContextSwitchInputMethod,
+            EventWatcherPhase::PostInputMethod, [this](Event &event) {
+                auto &icEvent = static_cast<InputContextEvent &>(event);
+                auto *ic = icEvent.inputContext();
+                std::ostringstream ss;
+                for (auto v : ic->uuid()) {
+                    ss << fmt::format("{:02x}", static_cast<int>(v));
+                }
+                this->inputContextSwitchInputMethod(ss.str(), ic->program(),
+                                                    ic->frontendName(),
+                                                    instance_->inputMethod(ic));
+            }));
     }
 
     void exit() { instance_->exit(); }
@@ -727,11 +729,11 @@ private:
     FCITX_OBJECT_VTABLE_SIGNAL(inputMethodGroupChanged,
                                "InputMethodGroupsChanged", "");
 
-    FCITX_OBJECT_VTABLE_SIGNAL(inputContextFocusIn,
-                               "InputContextFocusIn", "sss");
+    FCITX_OBJECT_VTABLE_SIGNAL(inputContextFocusIn, "InputContextFocusIn",
+                               "sss");
 
-    FCITX_OBJECT_VTABLE_SIGNAL(inputContextFocusOut,
-                               "InputContextFocusOut", "sss");
+    FCITX_OBJECT_VTABLE_SIGNAL(inputContextFocusOut, "InputContextFocusOut",
+                               "sss");
 
     FCITX_OBJECT_VTABLE_SIGNAL(inputContextSwitchInputMethod,
                                "InputContextSwitchInputMethod", "ssss");


### PR DESCRIPTION

你好！我在自己的dwm fork，dwmZ中实现了fcitx5输入法状态指示器：

![im_indicator_0](https://github.com/fcitx/fcitx5/assets/2550612/9c75ed7d-de73-4c93-aec9-8234d9518563)

![im_indicator_1](https://github.com/fcitx/fcitx5/assets/2550612/51d6ff90-d2c6-440d-9c25-4885192c50da)

如果你感兴趣的话，具体代码在这里：

[dwmZ](https://github.com/omegacoleman/dwmZ)

[the indicator](https://github.com/omegacoleman/dwmZ/blob/devel/include/fcitxim/fcitxim.hpp)

这一功能依赖于此项改动，使得dwmZ可以被动监听输入法切换状态，而无需主动busy polling。

可以使用以下命令查看发送的事件：

```
dbus-monitor --session "type='signal',sender='org.fcitx.Fcitx5'"
```

![dbus-signal_000](https://github.com/fcitx/fcitx5/assets/2550612/2aa245c8-dde3-4078-9698-d5f879471a48)

----

Added three new dbus signals for org.fcitx.Fcitx.Controller1:

* InputContextFocusIn
* InputContextFocusOut
* InputContextSwitchInputMethod

each was triggered when the EventType with same name fires