### PR TITLE
add hotkey method to Action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6.0)
-project(fcitx VERSION 5.1.10)
+project(fcitx VERSION 5.1.11)
 set(FCITX_VERSION ${PROJECT_VERSION})
 
 find_package(ECM REQUIRED 1.0.0)

--- a/src/lib/fcitx/action.cpp
+++ b/src/lib/fcitx/action.cpp
@@ -93,7 +93,7 @@ const std::string &Action::name() const {
 
 void Action::update(InputContext *ic) { emit<Update>(ic); }
 
-KeyList Action::hotkey() const {
+const KeyList &Action::hotkey() const {
     FCITX_D();
     return d->hotkey_;
 }

--- a/src/lib/fcitx/action.cpp
+++ b/src/lib/fcitx/action.cpp
@@ -18,6 +18,7 @@ public:
     int id_ = 0;
     bool checkable_ = false;
     bool separator_ = false;
+    KeyList hotkey_;
     FCITX_DEFINE_SIGNAL_PRIVATE(Action, Update);
 };
 
@@ -91,6 +92,16 @@ const std::string &Action::name() const {
 }
 
 void Action::update(InputContext *ic) { emit<Update>(ic); }
+
+KeyList Action::hotkey() const {
+    FCITX_D();
+    return d->hotkey_;
+}
+
+void Action::setHotkey(const KeyList &hotkey) {
+    FCITX_D();
+    d->hotkey_ = hotkey;
+}
 
 class SimpleActionPrivate : public QPtrHolder<Action> {
 public:

--- a/src/lib/fcitx/action.h
+++ b/src/lib/fcitx/action.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <fcitx-utils/element.h>
+#include <fcitx-utils/key.h>
 #include <fcitx-utils/macros.h>
 #include "fcitxcore_export.h"
 
@@ -138,6 +139,14 @@ public:
     void update(InputContext *ic);
 
     FCITX_DECLARE_SIGNAL(Action, Update, void(InputContext *));
+
+    /**
+     * Hotkey bound to the action.
+     *
+     * @return key list.
+     * @since 5.1.11
+     */
+    virtual KeyList hotkey() const { return {}; }
 
 private:
     void setName(const std::string &name);

--- a/src/lib/fcitx/action.h
+++ b/src/lib/fcitx/action.h
@@ -148,14 +148,15 @@ public:
      * @return key list.
      * @since 5.1.11
      */
-    KeyList hotkey() const;
+    const KeyList &hotkey() const;
 
     /**
      * Set associated hotkey for display.
      *
+     * @param hotkey keys that trigger the action.
      * @since 5.1.11
      */
-    void setHotkey(const KeyList &);
+    void setHotkey(const KeyList &hotkey);
 
 private:
     void setName(const std::string &name);

--- a/src/lib/fcitx/action.h
+++ b/src/lib/fcitx/action.h
@@ -142,11 +142,20 @@ public:
 
     /**
      * Hotkey bound to the action.
+     * This is only for display purpose when UI implementation supports it,
+     * and it has nothing to do with the key handling logic.
      *
      * @return key list.
      * @since 5.1.11
      */
-    virtual KeyList hotkey() const { return {}; }
+    KeyList hotkey() const;
+
+    /**
+     * Set associated hotkey for display.
+     *
+     * @since 5.1.11
+     */
+    void setHotkey(const KeyList &);
 
 private:
     void setName(const std::string &name);


### PR DESCRIPTION
It will be nice to show hotkey bound to actions in macOS menu like built-in Pinyin does.

<img width="382" src="https://github.com/fcitx/fcitx5/assets/26783539/c09e62d1-8787-4ef2-abca-5a4cdad578d7">
