### PR TITLE
Use _NET_WM_WINDOW_TYPE_COMBO as input window type under X11.

### DIFF
--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -18,10 +18,10 @@ XCBInputWindow::XCBInputWindow(XCBUI *ui)
           ui_->displayName(), "_KDE_NET_WM_BLUR_BEHIND_REGION", false)) {}
 
 void XCBInputWindow::postCreateWindow() {
-    if (ui_->ewmh()->_NET_WM_WINDOW_TYPE_POPUP_MENU &&
+    if (ui_->ewmh()->_NET_WM_WINDOW_TYPE_COMBO &&
         ui_->ewmh()->_NET_WM_WINDOW_TYPE) {
-        xcb_ewmh_set_wm_window_type(
-            ui_->ewmh(), wid_, 1, &ui_->ewmh()->_NET_WM_WINDOW_TYPE_POPUP_MENU);
+        xcb_ewmh_set_wm_window_type(ui_->ewmh(), wid_, 1,
+                                    &ui_->ewmh()->_NET_WM_WINDOW_TYPE_COMBO);
     }
 
     if (ui_->ewmh()->_NET_WM_PID) {


### PR DESCRIPTION
Pantheon has a bug that can't not display popup window under Xwayland
twice. While the bug is reported, it's not clear when it may be fixed.
Also, input method window is indeed more like a combo box and wmspec
mentioned that it's also a common override redirect. So try to use that
instead.

Workaround #1209
