### PR TITLE
The input method mode should be set physical keyboard when necessary

### DIFF
--- a/src/ui/virtualkeyboard/virtualkeyboard.cpp
+++ b/src/ui/virtualkeyboard/virtualkeyboard.cpp
@@ -34,7 +34,7 @@ public:
 
     void showVirtualKeyboard() { parent_->showVirtualKeyboardForcibly(); }
 
-    void hideVirtualKeyboard() { parent_->hideVirtualKeyboard(); }
+    void hideVirtualKeyboard() { parent_->hideVirtualKeyboardForcibly(); }
 
     void toggleVirtualKeyboard() { parent_->toggleVirtualKeyboard(); }
 
@@ -325,13 +325,25 @@ void VirtualKeyboard::showVirtualKeyboardForcibly() {
     showVirtualKeyboard();
 }
 
+void VirtualKeyboard::hideVirtualKeyboardForcibly() {
+    if (!available_) {
+        return;
+    }
+
+    hideVirtualKeyboard();
+
+    if (!instance_->virtualKeyboardAutoShow()) {
+        instance_->setInputMethodMode(InputMethodMode::PhysicalKeyboard);
+    }
+}
+
 void VirtualKeyboard::toggleVirtualKeyboard() {
     if (!available_) {
         return;
     }
 
     if (visible_) {
-        hideVirtualKeyboard();
+        hideVirtualKeyboardForcibly();
     } else {
         showVirtualKeyboardForcibly();
     }

--- a/src/ui/virtualkeyboard/virtualkeyboard.h
+++ b/src/ui/virtualkeyboard/virtualkeyboard.h
@@ -40,6 +40,7 @@ public:
     void hideVirtualKeyboard() override;
 
     void showVirtualKeyboardForcibly();
+    void hideVirtualKeyboardForcibly();
     void toggleVirtualKeyboard();
 
     void updateInputPanel(InputContext *inputContext);


### PR DESCRIPTION
If the virtual keyboard should not show automatically, then the input method mode should be set physical keyboard when the user closes the virtual  keyboard by interacting with the virtual keyboard itself. For example, if the user clicks a close button in the virtual keyboard or clicks an icon in the task bar or a float button on the desktop which can close the virtual keyboard, then the virtual keyboard will be closed and the input method mode should be set physical keyboard.