### PR TITLE
move SpellModuleFactory to header

### DIFF
--- a/src/modules/spell/spell.cpp
+++ b/src/modules/spell/spell.cpp
@@ -7,7 +7,6 @@
 
 #include "spell.h"
 #include "fcitx-config/iniparser.h"
-#include "fcitx/addonmanager.h"
 #include "config.h"
 #include "spell-custom.h"
 #ifdef ENABLE_ENCHANT
@@ -110,12 +109,6 @@ Spell::hintForDisplay(const std::string &language, SpellProvider provider,
 
     return iter->second->hint(language, word, limit);
 }
-
-class SpellModuleFactory : public AddonFactory {
-    AddonInstance *create(AddonManager *manager) override {
-        return new Spell(manager->instance());
-    }
-};
 } // namespace fcitx
 
 FCITX_ADDON_FACTORY(fcitx::SpellModuleFactory)

--- a/src/modules/spell/spell.h
+++ b/src/modules/spell/spell.h
@@ -13,6 +13,7 @@
 #include "fcitx-utils/i18n.h"
 #include "fcitx/addonfactory.h"
 #include "fcitx/addoninstance.h"
+#include "fcitx/addonmanager.h"
 #include "fcitx/instance.h"
 #include "spell_public.h"
 
@@ -103,6 +104,12 @@ public:
 
 private:
     Spell *parent_;
+};
+
+class SpellModuleFactory : public AddonFactory {
+    AddonInstance *create(AddonManager *manager) override {
+        return new Spell(manager->instance());
+    }
 };
 } // namespace fcitx
 


### PR DESCRIPTION
This enables including SpellModuleFactory on iOS to make a static addon.