### PR TITLE
Determine whether the obtained IC is the currently active IC, and then determine whether the engine needs to be inactivated

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -2462,6 +2462,10 @@ void Instance::deactivateInputMethod(InputContextEvent &event) {
     if (!engine || !entry) {
         return;
     }
+
+    if (ic != mostRecentInputContext()) {
+        return;
+    }
     inputState->overrideDeactivateIM_ = entry->uniqueName();
     engine->deactivate(*entry, event);
     inputState->overrideDeactivateIM_.clear();


### PR DESCRIPTION


1. In most cases, focus out should be called first, and then focus in.
2. Before the input method engine deactivates, determine whether the obtained IC is the currently activated IC, and then decide whether to inactivate the engine. If it is not the currently activated IC, it does not need to deactivate the engine to avoid the inactivation of the input method engine