### PR TITLE
fix: iterator is not pointer

### DIFF
--- a/src/lib/fcitx-utils/semver.cpp
+++ b/src/lib/fcitx-utils/semver.cpp
@@ -33,7 +33,7 @@ bool isIdChar(char c) {
 }
 
 std::optional<uint32_t> consumeNumericIdentifier(std::string_view &str) {
-    const auto *endOfNum =
+    auto endOfNum =
         std::find_if_not(str.begin(), str.end(), charutils::isdigit);
     auto length = std::distance(str.begin(), endOfNum);
     if (length == 0) {
@@ -45,8 +45,8 @@ std::optional<uint32_t> consumeNumericIdentifier(std::string_view &str) {
 
     auto numberStr = str.substr(0, length);
     uint32_t number;
-    if (auto [p, ec] =
-            std::from_chars(numberStr.begin(), numberStr.end(), number);
+    if (auto [p, ec] = std::from_chars(
+            numberStr.data(), numberStr.data() + numberStr.size(), number);
         ec == std::errc()) {
         str.remove_prefix(length);
         return number;

--- a/src/lib/fcitx-utils/semver.cpp
+++ b/src/lib/fcitx-utils/semver.cpp
@@ -33,7 +33,7 @@ bool isIdChar(char c) {
 }
 
 std::optional<uint32_t> consumeNumericIdentifier(std::string_view &str) {
-    auto endOfNum =
+    std::string_view::iterator endOfNum =
         std::find_if_not(str.begin(), str.end(), charutils::isdigit);
     auto length = std::distance(str.begin(), endOfNum);
     if (length == 0) {


### PR DESCRIPTION
After [upgrading](https://github.com/fcitx-contrib/fcitx5-js/pull/19) emscripten to 4.0.0, fcitx5 failed to compile:

```
FAILED: fcitx5/src/lib/fcitx-utils/CMakeFiles/Fcitx5Utils.dir/semver.cpp.o 
/home/runner/work/fcitx5-js/fcitx5-js/emsdk/upstream/emscripten/em++ -DFCITX_GETTEXT_DOMAIN=\"fcitx5\" -DFMT_HEADER_ONLY=1 -DFcitx5Utils_EXPORTS -I/home/runner/work/fcitx5-js/fcitx5-js/build/fcitx5 -I/home/runner/work/fcitx5-js/fcitx5-js/fcitx5/src/lib/fcitx-utils/.. -I/home/runner/work/fcitx5-js/fcitx5-js/build/fcitx5/src/lib/fcitx-utils/.. -isystem /home/runner/work/fcitx5-js/fcitx5-js/build/sysroot/usr/include -Wall -Wextra  -O3 -DNDEBUG -std=c++17 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -fexceptions -MD -MT fcitx5/src/lib/fcitx-utils/CMakeFiles/Fcitx5Utils.dir/semver.cpp.o -MF fcitx5/src/lib/fcitx-utils/CMakeFiles/Fcitx5Utils.dir/semver.cpp.o.d -o fcitx5/src/lib/fcitx-utils/CMakeFiles/Fcitx5Utils.dir/semver.cpp.o -c /home/runner/work/fcitx5-js/fcitx5-js/fcitx5/src/lib/fcitx-utils/semver.cpp
/home/runner/work/fcitx5-js/fcitx5-js/fcitx5/src/lib/fcitx-utils/semver.cpp:36:17: error: variable 'endOfNum' with type 'const auto *' has incompatible initializer of type 'std::__wrap_iter<const char *>'
   36 |     const auto *endOfNum =
      |                 ^
   37 |         std::find_if_not(str.begin(), str.end(), charutils::isdigit);
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```