### PR TITLE
Make fs.cpp compile on windows

### DIFF
--- a/src/lib/fcitx-utils/mtime_p.h
+++ b/src/lib/fcitx-utils/mtime_p.h
@@ -20,7 +20,7 @@ struct Timespec {
 
 template <typename T>
 inline std::enable_if_t<(&T::st_mtim, true), Timespec>
-modifiedTime(const T &p) {
+modifiedTimeImpl(const T &p, int /*unused*/) {
     return {p.st_mtim.tv_sec, p.st_mtim.tv_nsec};
 }
 
@@ -29,18 +29,22 @@ modifiedTime(const T &p) {
 #if !defined(st_mtimespec)
 template <typename T>
 inline std::enable_if_t<(&T::st_mtimespec, true), Timespec>
-modifiedTime(const T &p) {
+modifiedTimeImpl(const T &p, int /*unused*/) {
     return {p.st_mtimespec.tv_sec, p.st_mtimespec.tv_nsec};
 }
 #endif
 
 #if !defined(st_mtimensec) && !defined(__alpha__)
 template <typename T>
-inline std::enable_if_t<(&T::st_mtimensec, true), Timespec>
-modifiedTime(const T &p) {
+inline std::enable_if_t<(&T::st_mtime, &T::st_mtimensec, true), Timespec>
+modifiedTimeImpl(const T &p, int /*unused*/) {
     return {p.st_mtime, p.st_mtimensec};
 }
 #endif
+
+Timespec modifiedTimeImpl(const struct stat &p, unsigned long /*unused*/) {
+    return {p.st_mtime, 0};
+}
 
 } // namespace fcitx
 


### PR DESCRIPTION
1. mtime uses st_mtime as fallback
2. fix mkdir
3. Effectively disable icon theme cache on windows, there's no tool generate cache anyway on windows. We may still need it to load icon.

Effectively disable icon theme cache on windows

Close #1245