### PR TITLE
Check inputContext before updating position

### DIFF
--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -223,7 +223,9 @@ void XCBInputWindow::update(InputContext *inputContext) {
     }
 
     cairo_t *c = cairo_create(prerender());
-    updatePosition(inputContext);
+    if (inputContext) {
+        updatePosition(inputContext);
+    }
     if (!oldVisible) {
         xcb_map_window(ui_->connection(), wid_);
     }


### PR DESCRIPTION
Add null check for inputContext before calling updatePosition to prevent potential null pointer dereference in XCBInputWindow::update.