### PR TITLE
Send modifiers to the Wayland server when a modifier key event needs to be forwarded

### DIFF
--- a/src/frontend/waylandim/virtualinputcontext.h
+++ b/src/frontend/waylandim/virtualinputcontext.h
@@ -17,6 +17,23 @@
 #include "fcitx/inputcontext.h"
 #include "appmonitor.h"
 
+#ifdef __linux__
+#include <linux/input-event-codes.h>
+#elif __FreeBSD__
+#include <dev/evdev/input-event-codes.h>
+#else
+#define KEY_LEFTCTRL    29
+#define KEY_LEFTSHIFT   42
+#define KEY_RIGHTSHIFT  54
+#define KEY_LEFTALT     56
+#define KEY_CAPSLOCK    58
+#define KEY_NUMLOCK     69
+#define KEY_RIGHTCTRL   97
+#define KEY_RIGHTALT    100
+#define KEY_LEFTMETA    125
+#define KEY_RIGHTMETA   126
+#endif
+
 namespace fcitx {
 
 class VirtualInputContextManager;
@@ -51,6 +68,20 @@ public:
     void focusOutWrapper();
     void updateSurroundingTextWrapper();
     void setCapabilityFlagsWrapper(CapabilityFlags flags);
+
+    static bool isModifier(const int keycode) {
+        int code = keycode - 8;
+        return code == KEY_LEFTCTRL ||
+            code == KEY_LEFTSHIFT ||
+            code == KEY_RIGHTSHIFT ||
+            code == KEY_LEFTALT ||
+            code == KEY_CAPSLOCK ||
+            code == KEY_NUMLOCK ||
+            code == KEY_RIGHTCTRL ||
+            code == KEY_RIGHTALT ||
+            code == KEY_LEFTMETA ||
+            code == KEY_RIGHTMETA;
+    }
 
 private:
     void commitStringImpl(const std::string &text) override {

--- a/src/frontend/waylandim/waylandimserver.cpp
+++ b/src/frontend/waylandim/waylandimserver.cpp
@@ -603,6 +603,65 @@ void WaylandIMInputContextV1::sendKeyToVK(uint32_t time, const Key &key,
     }
 }
 
+void WaylandIMInputContextV1::sendModifiers(const int keycode,
+                                          uint32_t state) const {
+    if (!ic_ || !server_->state_) {
+        return;
+    }
+
+    if (!isModifier(keycode)) {
+        return;
+    }
+
+    xkb_mod_mask_t modsDepressed, modsLatched, modsLocked, mask = 0;
+    xkb_layout_index_t group;
+
+    modsDepressed = xkb_state_serialize_mods(server_->state_.get(),
+                                    XKB_STATE_MODS_DEPRESSED);
+    modsLatched = xkb_state_serialize_mods(server_->state_.get(),
+                                    XKB_STATE_MODS_LATCHED);
+    modsLocked = xkb_state_serialize_mods(server_->state_.get(),
+                                    XKB_STATE_MODS_LATCHED);
+    group = xkb_state_serialize_layout(server_->state_.get(),
+                                    XKB_STATE_LAYOUT_LOCKED);
+
+    int code = keycode - 8;
+
+    bool isLock = false;
+    if (code == KEY_LEFTCTRL || code == KEY_RIGHTCTRL) {
+        mask = server_->stateMask_.control_mask;
+    } else if (code == KEY_LEFTSHIFT || code == KEY_LEFTSHIFT) {
+        mask = server_->stateMask_.shift_mask;
+    } else if (code == KEY_LEFTALT || code == KEY_RIGHTALT) {
+        mask = server_->stateMask_.mod1_mask;
+    } else if (code == KEY_LEFTMETA || code == KEY_RIGHTMETA) {
+        mask = server_->stateMask_.mod4_mask;
+    } else if (code == KEY_CAPSLOCK) {
+        mask = server_->stateMask_.lock_mask;
+        isLock = true;
+    } else if (code == KEY_NUMLOCK) {
+        mask = server_->stateMask_.mod2_mask;
+        isLock = true;
+    }
+
+    if (isLock) {
+        if (state == WL_KEYBOARD_KEY_STATE_RELEASED) {
+            modsLocked ^= mask;
+        } else {
+            // only update lock modifiers after released.
+            return;
+        }
+    } else {
+        if (state == WL_KEYBOARD_KEY_STATE_RELEASED) {
+            modsDepressed &= ~mask;
+        } else {
+            modsDepressed |= mask;
+        }
+    }
+
+    ic_->modifiers(serial_, modsDepressed, modsLatched, modsLocked, group);
+}
+
 void WaylandIMInputContextV1::updatePreeditDelegate(InputContext *ic) const {
     if (!ic_) {
         return;

--- a/src/frontend/waylandim/waylandimserver.h
+++ b/src/frontend/waylandim/waylandimserver.h
@@ -104,12 +104,18 @@ protected:
             return;
         }
         if (key.rawKey().code() && key.rawKey().states() == KeyState::NoState) {
-            sendKeyToVK(time_, key.rawKey(),
-                        key.isRelease() ? WL_KEYBOARD_KEY_STATE_RELEASED
-                                        : WL_KEYBOARD_KEY_STATE_PRESSED);
-            if (!key.isRelease()) {
+            if (isModifier(key.rawKey().code())) {
+                sendModifiers(key.rawKey().code(),
+                            key.isRelease() ? WL_KEYBOARD_KEY_STATE_RELEASED
+                                            : WL_KEYBOARD_KEY_STATE_PRESSED);
+            } else {
                 sendKeyToVK(time_, key.rawKey(),
-                            WL_KEYBOARD_KEY_STATE_RELEASED);
+                            key.isRelease() ? WL_KEYBOARD_KEY_STATE_RELEASED
+                                            : WL_KEYBOARD_KEY_STATE_PRESSED);
+                if (!key.isRelease()) {
+                    sendKeyToVK(time_, key.rawKey(),
+                                WL_KEYBOARD_KEY_STATE_RELEASED);
+                }
             }
         } else {
             sendKey(time_, key.rawKey().sym(),
@@ -146,6 +152,7 @@ private:
     void sendKey(uint32_t time, uint32_t sym, uint32_t state,
                  KeyStates states) const;
     void sendKeyToVK(uint32_t time, const Key &key, uint32_t state) const;
+    void sendModifiers(const int keycode, uint32_t state) const;
 
     static uint32_t toModifiers(KeyStates states) {
         uint32_t modifiers = 0;

--- a/src/frontend/waylandim/waylandimserverv2.h
+++ b/src/frontend/waylandim/waylandimserverv2.h
@@ -129,6 +129,7 @@ private:
                            uint32_t group);
     void repeatInfoCallback(int32_t rate, int32_t delay);
     void sendKeyToVK(uint32_t time, const Key &key, uint32_t state) const;
+    void sendModifiers(const int keycode, uint32_t state) const;
 
     int32_t repeatRate() const;
     int32_t repeatDelay() const;


### PR DESCRIPTION
I'm using kwin 6 with wayland enabled, and I'm writing a virtual keyboard using the `org.fcitx.Fcitx5.VirtualKeyboardBackend1` interface. Currently, a modifier key event is forwarded to the wayland server through `wl_keyboard::key`. This doesn't work, at least in kwin 6. I think the correct way is using `wl_keyboard::modifiers`. 

My virtual keyboard works well with this patch.

This paragraph is composed using my virtual keyboard. Uppercase letters can be inputted since `Shift` works. 中文輸入也可以。
