### PR TITLE
remove duplicated cutf8.h on install

### DIFF
--- a/src/lib/fcitx-utils/CMakeLists.txt
+++ b/src/lib/fcitx-utils/CMakeLists.txt
@@ -92,7 +92,6 @@ set(FCITX_UTILS_HEADERS
     intrusivelist.h
     misc.h
     utf8.h
-    cutf8.h
     element.h
     rect.h
     charutils.h


### PR DESCRIPTION
Already at L77.