### PR TITLE
Add a new API setBufferWithRestoreCallback to quickphrase

### DIFF
--- a/src/modules/quickphrase/quickphrase.h
+++ b/src/modules/quickphrase/quickphrase.h
@@ -78,6 +78,9 @@ public:
                  const std::string &prefix, const std::string &str,
                  const std::string &alt, const Key &key);
     void setBuffer(InputContext *ic, const std::string &text);
+    void setBufferWithRestoreCallback(InputContext *ic, const std::string &text,
+                                      const std::string &original,
+                                      QuickPhraseRestoreCallback callback);
 
     std::unique_ptr<HandlerTableEntry<QuickPhraseProviderCallback>>
         addProvider(QuickPhraseProviderCallback);
@@ -90,6 +93,7 @@ private:
     FCITX_ADDON_EXPORT_FUNCTION(QuickPhrase, addProvider);
     FCITX_ADDON_EXPORT_FUNCTION(QuickPhrase, addProviderV2);
     FCITX_ADDON_EXPORT_FUNCTION(QuickPhrase, setBuffer);
+    FCITX_ADDON_EXPORT_FUNCTION(QuickPhrase, setBufferWithRestoreCallback);
 
     void setSelectionKeys(QuickPhraseAction action);
 

--- a/src/modules/quickphrase/quickphrase_public.h
+++ b/src/modules/quickphrase/quickphrase_public.h
@@ -40,6 +40,8 @@ using QuickPhraseAddCandidateCallbackV2 =
 using QuickPhraseProviderCallbackV2 =
     std::function<bool(InputContext *ic, const std::string &,
                        const QuickPhraseAddCandidateCallbackV2 &)>;
+using QuickPhraseRestoreCallback =
+    std::function<void(InputContext *ic, const std::string &buffer)>;
 
 } // namespace fcitx
 
@@ -52,6 +54,14 @@ FCITX_ADDON_DECLARE_FUNCTION(QuickPhrase, trigger,
                                   const std::string &alt, const Key &key));
 FCITX_ADDON_DECLARE_FUNCTION(QuickPhrase, setBuffer,
                              void(InputContext *ic, const std::string &text));
+// Set buffer with a restore callback.
+// If after "backspace", the current buffer is restore to the original value,
+// the callback will be invoked, to allow input method to restore the buffer to
+// original state.
+FCITX_ADDON_DECLARE_FUNCTION(QuickPhrase, setBufferWithRestoreCallback,
+                             void(InputContext *ic, const std::string &text,
+                                  const std::string &original,
+                                  QuickPhraseRestoreCallback callback));
 
 FCITX_ADDON_DECLARE_FUNCTION(
     QuickPhrase, addProvider,

--- a/testing/testfrontend/testfrontend_public.h
+++ b/testing/testfrontend/testfrontend_public.h
@@ -8,6 +8,7 @@
 #define _TESTFRONTEND_TESTFRONTEND_PUBLIC_H_
 
 #include <string>
+#include <fcitx-utils/key.h>
 #include <fcitx/addoninstance.h>
 #include <fcitx/inputcontext.h>
 


### PR DESCRIPTION
Whenever an input method want to temporarily enter quickphrase, we allow
quickphrase to restore to engine, if user change buffer into a specified
state.
