### PR TITLE
Set CMake policy CMP0067 to NEW.

### DIFF
--- a/cmake/Fcitx5CompilerSettings.cmake
+++ b/cmake/Fcitx5CompilerSettings.cmake
@@ -23,6 +23,11 @@ if (POLICY CMP0063)
     cmake_policy(SET CMP0063 NEW)
 endif()
 
+if (POLICY CMP0067)
+    # make check_cxx_source_compiles honors CMAKE_CXX_STANDARD
+    cmake_policy(SET CMP0067 NEW)
+endif()
+
 if(ENABLE_COVERAGE)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fprofile-arcs -ftest-coverage")


### PR DESCRIPTION
https://github.com/fcitx/libime/pull/81 introduces build time checking for `std::filesystem` by [check_cxx_source_compiles](https://cmake.org/cmake/help/latest/module/CheckCXXSourceCompiles.html), but it ([try_compile](https://cmake.org/cmake/help/latest/command/try_compile.html) actually) would ignore language standard setting variables. CMP0067 corrects such behavior.

https://cmake.org/cmake/help/latest/policy/CMP0067.html