### PR TITLE
disable geteuid on win32

### DIFF
--- a/src/lib/fcitx-utils/standardpath.cpp
+++ b/src/lib/fcitx-utils/standardpath.cpp
@@ -211,6 +211,7 @@ private:
                 }
                 dir = stringutils::joinPath(home, defaultPath);
             } else {
+#ifndef _WIN32
                 if (env && strcmp(env, "XDG_RUNTIME_DIR") == 0) {
                     dir = stringutils::joinPath(
                         defaultPath,
@@ -221,11 +222,15 @@ private:
                         }
                     }
                 } else {
+#endif
                     dir = defaultPath;
+#ifndef _WIN32
                 }
+#endif
             }
         }
 
+#ifndef _WIN32
         if (!dir.empty() && env && strcmp(env, "XDG_RUNTIME_DIR") == 0) {
             struct stat buf;
             if (stat(dir.c_str(), &buf) != 0 || buf.st_uid != geteuid() ||
@@ -233,6 +238,7 @@ private:
                 return {};
             }
         }
+#endif
         return dir;
     }
 


### PR DESCRIPTION
XDG_RUNTIME_DIR related code has no use case on win32.