### PR TITLE
libdbus: <arg> for <signal> should not have directions

### DIFF
--- a/src/lib/fcitx-utils/dbus/libdbus/objectvtable_libdbus.cpp
+++ b/src/lib/fcitx-utils/dbus/libdbus/objectvtable_libdbus.cpp
@@ -50,8 +50,7 @@ const std::string &ObjectVTableBasePrivate::getXml(ObjectVTableBase *q) {
             p->xml_ +=
                 stringutils::concat("<signal name=\"", sig->name(), "\">");
             for (auto &type : splitDBusSignature(sig->signature())) {
-                p->xml_ += stringutils::concat("<arg direction=\"in\" type=\"",
-                                               type, "\"/>");
+                p->xml_ += stringutils::concat("<arg type=\"", type, "\"/>");
             }
             p->xml_ += "</signal>";
         }


### PR DESCRIPTION
依据[官方标准](https://dbus.freedesktop.org/doc/dbus-specification.html#introspection-format)，\<signal\>下的\<arg\>不应有direction。这个attr给一些用于调试的外部工具，例如d-spy造成了解析错误