### PR TITLE
define LC_MESSAGES when missing

### DIFF
--- a/src/lib/fcitx-utils/i18nstring.cpp
+++ b/src/lib/fcitx-utils/i18nstring.cpp
@@ -13,7 +13,7 @@
 #include "misc.h"
 
 #ifndef LC_MESSAGES
-#define LC_MESSAGES 0
+#define LC_MESSAGES LC_ALL
 #endif
 
 namespace fcitx {

--- a/src/lib/fcitx-utils/i18nstring.cpp
+++ b/src/lib/fcitx-utils/i18nstring.cpp
@@ -12,6 +12,10 @@
 #include "charutils.h"
 #include "misc.h"
 
+#ifndef LC_MESSAGES
+#define LC_MESSAGES 0
+#endif
+
 namespace fcitx {
 const std::string &I18NString::match(const std::string &locale_) const {
     std::string locale = locale_;


### PR DESCRIPTION
0 is LC_ALL on win32, although I don't think this else branch will be used in the future.