### PR TITLE
clipboard: improve description of password display

### DIFF
--- a/src/modules/clipboard/clipboard.h
+++ b/src/modules/clipboard/clipboard.h
@@ -66,8 +66,7 @@ FCITX_CONFIGURATION(
                "manager supports marking the clipboard content as password, "
                "this clipboard update will be ignored.")}};
     ConditionalHidden<isAndroid(), Option<bool>> showPassword{
-        this, "ShowPassword",
-        _("Hidden clipboard content that contains a password"), false};
+        this, "ShowPassword", _("Display passwords as plain text"), false};
     ConditionalHidden<
         isAndroid(),
         Option<int, IntConstrain, DefaultMarshaller<int>, ToolTipAnnotation>>


### PR DESCRIPTION
Improve the description of the password display option. The previous english description was the wrong way around, as it indicated that the password was only shown when the checkbox was checked.