### PR TITLE
Add support for shared addon loader to load multiple libraries

### DIFF
--- a/src/lib/fcitx/addonloader.cpp
+++ b/src/lib/fcitx/addonloader.cpp
@@ -30,37 +30,59 @@ AddonInstance *SharedLibraryLoader::load(const AddonInfo &info,
                                          AddonManager *manager) {
     auto iter = registry_.find(info.uniqueName());
     if (iter == registry_.end()) {
-        std::string libname = info.library();
-        Flags<LibraryLoadHint> flag = LibraryLoadHint::DefaultHint;
-        if (stringutils::startsWith(libname, "export:")) {
-            libname = libname.substr(7);
-            flag |= LibraryLoadHint::ExportExternalSymbolsHint;
+        std::vector<std::string> libnames =
+            stringutils::split(info.library(), ";");
+
+        if (libnames.empty()) {
+            FCITX_ERROR() << "Failed to parse Library field: " << info.library()
+                          << " for addon " << info.uniqueName();
+            return nullptr;
         }
-        auto file = libname + FCITX_LIBRARY_SUFFIX;
-        auto libs = standardPath_.locateAll(StandardPath::Type::Addon, file);
-        if (libs.empty()) {
-            FCITX_ERROR() << "Could not locate library " << file
-                          << " for addon " << info.uniqueName() << ".";
-        }
-        for (const auto &libraryPath : libs) {
-            Library lib(libraryPath);
-            if (!lib.load(flag)) {
-                FCITX_ERROR()
-                    << "Failed to load library for addon " << info.uniqueName()
-                    << " on " << libraryPath << ". Error: " << lib.error();
-                continue;
+
+        std::vector<Library> libraries;
+        for (std::string_view libname : libnames) {
+            Flags<LibraryLoadHint> flag = LibraryLoadHint::DefaultHint;
+            if (stringutils::consumePrefix(libname, "export:")) {
+                flag |= LibraryLoadHint::ExportExternalSymbolsHint;
             }
+            const auto file =
+                stringutils::concat(libname, FCITX_LIBRARY_SUFFIX);
+            const auto libraryPaths =
+                standardPath_.locateAll(StandardPath::Type::Addon, file);
+            if (libraryPaths.empty()) {
+                FCITX_ERROR() << "Could not locate library " << file
+                              << " for addon " << info.uniqueName() << ".";
+            }
+            bool loaded = false;
+            ;
+            for (const auto &libraryPath : libraryPaths) {
+                Library library(libraryPath);
+                if (library.load(flag)) {
+                    libraries.push_back(std::move(library));
+                    loaded = true;
+                    break;
+                } else {
+                    FCITX_ERROR() << "Failed to load library for addon "
+                                  << info.uniqueName() << " on " << libraryPath
+                                  << ". Error: " << library.error();
+                }
+            }
+            if (!loaded) {
+                break;
+            }
+        }
+
+        if (libraries.size() == libnames.size()) {
             try {
                 registry_.emplace(info.uniqueName(),
                                   std::make_unique<SharedLibraryFactory>(
-                                      info, std::move(lib)));
+                                      info, std::move(libraries)));
             } catch (const std::exception &e) {
                 FCITX_ERROR() << "Failed to initialize addon factory for addon "
                               << info.uniqueName() << ". Error: " << e.what();
             }
-            break;
+            iter = registry_.find(info.uniqueName());
         }
-        iter = registry_.find(info.uniqueName());
     }
 
     if (iter == registry_.end()) {

--- a/test/addon/CMakeLists.txt
+++ b/test/addon/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_library(dummyaddon MODULE dummyaddon.cpp)
 target_link_libraries(dummyaddon Fcitx5::Core)
 
+add_library(dummyaddondeps MODULE dummyaddondeps.cpp)
+target_link_libraries(dummyaddondeps Fcitx5::Utils)
+
 set(COPY_ADDON_DEPENDS unicode.conf.in-fmt quickphrase.conf.in-fmt xcb.conf.in-fmt spell.conf.in-fmt)
 
 if (ENABLE_KEYBOARD)

--- a/test/addon/dummyaddondeps.cpp
+++ b/test/addon/dummyaddondeps.cpp
@@ -1,0 +1,8 @@
+#include <fcitx-utils/log.h>
+
+FCITX_DEFINE_LOG_CATEGORY(dummyaddondeps, "dummyaddondeps");
+
+static int init = []() {
+    fcitx::Log::setLogRule("default=3");
+    return 0;
+}();

--- a/test/addon2/fcitx5/addon/dummyaddon2.conf
+++ b/test/addon2/fcitx5/addon/dummyaddon2.conf
@@ -1,7 +1,7 @@
 [Addon]
 Name=dummyaddon2
 Type=SharedLibrary
-Library=libdummyaddon
+Library=libdummyaddondeps;libdummyaddon
 Category=Module
 
 [Addon/Dependencies]

--- a/test/testaddon.cpp
+++ b/test/testaddon.cpp
@@ -41,5 +41,12 @@ int main() {
     FCITX_ASSERT(addon2);
     auto *addon3 = manager.addon("dummyaddon3");
     FCITX_ASSERT(!addon3);
+    // loading dummyaddondeps will change log rule level to 3.
+    FCITX_ASSERT(
+        !fcitx::Log::defaultCategory().checkLogLevel(fcitx::LogLevel::Info));
+    FCITX_ASSERT(
+        fcitx::Log::defaultCategory().checkLogLevel(fcitx::LogLevel::Warn));
+    fcitx::Log::setLogRule("default=5");
+
     return 0;
 }


### PR DESCRIPTION
In general this is not very useful on linux, but for android where
LD_LIBRARY_PATH doesn't work, it can be used as an built-in linker to
load depenedency libraries.
