### PR TITLE
no default dot in candidate label on macOS

### DIFF
--- a/src/lib/fcitx/candidatelist.cpp
+++ b/src/lib/fcitx/candidatelist.cpp
@@ -431,8 +431,10 @@ std::string keyToLabel(const Key &key) {
     } else {
         result = Key::keySymToString(key.sym(), KeyStringFormat::Localized);
     }
-    // add a dot as separator
-    result += ". ";
+    if (!isApple()) {
+        // add a dot as separator
+        result += ". ";
+    }
 
     return result;
 }


### PR DESCRIPTION
<img width="411" alt="Screenshot 2024-11-27 at 9 31 43 PM" src="https://github.com/user-attachments/assets/7405ce1d-95e2-40bf-9f24-7fac314afb50">

macOS built-in IM doesn't have the dot.