### PR TITLE
add keyboard shortcuts for changing to input method index within group

### DIFF
--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -143,6 +143,23 @@ FCITX_CONFIGURATION(
                                 _("Toggle embedded preedit"),
                                 {Key("Control+Alt+P")},
                                 KeyListConstrain()};
+    KeyListOption inputMethod0{this,
+                                "InputMethod0",
+                                _("Switch to input method 0 of input method group"),
+                                {Key("Alt+parenright")},
+                                KeyListConstrain()};
+    KeyListOption inputMethod1{this,
+                                "InputMethod1",
+                                _("Switch to input method 1 of input method group"),
+                                {Key("Alt+parenleft")},
+                                KeyListConstrain()};
+    KeyListOption inputMethod2{this,
+                                "InputMethod2",
+                                _("Switch to input method 1 of input method group"),
+                                {Key("Alt+asterisk")},
+                                KeyListConstrain()};
+    
+                                    
     Option<int, IntConstrain, DefaultMarshaller<int>, ToolTipAnnotation>
         modifierOnlyKeyTimeout{
             this,
@@ -306,6 +323,21 @@ const KeyList &GlobalConfig::enumerateGroupBackwardKeys() const {
 const KeyList &GlobalConfig::togglePreeditKeys() const {
     FCITX_D();
     return *d->hotkey->togglePreedit;
+}
+
+const KeyList &GlobalConfig::inputMethod0() const {
+    FCITX_D();
+    return *d->hotkey->inputMethod0;
+}
+
+const KeyList &GlobalConfig::inputMethod1() const {
+    FCITX_D();
+    return *d->hotkey->inputMethod1;
+}
+
+const KeyList &GlobalConfig::inputMethod2() const {
+    FCITX_D();
+    return *d->hotkey->inputMethod2;
 }
 
 bool GlobalConfig::activeByDefault() const {

--- a/src/lib/fcitx/globalconfig.h
+++ b/src/lib/fcitx/globalconfig.h
@@ -37,6 +37,9 @@ public:
     const KeyList &enumerateGroupForwardKeys() const;
     const KeyList &enumerateGroupBackwardKeys() const;
     const KeyList &togglePreeditKeys() const;
+    const KeyList &inputMethod0() const;
+    const KeyList &inputMethod1() const;
+    const KeyList &inputMethod2() const;
 
     bool activeByDefault() const;
 

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -781,6 +781,21 @@ Instance::Instance(int argc, char **argv) {
                  [ic, d, origKey](bool) {
                      return d->navigateGroup(ic, origKey, false);
                  }},
+                {d->globalConfig_.inputMethod0(),
+                 [this]() { return true; },
+                 [this](bool) {
+                     return setCurrentInputMethod(0);
+                 }},
+                {d->globalConfig_.inputMethod1(),
+                 [this]() { return true; },
+                 [this](bool) {
+                     return setCurrentInputMethod(1);
+                 }},
+                {d->globalConfig_.inputMethod2(),
+                 [this]() { return true; },
+                 [this](bool) {
+                     return setCurrentInputMethod(2);
+                 }},
             };
 
             auto *inputState = ic->propertyFor(&d->inputStateFactory_);
@@ -2121,6 +2136,16 @@ void Instance::setCurrentInputMethod(InputContext *ic, const std::string &name,
             setGlobalDefaultInputMethod(name);
         }
         return;
+    }
+}
+
+void Instance::setCurrentInputMethod(const int& index) {
+    auto &imList = inputMethodManager().currentGroup().inputMethodList();
+    if (index < 0 || index >= int(imList.size())) {
+        FCITX_DEBUG() << "Error: index " << index << " is out of range, "
+                      << "number of entries in input method group: " << imList.size();
+    } else {
+        setCurrentInputMethod(mostRecentInputContext(), imList[index].name(), false);
     }
 }
 

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -396,6 +396,15 @@ public:
     void setCurrentInputMethod(InputContext *ic, const std::string &imName,
                                bool local);
 
+
+    /**
+     * Set the input method of given input context to the one corresponding to
+     * the given index. This is within the current group.
+     *
+     * @param index index in list of input methods in current group
+     */
+    void setCurrentInputMethod(const int& index);
+
     /*
      * Enumerate input method group
      *


### PR DESCRIPTION
Tested on local machine on a `make install`, manually triggering `Alt+Shift+0`, `Alt+Shift+9`, `Alt+Shift+8`. Remains to add corresponding hotkey option to fcitx-config (something I do not feel especially excited about doing).