### PR TITLE
fix: typo in clipboard.cpp password masking placeholder

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -89,7 +89,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<Succedani alt d'ús no privat>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/da.po
+++ b/po/da.po
@@ -89,7 +89,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<Høj surrogat for ikke privat brug>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/de.po
+++ b/po/de.po
@@ -91,7 +91,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<Non Private Use High Surrogate>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/es.po
+++ b/po/es.po
@@ -87,7 +87,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr ""
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/fcitx5.pot
+++ b/po/fcitx5.pot
@@ -84,7 +84,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr ""
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/fr.po
+++ b/po/fr.po
@@ -90,7 +90,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<Usage non privé haut substitut>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/he.po
+++ b/po/he.po
@@ -90,7 +90,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr ""
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/ja.po
+++ b/po/ja.po
@@ -91,8 +91,8 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<Non Private Use High Surrogate>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
-msgstr "<Passowrd>"
+msgid "<Password>"
+msgstr "<Password>"
 
 #: src/modules/unicode/charselectdata.cpp:213
 msgid "<Private Use High Surrogate>"

--- a/po/ko.po
+++ b/po/ko.po
@@ -92,7 +92,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<비 개인용 상위 확장코드>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/ru.po
+++ b/po/ru.po
@@ -92,7 +92,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<Не лично использовать высокий заменитель>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr "<Пароль>"
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/vi.po
+++ b/po/vi.po
@@ -88,7 +88,7 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<Non Private Use High Surrogate>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
+msgid "<Password>"
 msgstr ""
 
 #: src/modules/unicode/charselectdata.cpp:213

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -92,8 +92,8 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<非专用高半代理区>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
-msgstr "<Passowrd>"
+msgid "<Password>"
+msgstr "<Password>"
 
 #: src/modules/unicode/charselectdata.cpp:213
 msgid "<Private Use High Surrogate>"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -98,8 +98,8 @@ msgid "<Non Private Use High Surrogate>"
 msgstr "<非專用高半代理區>"
 
 #: src/modules/clipboard/clipboard.cpp:116
-msgid "<Passowrd>"
-msgstr "<Passowrd>"
+msgid "<Password>"
+msgstr "<Password>"
 
 #: src/modules/unicode/charselectdata.cpp:213
 msgid "<Private Use High Surrogate>"

--- a/src/modules/clipboard/clipboard.cpp
+++ b/src/modules/clipboard/clipboard.cpp
@@ -113,7 +113,7 @@ public:
                 length -= 1;
             }
             text.append(dot);
-            setComment(Text{_("<Passowrd>")});
+            setComment(Text{_("<Password>")});
         } else {
             text.append(ClipboardSelectionStrip(str));
         }


### PR DESCRIPTION
- Fix typo "<Passowrd>" -> "<Password>" in clipboard.cpp
- Update corresponding translations in all .po files