### PR TITLE
Make standardpath compile on win32

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -41,6 +41,7 @@ Standard:        Cpp11
 IndentWidth:     4
 TabWidth:        4
 UseTab:          Never
+LineEnding:      LF
 BreakBeforeBraces: Attach
 SpacesInParentheses: false
 SpacesInAngles:  false

--- a/src/lib/fcitx-utils/standardpath.cpp
+++ b/src/lib/fcitx-utils/standardpath.cpp
@@ -223,6 +223,10 @@ private:
                 dir = stringutils::joinPath(*home, defaultPath);
             } else {
                 if (env && strcmp(env, "XDG_RUNTIME_DIR") == 0) {
+#ifdef _WIN32
+                    dir = stringutils::joinPath(
+                        defaultPath, stringutils::concat("fcitx-runtime"));
+#else
                     dir = stringutils::joinPath(
                         defaultPath,
                         stringutils::concat("fcitx-runtime-", geteuid()));
@@ -231,12 +235,14 @@ private:
                             return {};
                         }
                     }
+#endif
                 } else {
                     dir = defaultPath;
                 }
             }
         }
 
+#ifndef _WIN32
         if (!dir.empty() && env && strcmp(env, "XDG_RUNTIME_DIR") == 0) {
             struct stat buf;
             if (stat(dir.c_str(), &buf) != 0 || buf.st_uid != geteuid() ||
@@ -244,6 +250,7 @@ private:
                 return {};
             }
         }
+#endif
         return dir;
     }
 


### PR DESCRIPTION
The plan was to replace it with a new version of the class, but we want to make it compile.