### PR TITLE
notifications: add showTipV2 for extra context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.6.0)
-project(fcitx VERSION 5.1.11)
+project(fcitx VERSION 5.1.12)
 set(FCITX_VERSION ${PROJECT_VERSION})
 
 find_package(ECM REQUIRED 1.0.0)

--- a/src/modules/notifications/notifications.cpp
+++ b/src/modules/notifications/notifications.cpp
@@ -195,6 +195,15 @@ void Notifications::showTip(const std::string &tipId,
                             const std::string &appIcon,
                             const std::string &summary, const std::string &body,
                             int32_t timeout) {
+    showTipV2(tipId, appName, appIcon, summary, body, timeout, {});
+}
+
+void Notifications::showTipV2(
+    const std::string &tipId, const std::string &appName,
+    const std::string &appIcon, const std::string &summary,
+    const std::string &body, int32_t timeout,
+    const std::unordered_map<std::string, std::string> &context) {
+    FCITX_UNUSED(context);
     if (hiddenNotifications_.count(tipId)) {
         return;
     }

--- a/src/modules/notifications/notifications.h
+++ b/src/modules/notifications/notifications.h
@@ -66,12 +66,17 @@ public:
     void showTip(const std::string &tipId, const std::string &appName,
                  const std::string &appIcon, const std::string &summary,
                  const std::string &body, int32_t timeout);
+    void showTipV2(const std::string &tipId, const std::string &appName,
+                   const std::string &appIcon, const std::string &summary,
+                   const std::string &body, int32_t timeout,
+                   const std::unordered_map<std::string, std::string> &context);
 
     void closeNotification(uint64_t internalId);
 
 private:
     FCITX_ADDON_EXPORT_FUNCTION(Notifications, sendNotification);
     FCITX_ADDON_EXPORT_FUNCTION(Notifications, showTip);
+    FCITX_ADDON_EXPORT_FUNCTION(Notifications, showTipV2);
     FCITX_ADDON_EXPORT_FUNCTION(Notifications, closeNotification);
     NotificationItem *find(uint64_t internalId) {
         auto itemIter = items_.find(internalId);

--- a/src/modules/notifications/notifications_public.h
+++ b/src/modules/notifications/notifications_public.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include <fcitx/addoninstance.h>
 
@@ -38,6 +39,20 @@ FCITX_ADDON_DECLARE_FUNCTION(Notifications, showTip,
                                   const std::string &appIcon,
                                   const std::string &summary,
                                   const std::string &body, int32_t timeout));
+/**
+ * Show a tip with context that may be platform-specific.
+ *
+ * @param context {
+ *    "type": "info" | "warning" | "error" | "success"
+ *  }
+ * @since 5.1.12
+ */
+FCITX_ADDON_DECLARE_FUNCTION(
+    Notifications, showTipV2,
+    void(const std::string &tipId, const std::string &appName,
+         const std::string &appIcon, const std::string &summary,
+         const std::string &body, int32_t timeout,
+         const std::unordered_map<std::string, std::string> &context));
 FCITX_ADDON_DECLARE_FUNCTION(Notifications, closeNotification,
                              void(uint64_t internalId));
 


### PR DESCRIPTION
Intent is to show different notification type for rime deployment in fcitx5-ios and fcitx5-online.