### PR TITLE
Add new global option to allow change the time limit on modifier only key triggering

### DIFF
--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -142,7 +142,7 @@ FCITX_CONFIGURATION(
             this,
             "ModifierOnlyKeyTimeout",
             _("Modifier Only Hotkey Timeout in Milliseconds"),
-            500,
+            250,
             IntConstrain{-1, 5000},
             {},
             ToolTipAnnotation{

--- a/src/lib/fcitx/globalconfig.h
+++ b/src/lib/fcitx/globalconfig.h
@@ -7,8 +7,11 @@
 #ifndef _FCITX_GLOBALCONFIG_H_
 #define _FCITX_GLOBALCONFIG_H_
 
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
+#include <fcitx-config/configuration.h>
 #include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/key.h>
 #include <fcitx-utils/macros.h>
@@ -108,6 +111,29 @@ public:
      * @since 5.1.2
      */
     int autoSavePeriod() const;
+
+    /**
+     * Number of milliseconds that modifier only key can be triggered with key
+     * release.
+     *
+     * @return timeout
+     * @since 5.1.12
+     */
+    int modifierOnlyKeyTimeout() const;
+
+    /**
+     * Helper function to check whether the modifier only key should be
+     * triggered.
+     *
+     * The user may need to record the time when the corresponding modifier only
+     * key is pressed. The input time should use CLOCK_MONOTONIC.
+     *
+     * If timeout < 0, always return true.
+     * Otherwise, check if it should be triggered based on current time.
+     *
+     * @return should trigger modifier only key
+     */
+    bool checkModifierOnlyKeyTimeout(uint64_t lastPressedTime) const;
 
     const std::vector<std::string> &enabledAddons() const;
     const std::vector<std::string> &disabledAddons() const;

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include <cstdint>
 #include <ctime>
+#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -25,6 +26,7 @@
 #include "fcitx-utils/eventdispatcher.h"
 #include "fcitx-utils/eventloopinterface.h"
 #include "fcitx-utils/i18n.h"
+#include "fcitx-utils/key.h"
 #include "fcitx-utils/log.h"
 #include "fcitx-utils/macros.h"
 #include "fcitx-utils/misc.h"

--- a/src/lib/fcitx/instance_p.h
+++ b/src/lib/fcitx/instance_p.h
@@ -56,6 +56,7 @@ struct InputState : public InputContextProperty {
     CheckInputMethodChanged *imChanged_ = nullptr;
     int keyReleased_ = -1;
     Key lastKeyPressed_;
+    uint64_t lastKeyPressedTime_ = 0;
     bool totallyReleased_ = true;
     bool firstTrigger_ = false;
     size_t pendingGroupIndex_ = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -84,6 +84,7 @@ foreach(TESTCASE ${FCITX_CONFIG_TEST})
 endforeach()
 
 set(testinputcontext_LIBS Fcitx5::Module::TestFrontend Fcitx5::Module::TestIM)
+set(testinstance_LIBS Fcitx5::Module::TestFrontend)
 
 set(FCITX_CORE_TEST
     testinputcontext

--- a/test/testinstance.cpp
+++ b/test/testinstance.cpp
@@ -4,51 +4,125 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
  */
+#include <chrono>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
 #include "fcitx-utils/eventdispatcher.h"
+#include "fcitx-utils/key.h"
+#include "fcitx-utils/log.h"
+#include "fcitx-utils/macros.h"
 #include "fcitx-utils/testing.h"
 #include "fcitx/addonmanager.h"
+#include "fcitx/event.h"
+#include "fcitx/inputmethodgroup.h"
+#include "fcitx/inputmethodmanager.h"
 #include "fcitx/instance.h"
 #include "testdir.h"
+#include "testfrontend_public.h"
 
 using namespace fcitx;
 
-void testCheckUpdate(EventDispatcher *dispatcher, Instance *instance) {
-    dispatcher->schedule([instance]() {
-        FCITX_ASSERT(!instance->checkUpdate());
+void testCheckUpdate(Instance &instance) {
+    instance.eventDispatcher().schedule([&instance]() {
+        FCITX_ASSERT(!instance.checkUpdate());
         auto hasUpdateTrue =
-            instance->watchEvent(EventType::CheckUpdate,
-                                 EventWatcherPhase::Default, [](Event &event) {
-                                     auto &checkUpdate =
-                                         static_cast<CheckUpdateEvent &>(event);
-                                     checkUpdate.setHasUpdate();
-                                 });
-        FCITX_ASSERT(instance->checkUpdate());
+            instance.watchEvent(EventType::CheckUpdate,
+                                EventWatcherPhase::Default, [](Event &event) {
+                                    auto &checkUpdate =
+                                        static_cast<CheckUpdateEvent &>(event);
+                                    checkUpdate.setHasUpdate();
+                                });
+        FCITX_ASSERT(instance.checkUpdate());
         hasUpdateTrue.reset();
-        FCITX_ASSERT(!instance->checkUpdate());
+        FCITX_ASSERT(!instance.checkUpdate());
     });
 }
 
-void testReloadGlobalConfig(EventDispatcher *dispatcher, Instance *instance) {
-    dispatcher->schedule([instance]() {
+void testReloadGlobalConfig(Instance &instance) {
+    instance.eventDispatcher().schedule([&instance]() {
         bool globalConfigReloadedEventFired = false;
         auto reloadConfigEventWatcher =
-            instance->watchEvent(EventType::GlobalConfigReloaded,
-                                 EventWatcherPhase::Default, [&](Event &) {
-                                     globalConfigReloadedEventFired = true;
-                                     FCITX_INFO() << "Global config reloaded";
-                                 });
-        instance->reloadConfig();
+            instance.watchEvent(EventType::GlobalConfigReloaded,
+                                EventWatcherPhase::Default, [&](Event &) {
+                                    globalConfigReloadedEventFired = true;
+                                    FCITX_INFO() << "Global config reloaded";
+                                });
+        instance.reloadConfig();
         FCITX_ASSERT(globalConfigReloadedEventFired);
-        instance->exit();
+    });
+}
+
+void testModifierOnlyHotkey(Instance &instance) {
+    instance.eventDispatcher().schedule([&instance]() {
+        auto defaultGroup = instance.inputMethodManager().currentGroup();
+        defaultGroup.inputMethodList().clear();
+        defaultGroup.inputMethodList().push_back(
+            InputMethodGroupItem("keyboard-us"));
+        defaultGroup.inputMethodList().push_back(
+            InputMethodGroupItem("testim"));
+        instance.inputMethodManager().setGroup(std::move(defaultGroup));
+
+        auto *testfrontend = instance.addonManager().addon("testfrontend");
+        auto uuid =
+            testfrontend->call<ITestFrontend::createInputContext>("testapp");
+        auto *ic = instance.inputContextManager().findByUUID(uuid);
+        FCITX_ASSERT(ic);
+
+        FCITX_ASSERT(instance.inputMethod(ic) == "keyboard-us");
+        // Alt trigger doesn't work since we are at first im.
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift_L"), false));
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift+Shift_L"), true));
+        FCITX_ASSERT(instance.inputMethod(ic) == "keyboard-us");
+
+        FCITX_ASSERT(instance.inputMethod(ic) == "keyboard-us");
+        FCITX_ASSERT(testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Control+space"), false));
+        FCITX_ASSERT(instance.inputMethod(ic) == "testim");
+
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift_L"), false));
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift+Shift_L"), true));
+        FCITX_ASSERT(instance.inputMethod(ic) == "keyboard-us");
+
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift_L"), false));
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift+Shift_L"), true));
+        FCITX_ASSERT(instance.inputMethod(ic) == "testim");
+
+        // Sleep 1 sec between press and release, should not trigger based on
+        // default 250ms.
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift_L"), false));
+        std::this_thread::sleep_until(std::chrono::steady_clock::now() +
+                                      std::chrono::seconds(1));
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift+Shift_L"), true));
+        FCITX_ASSERT(instance.inputMethod(ic) == "testim");
+
+        // Some other key pressed between shift, should not trigger.
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift_L"), false));
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift+A"), false));
+        FCITX_ASSERT(!testfrontend->call<ITestFrontend::sendKeyEvent>(
+            uuid, Key("Shift+Shift_L"), true));
+        FCITX_ASSERT(instance.inputMethod(ic) == "testim");
     });
 }
 
 int main() {
-    setupTestingEnvironment(FCITX5_BINARY_DIR, {"testing/testim"}, {});
+    setupTestingEnvironment(FCITX5_BINARY_DIR,
+                            {"testing/testim", "testing/testfrontend"}, {});
 
     char arg0[] = "testinstance";
     char arg1[] = "--disable=all";
-    char arg2[] = "--enable=testim";
+    char arg2[] = "--enable=testim,testfrontend";
     char arg3[] = "--option=name1=opt1a:opt1b,name2=opt2a:opt2b";
     char *argv[] = {arg0, arg1, arg2, arg3};
     Instance instance(FCITX_ARRAY_SIZE(argv), argv);
@@ -59,10 +133,10 @@ int main() {
                  std::vector<std::string>{"opt2a", "opt2b"});
     FCITX_ASSERT(instance.addonManager().addonOptions("name3") ==
                  std::vector<std::string>{});
-    EventDispatcher dispatcher;
-    dispatcher.attach(&instance.eventLoop());
-    testCheckUpdate(&dispatcher, &instance);
-    testReloadGlobalConfig(&dispatcher, &instance);
+    testCheckUpdate(instance);
+    testReloadGlobalConfig(instance);
+    testModifierOnlyHotkey(instance);
+    instance.eventDispatcher().schedule([&instance]() { instance.exit(); });
     instance.exec();
     return 0;
 }


### PR DESCRIPTION
This is intended to solve some issue when user have other intentions.

For example, user may press "Shift" to do some text selection with
mouse. However, input method may not be capable (theoratically
possible on certain platform, but it's not implemented and not possible
on all platform) to detect user actually want to use mouse. If application
does not send "reset()", input method may wrongly trigger the action.

Some other cases include:
- Ctrl and scroll mouse
- user wants to type Shift+A, but regrets after press shift. So user
  release all key but accidentally triggers "Shift" to switch input
  method.

This is not perfect but should help solve some unintended action.
