### PR TITLE
Simplify the xcb tray window logic and avoid SNI transitional flicker between two UI

### DIFF
--- a/src/modules/notificationitem/notificationitem.h
+++ b/src/modules/notificationitem/notificationitem.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <fcitx/addonmanager.h>
 #include "fcitx-utils/dbus/servicewatcher.h"
+#include "fcitx-utils/trackableobject.h"
 #include "fcitx/addoninstance.h"
 #include "fcitx/instance.h"
 #include "dbus_public.h"
@@ -60,10 +61,11 @@ private:
         eventHandlers_;
     std::unique_ptr<dbus::Slot> pendingRegisterCall_;
     std::string sniWatcherName_;
-    bool enabled_ = false;
+    uint32_t enabled_ = 0;
     bool registered_ = false;
     std::unique_ptr<EventSourceTime> scheduleRegister_;
     HandlerTable<NotificationItemCallback> handlers_;
+    TrackableObject<void> lifeTimeTracker_;
 };
 
 } // namespace fcitx

--- a/src/modules/notificationitem/notificationitem_public.h
+++ b/src/modules/notificationitem/notificationitem_public.h
@@ -7,6 +7,7 @@
 #ifndef _FCITX_MODULES_NOTIFICATIONITEM_NOTIFICATIONITEM_PUBLIC_H_
 #define _FCITX_MODULES_NOTIFICATIONITEM_NOTIFICATIONITEM_PUBLIC_H_
 
+#include <fcitx-utils/handlertable.h>
 #include <fcitx/addoninstance.h>
 
 namespace fcitx {
@@ -15,12 +16,15 @@ using NotificationItemCallback = std::function<void(bool)>;
 
 } // namespace fcitx
 
+// When enable is called
 FCITX_ADDON_DECLARE_FUNCTION(NotificationItem, enable, void());
+// Callback will be called when registered changed.
 FCITX_ADDON_DECLARE_FUNCTION(
     NotificationItem, watch,
     std::unique_ptr<HandlerTableEntry<NotificationItemCallback>>(
         NotificationItemCallback));
 FCITX_ADDON_DECLARE_FUNCTION(NotificationItem, disable, void());
+// Can be used to query current state.
 FCITX_ADDON_DECLARE_FUNCTION(NotificationItem, registered, bool());
 
 #endif // _FCITX_MODULES_NOTIFICATIONITEM_NOTIFICATIONITEM_PUBLIC_H_

--- a/src/ui/classic/xcbui.cpp
+++ b/src/ui/classic/xcbui.cpp
@@ -742,26 +742,19 @@ int XCBUI::scaledDPI(int dpi) {
     return targetDPI;
 }
 
-void XCBUI::resume() { updateTray(); }
+void XCBUI::resume() {}
 
 void XCBUI::suspend() {
     inputWindow_->update(nullptr);
-    updateTray();
+    trayWindow_->suspend();
 }
 
-void XCBUI::updateTray() {
-    bool enableTray = enableTray_ && !parent_->suspended();
+void XCBUI::setEnableTray(bool enable) {
+    bool enableTray = enable && !parent_->suspended();
     if (enableTray) {
         trayWindow_->resume();
     } else {
         trayWindow_->suspend();
-    }
-}
-
-void XCBUI::setEnableTray(bool enable) {
-    if (enable != enableTray_) {
-        enableTray_ = enable;
-        updateTray();
     }
 }
 

--- a/src/ui/classic/xcbui.h
+++ b/src/ui/classic/xcbui.h
@@ -73,7 +73,6 @@ private:
     void refreshManager();
     void readXSettings();
     void initScreen();
-    void updateTray();
     void scheduleUpdateScreen();
 
     static void destroyCairoDevice(cairo_device_t *device);
@@ -90,7 +89,6 @@ private:
     bool needFreeColorMap_ = false;
     std::unique_ptr<XCBInputWindow> inputWindow_;
     std::unique_ptr<XCBTrayWindow> trayWindow_;
-    bool enableTray_ = false;
 
     std::string iconThemeName_;
 


### PR DESCRIPTION
Right now both virtual keyboard & classicui want SNI, but when transition 
between two UI, sni is disabled and then re-enabled which is causing XCB
tray window being show/hide immediately.

This change try to simplify the xcb tray window logic:
1. hide, if suspend()
2. If SNI addon is not available. show on resume
    If SNI addon is available, defer 1sec and check SNI status.

SNI enable/disable logic is updated to allow multiple enable/disable by
using a reference counter. disable() is deferred with event dispatcher,
to avoid enable/disable causing register/unregistration.
