### PR TITLE
The virtual keyboard should show or hide automatically if enabled

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1042,11 +1042,9 @@ Instance::Instance(int argc, char **argv) {
 
             activateInputMethod(icEvent);
 
-            if (virtualKeyboardAutoShow()) {
-                auto *inputContext = icEvent.inputContext();
-                if (!inputContext->clientControlVirtualkeyboardShow()) {
-                    inputContext->showVirtualKeyboard();
-                }
+            auto *inputContext = icEvent.inputContext();
+            if (!inputContext->clientControlVirtualkeyboardShow()) {
+                inputContext->showVirtualKeyboard();
             }
 
             if (!d->globalConfig_.showInputMethodInformationWhenFocusIn() ||
@@ -1091,11 +1089,10 @@ Instance::Instance(int argc, char **argv) {
             d->lastUnFocusedProgram_ = icEvent.inputContext()->program();
             d->lastUnFocusedIc_ = icEvent.inputContext()->watch();
             deactivateInputMethod(icEvent);
-            if (virtualKeyboardAutoHide()) {
-                auto *inputContext = icEvent.inputContext();
-                if (!inputContext->clientControlVirtualkeyboardHide()) {
-                    inputContext->hideVirtualKeyboard();
-                }
+
+            auto *inputContext = icEvent.inputContext();
+            if (!inputContext->clientControlVirtualkeyboardHide()) {
+                inputContext->hideVirtualKeyboard();
             }
         }));
     d->eventWatchers_.emplace_back(d->watchEvent(

--- a/src/lib/fcitx/instance_p.h
+++ b/src/lib/fcitx/instance_p.h
@@ -219,9 +219,9 @@ public:
 
     std::string lastGroup_;
 
-    bool virtualKeyboardAutoShow_ = true;
+    bool virtualKeyboardAutoShow_ = false;
 
-    bool virtualKeyboardAutoHide_ = true;
+    bool virtualKeyboardAutoHide_ = false;
 
     VirtualKeyboardFunctionMode virtualKeyboardFunctionMode_ =
         VirtualKeyboardFunctionMode::Full;

--- a/src/lib/fcitx/userinterfacemanager.cpp
+++ b/src/lib/fcitx/userinterfacemanager.cpp
@@ -333,6 +333,11 @@ bool UserInterfaceManager::isVirtualKeyboardVisible() const {
 void UserInterfaceManager::showVirtualKeyboard() const {
     FCITX_D();
 
+    auto *instance = d->addonManager_->instance();
+    if (!instance->virtualKeyboardAutoShow()) {
+        return;
+    }
+
     auto *ui = d->ui_;
     if (ui == nullptr || ui->addonInfo() == nullptr ||
         ui->addonInfo()->uiType() != UIType::OnScreenKeyboard) {
@@ -345,6 +350,11 @@ void UserInterfaceManager::showVirtualKeyboard() const {
 
 void UserInterfaceManager::hideVirtualKeyboard() const {
     FCITX_D();
+
+    auto *instance = d->addonManager_->instance();
+    if (!instance->virtualKeyboardAutoHide()) {
+        return;
+    }
 
     auto *ui = d->ui_;
     if (ui == nullptr || ui->addonInfo() == nullptr ||


### PR DESCRIPTION
1. When the user interacts with some applications rather than the virtual keyboard itself, the virtual keyboard should show or hide if it is enabled.

2. For example, if the user clicks a window and the window has a text input control which has the focus and accepts the input from the keyboard, then the virtual keyboard should show automatically if the auto show switch is enabled.

3. Then, if the window loses the focus, the virtual keyboard should hide automatically if the auto hide switch is enabled.