### PR TITLE
add API to indicate whether InputPanel is transient

### DIFF
--- a/src/lib/fcitx/inputpanel.cpp
+++ b/src/lib/fcitx/inputpanel.cpp
@@ -19,6 +19,7 @@ public:
     InputContext *ic_;
     CustomInputPanelCallback customCallback_ = nullptr;
     CustomInputPanelCallback customVirtualKeyboardCallback_ = nullptr;
+    bool transient_;
 };
 
 InputPanel::InputPanel(InputContext *ic)
@@ -102,6 +103,16 @@ void InputPanel::setCustomVirtualKeyboardCallback(
     d->customVirtualKeyboardCallback_ = std::move(callback);
 }
 
+void InputPanel::setTransient(bool transient) {
+    FCITX_D();
+    d->transient_ = transient;
+}
+
+bool InputPanel::transient() const {
+    FCITX_D();
+    return d->transient_;
+}
+
 void InputPanel::reset() {
     FCITX_D();
     d->preedit_.clear();
@@ -112,6 +123,7 @@ void InputPanel::reset() {
     d->auxDown_.clear();
     d->customCallback_ = nullptr;
     d->customVirtualKeyboardCallback_ = nullptr;
+    d->transient_ = false;
 }
 
 bool InputPanel::empty() const {

--- a/src/lib/fcitx/inputpanel.h
+++ b/src/lib/fcitx/inputpanel.h
@@ -100,6 +100,24 @@ public:
 
     void setCustomVirtualKeyboardCallback(CustomInputPanelCallback callback);
 
+    /**
+     * Set whether the input panel will automatically disappear.
+     * It doesn't actually hide the input panel.
+     *
+     * @param transient whether the input panel is transient.
+     * @since 5.1.11
+     */
+    void setTransient(bool transient);
+
+    /**
+     * Return whether the input panel will automatically disappear.
+     *
+     * @see setTransient
+     * @return whether the input panel is transient.
+     * @since 5.1.11
+     */
+    bool transient() const;
+
     void reset();
 
     /// Whether input panel is totally empty.

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -495,6 +495,7 @@ InputState::InputState(InstancePrivate *d, InputContext *ic)
 
 void InputState::showInputMethodInformation(const std::string &name) {
     ic_->inputPanel().setAuxUp(Text(name));
+    ic_->inputPanel().setTransient(true);
     ic_->updateUserInterface(UserInterfaceComponent::InputPanel);
     lastInfo_ = name;
     imInfoTimer_ = d_ptr->eventLoop_.addTimeEvent(


### PR DESCRIPTION
On macOS Terminal, a dummy client preedit is needed to close an empty clipboard by ESC or input ascii semicolon by Return with 双拼.
However, the dummy preedit shouldn't be set when using Shift to switch IM, as it clears current cell in LibreOffice.
The `setTransient` API could be used to distinguish these scenarios.