### PR TITLE
Fix to prevent conflict between /etc/xdg/autostart/org.fcitx.Fcitx5.desktop and fcitx5 launched from KWin

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -4,6 +4,8 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fcitx5-configtool.desktop.in.in
                ${CMAKE_CURRENT_BINARY_DIR}/fcitx5-configtool.desktop.in @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/org.fcitx.Fcitx5.desktop.in.in
                ${CMAKE_CURRENT_BINARY_DIR}/org.fcitx.Fcitx5.desktop.in @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/start-fcitx5.sh.in
+               ${CMAKE_CURRENT_BINARY_DIR}/start-fcitx5.sh @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/fcitx5-diagnose.sh
                ${CMAKE_CURRENT_BINARY_DIR}/fcitx5-diagnose ESCAPE_QUOTES @ONLY)
 
@@ -30,6 +32,9 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/fcitx5-diagnose" DESTINATION "${FCITX
 GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
 install(DIRECTORY default DESTINATION "${FCITX_INSTALL_PKGDATADIR}" COMPONENT config)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/start-fcitx5.sh"
+        DESTINATION "${FCITX_INSTALL_LIBEXECDIR}/fcitx5/"
+        PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
 if (WAYLAND_FOUND AND ENABLE_X11)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/20-fcitx-x11.in

--- a/data/org.fcitx.Fcitx5.desktop.in.in
+++ b/data/org.fcitx.Fcitx5.desktop.in.in
@@ -2,7 +2,7 @@
 Name=Fcitx 5
 GenericName=Input Method
 Comment=Start Input Method
-Exec=@FCITX_INSTALL_BINDIR@/fcitx5
+Exec=sh @FCITX_INSTALL_LIBEXECDIR@/fcitx5/start-fcitx5.sh
 Icon=@FCITX_ICON_NAME@
 Terminal=false
 Type=Application

--- a/data/start-fcitx5.sh.in
+++ b/data/start-fcitx5.sh.in
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ "$XDG_CURRENT_DESKTOP" = "KDE" ];then
+if [ $(pgrep plasmashell) ];then
     SUDO_USER="$(who|head -n1|cut -f1 -d' ')"
     RET=$(su $SUDO_USER -c 'qdbus6 org.kde.KWin /VirtualKeyboard org.kde.kwin.VirtualKeyboard.active')
     if [ "$RET" = "true" ]; then

--- a/data/start-fcitx5.sh.in
+++ b/data/start-fcitx5.sh.in
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$XDG_CURRENT_DESKTOP" = "KDE" ];then
+    SUDO_USER="$(who|head -n1|cut -f1 -d' ')"
+    RET=$(su $SUDO_USER -c 'qdbus6 org.kde.KWin /VirtualKeyboard org.kde.kwin.VirtualKeyboard.active')
+    if [ "$RET" = "true" ]; then
+        exit
+    fi
+fi
+exec @FCITX_INSTALL_BINDIR@/fcitx5


### PR DESCRIPTION
Added start-fcitx5.sh

Change org.fcitx.Fcitx5.desktop to a script that does not run fcitx5 when KWin's VirtualKeyboard is enabled.

