### PR TITLE
Add a new overload to locate and replace multiOpen with locate

### DIFF
--- a/src/lib/fcitx-config/configuration.h
+++ b/src/lib/fcitx-config/configuration.h
@@ -7,11 +7,14 @@
 #ifndef _FCITX_CONFIG_CONFIGURATION_H_
 #define _FCITX_CONFIG_CONFIGURATION_H_
 
+#include <memory>
+#include <string>
+#include <vector>
 #include <fcitx-config/option.h>
+#include <fcitx-config/optiontypename.h>
+#include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/macros.h>
 #include "fcitxconfig_export.h"
-
-#include <memory>
 
 #define FCITX_CONFIGURATION_EXTEND(NAME, SUBCLASS, ...)                        \
     class NAME;                                                                \

--- a/src/lib/fcitx-config/iniparser.cpp
+++ b/src/lib/fcitx-config/iniparser.cpp
@@ -7,7 +7,13 @@
 #include "iniparser.h"
 #include <fcntl.h>
 #include <cstdio>
+#include <functional>
+#include <string>
+#include <string_view>
+#include "fcitx-config/rawconfig.h"
 #include "fcitx-utils/fs.h"
+#include "fcitx-utils/macros.h"
+#include "fcitx-utils/misc.h"
 #include "fcitx-utils/standardpath.h"
 #include "fcitx-utils/stringutils.h"
 #include "fcitx-utils/unixfd.h"
@@ -54,8 +60,6 @@ void readFromIni(RawConfig &config, FILE *fin) {
             continue;
         }
 
-        std::string::size_type equalPos;
-
         if (lineBuf.front() == '[' && lineBuf.back() == ']') {
             currentGroup = lineBuf.substr(1, lineBuf.size() - 2);
             config.visitItemsOnPath(
@@ -65,8 +69,8 @@ void readFromIni(RawConfig &config, FILE *fin) {
                     }
                 },
                 currentGroup);
-        } else if ((equalPos = lineBuf.find_first_of('=')) !=
-                   std::string::npos) {
+        } else if (std::string::size_type equalPos = lineBuf.find_first_of('=');
+                   equalPos != std::string::npos) {
             auto name = lineBuf.substr(0, equalPos);
             auto valueStart = equalPos + 1;
 
@@ -91,7 +95,7 @@ void readFromIni(RawConfig &config, FILE *fin) {
     }
 }
 
-bool writeAsIni(const RawConfig &root, FILE *fout) {
+bool writeAsIni(const RawConfig &config, FILE *fout) {
     std::function<bool(const RawConfig &, const std::string &path)> callback;
 
     callback = [fout, &callback](const RawConfig &config,
@@ -131,7 +135,7 @@ bool writeAsIni(const RawConfig &root, FILE *fout) {
         return true;
     };
 
-    return callback(root, "");
+    return callback(config, "");
 }
 
 void readAsIni(RawConfig &rawConfig, const std::string &path) {

--- a/src/lib/fcitx-config/iniparser.h
+++ b/src/lib/fcitx-config/iniparser.h
@@ -7,6 +7,8 @@
 #ifndef _FCITX_CONFIG_INIPARSER_H_
 #define _FCITX_CONFIG_INIPARSER_H_
 
+#include <cstdio>
+#include <string>
 #include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/standardpath.h>
 #include "fcitxconfig_export.h"
@@ -17,22 +19,25 @@ FCITXCONFIG_EXPORT void readFromIni(RawConfig &config, int fd);
 FCITXCONFIG_EXPORT bool writeAsIni(const RawConfig &config, int fd);
 FCITXCONFIG_EXPORT void readFromIni(RawConfig &config, FILE *fin);
 FCITXCONFIG_EXPORT bool writeAsIni(const RawConfig &config, FILE *fout);
-FCITXCONFIG_EXPORT void readAsIni(Configuration &, const std::string &name);
-FCITXCONFIG_EXPORT void readAsIni(RawConfig &, const std::string &name);
-FCITXCONFIG_EXPORT void readAsIni(Configuration &, StandardPath::Type type,
-                                  const std::string &name);
-FCITXCONFIG_EXPORT void readAsIni(RawConfig &, StandardPath::Type type,
-                                  const std::string &name);
-FCITXCONFIG_EXPORT bool safeSaveAsIni(const Configuration &,
-                                      const std::string &name);
-FCITXCONFIG_EXPORT bool safeSaveAsIni(const RawConfig &,
-                                      const std::string &name);
-FCITXCONFIG_EXPORT bool safeSaveAsIni(const Configuration &,
+FCITXCONFIG_EXPORT void readAsIni(Configuration &configuration,
+                                  const std::string &path);
+FCITXCONFIG_EXPORT void readAsIni(RawConfig &rawConfig,
+                                  const std::string &path);
+FCITXCONFIG_EXPORT void readAsIni(Configuration &configuration,
+                                  StandardPath::Type type,
+                                  const std::string &path);
+FCITXCONFIG_EXPORT void readAsIni(RawConfig &rawConfig, StandardPath::Type type,
+                                  const std::string &path);
+FCITXCONFIG_EXPORT bool safeSaveAsIni(const Configuration &configuration,
+                                      const std::string &path);
+FCITXCONFIG_EXPORT bool safeSaveAsIni(const RawConfig &rawConfig,
+                                      const std::string &path);
+FCITXCONFIG_EXPORT bool safeSaveAsIni(const Configuration &configuration,
                                       StandardPath::Type type,
-                                      const std::string &name);
-FCITXCONFIG_EXPORT bool safeSaveAsIni(const RawConfig &,
+                                      const std::string &path);
+FCITXCONFIG_EXPORT bool safeSaveAsIni(const RawConfig &rawConfig,
                                       StandardPath::Type type,
-                                      const std::string &name);
+                                      const std::string &path);
 } // namespace fcitx
 
 #endif // _FCITX_CONFIG_INIPARSER_H_

--- a/src/lib/fcitx-config/optiontypename.h
+++ b/src/lib/fcitx-config/optiontypename.h
@@ -8,9 +8,12 @@
 #define _FCITX_CONFIG_TYPENAME_H_
 
 #include <string>
+#include <type_traits>
+#include <vector>
 #include <fcitx-utils/color.h>
 #include <fcitx-utils/i18nstring.h>
 #include <fcitx-utils/key.h>
+#include <fcitx-utils/macros.h>
 #include <fcitx-utils/semver.h>
 
 namespace fcitx {
@@ -42,8 +45,7 @@ struct OptionTypeName<std::vector<T>> {
 };
 
 template <typename T>
-struct OptionTypeName<T,
-                      typename std::enable_if<std::is_enum<T>::value>::type> {
+struct OptionTypeName<T, std::enable_if_t<std::is_enum_v<T>>> {
     static std::string get() { return "Enum"; }
 };
 } // namespace fcitx

--- a/src/lib/fcitx/addoninfo.cpp
+++ b/src/lib/fcitx/addoninfo.cpp
@@ -6,7 +6,19 @@
  */
 
 #include "addoninfo.h"
+
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 #include "fcitx-config/configuration.h"
+#include "fcitx-config/option.h"
+#include "fcitx-config/rawconfig.h"
+#include "fcitx-utils/i18nstring.h"
+#include "fcitx-utils/macros.h"
+#include "fcitx-utils/semver.h"
+#include "fcitx-utils/stringutils.h"
 namespace fcitx {
 
 FCITX_CONFIGURATION(
@@ -57,7 +69,7 @@ void parseDependencies(const std::vector<std::string> &data,
 
 class AddonInfoPrivate : public AddonConfig {
 public:
-    AddonInfoPrivate(const std::string &name) : uniqueName_(name) {}
+    AddonInfoPrivate(std::string name) : uniqueName_(std::move(name)) {}
 
     bool valid_ = false;
     std::string uniqueName_;

--- a/src/lib/fcitx/addoninfo.h
+++ b/src/lib/fcitx/addoninfo.h
@@ -8,8 +8,11 @@
 #define _FCITX_ADDON_H_
 
 #include <memory>
+#include <string>
+#include <tuple>
 #include <vector>
 #include <fcitx-config/enum.h>
+#include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/i18nstring.h>
 #include <fcitx-utils/macros.h>
 #include <fcitx-utils/semver.h>

--- a/src/lib/fcitx/addonmanager.cpp
+++ b/src/lib/fcitx/addonmanager.cpp
@@ -7,15 +7,28 @@
 
 #include "addonmanager.h"
 #include <fcntl.h>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 #include "fcitx-config/iniparser.h"
+#include "fcitx-config/rawconfig.h"
 #include "fcitx-utils/log.h"
+#include "fcitx-utils/macros.h"
 #include "fcitx-utils/misc_p.h"
-#include "fcitx/addoninstance.h"
+#include "fcitx-utils/semver.h"
+#include "fcitx-utils/standardpath.h"
+#include "fcitx-utils/unixfd.h"
+#include "addoninfo.h"
+#include "addoninstance.h"
 #include "addoninstance_p.h"
 #include "addonloader.h"
 #include "addonloader_p.h"
+#include "config.h"
 #include "instance.h"
 
 namespace fcitx {
@@ -60,7 +73,7 @@ enum class DependencyCheckStatus {
 
 class AddonManagerPrivate {
 public:
-    AddonManagerPrivate() : instance_(nullptr) {}
+    AddonManagerPrivate() {}
 
     Addon *addon(const std::string &name) const {
         auto iter = addons_.find(name);
@@ -76,9 +89,8 @@ public:
             if (dependency == "core") {
                 if (depVersion <= version_) {
                     continue;
-                } else {
-                    return DependencyCheckStatus::Failed;
                 }
+                return DependencyCheckStatus::Failed;
             }
             Addon *dep = addon(dependency);
             if (!dep || !dep->isLoadable()) {
@@ -250,12 +262,11 @@ void AddonManager::load(const std::unordered_set<std::string> &enabled,
     const auto &path = StandardPath::global();
     d->timestamp_ =
         path.timestamp(StandardPath::Type::PkgData, d->addonConfigDir_);
-    auto fileMap =
-        path.multiOpen(StandardPath::Type::PkgData, d->addonConfigDir_,
-                       O_RDONLY, filter::Suffix(".conf"));
+    auto fileNames = path.locate(StandardPath::Type::PkgData,
+                                 d->addonConfigDir_, filter::Suffix(".conf"));
     bool enableAll = enabled.count("all");
     bool disableAll = disabled.count("all");
-    for (const auto &[fileName, file] : fileMap) {
+    for (const auto &[fileName, fullName] : fileNames) {
         // remove .conf
         std::string name = fileName.substr(0, fileName.size() - 5);
         if (name == "core") {
@@ -267,7 +278,8 @@ void AddonManager::load(const std::unordered_set<std::string> &enabled,
         }
 
         RawConfig config;
-        readFromIni(config, file.fd());
+        UnixFD fd = UnixFD::own(open(fullName.c_str(), O_RDONLY));
+        readFromIni(config, fd.fd());
 
         // override configuration
         auto addon = std::make_unique<Addon>(name, config);
@@ -403,7 +415,7 @@ void AddonManager::setAddonOptions(
 
 std::vector<std::string> AddonManager::addonOptions(const std::string &name) {
     FCITX_D();
-    if (auto options = findValue(d->options_, name)) {
+    if (auto *options = findValue(d->options_, name)) {
         return *options;
     }
     return {};

--- a/src/modules/quickphrase/quickphraseprovider.h
+++ b/src/modules/quickphrase/quickphraseprovider.h
@@ -8,8 +8,13 @@
 #define _FCITX5_MODULES_QUICKPHRASE_QUICKPHRASEPROVIDER_H_
 
 #include <map>
+#include <memory>
 #include <string>
+#include <utility>
 #include "fcitx-utils/connectableobject.h"
+#include "fcitx-utils/handlertable.h"
+#include "fcitx-utils/misc.h"
+#include "fcitx/addoninstance.h"
 #include "fcitx/addonmanager.h"
 #include "fcitx/instance.h"
 #include "quickphrase_public.h"
@@ -33,7 +38,7 @@ public:
     void reloadConfig();
 
 private:
-    void load(StandardPathFile &file);
+    void load(UniqueFilePtr fp);
     std::multimap<std::string, std::string> map_;
 };
 

--- a/test/teststandardpath.cpp
+++ b/test/teststandardpath.cpp
@@ -6,7 +6,10 @@
  */
 
 #include <fcntl.h>
+#include <cstdlib>
 #include <set>
+#include <string>
+#include <vector>
 #include "fcitx-utils/fs.h"
 #include "fcitx-utils/log.h"
 #include "fcitx-utils/standardpath.h"
@@ -34,8 +37,9 @@ void test_basic() {
         auto result = standardPath.multiOpen(
             StandardPath::Type::PkgData, "addon", O_RDONLY,
             filter::Not(filter::User()), filter::Suffix(".conf"));
-        std::set<std::string> names,
-            expect_names = {"testim.conf", "testfrontend.conf"};
+        std::set<std::string> names;
+        std::set<std::string> expect_names = {"testim.conf",
+                                              "testfrontend.conf"};
         for (auto &p : result) {
             names.insert(p.first);
             FCITX_ASSERT(p.second.fd() >= 0);
@@ -45,10 +49,25 @@ void test_basic() {
     }
 
     {
+        auto result = standardPath.locate(StandardPath::Type::PkgData, "addon",
+                                          filter::Not(filter::User()),
+                                          filter::Suffix(".conf"));
+        std::set<std::string> names;
+        std::set<std::string> expect_names = {"testim.conf",
+                                              "testfrontend.conf"};
+        for (auto &p : result) {
+            names.insert(p.first);
+        }
+
+        FCITX_ASSERT(names == expect_names);
+    }
+
+    {
         auto result = standardPath.multiOpen(
             StandardPath::Type::PkgData, "addon", O_RDONLY,
             filter::Not(filter::User()), filter::Suffix("im.conf"));
-        std::set<std::string> names, expect_names = {"testim.conf"};
+        std::set<std::string> names;
+        std::set<std::string> expect_names = {"testim.conf"};
         for (auto &p : result) {
             names.insert(p.first);
             FCITX_ASSERT(p.second.fd() >= 0);
@@ -82,8 +101,9 @@ void test_nouser() {
         auto result = standardPath.multiOpen(
             StandardPath::Type::PkgData, "addon", O_RDONLY,
             filter::Not(filter::User()), filter::Suffix(".conf"));
-        std::set<std::string> names,
-            expect_names = {"testim.conf", "testfrontend.conf"};
+        std::set<std::string> names;
+        std::set<std::string> expect_names = {"testim.conf",
+                                              "testfrontend.conf"};
         for (auto &p : result) {
             names.insert(p.first);
             FCITX_ASSERT(p.second.fd() >= 0);
@@ -96,7 +116,8 @@ void test_nouser() {
         auto result = standardPath.multiOpen(
             StandardPath::Type::PkgData, "addon", O_RDONLY,
             filter::Not(filter::User()), filter::Suffix("im.conf"));
-        std::set<std::string> names, expect_names = {"testim.conf"};
+        std::set<std::string> names;
+        std::set<std::string> expect_names = {"testim.conf"};
         for (auto &p : result) {
             names.insert(p.first);
             FCITX_ASSERT(p.second.fd() >= 0);


### PR DESCRIPTION
There is a risk that multiOpen open too many files at the same time and use all the fd. Should prefer the new locate over multiOpen. (#1052)