### PR TITLE
Fix icon theme scale parsing

### DIFF
--- a/src/lib/fcitx/icontheme.cpp
+++ b/src/lib/fcitx/icontheme.cpp
@@ -84,7 +84,7 @@ public:
         }
 
         if (auto subConfig = config.get("Scale")) {
-            unmarshallOption(size_, *subConfig, false);
+            unmarshallOption(scale_, *subConfig, false);
         }
         if (auto subConfig = config.get("Context")) {
             unmarshallOption(context_, *subConfig, false);


### PR DESCRIPTION
Icon theme scale was incorrectly being assigned to size_ instead of scale_ when parsing Scale config option.