### PR TITLE
fix shift+click changes im by checking MousePressed

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -784,7 +784,9 @@ Instance::Instance(int argc, char **argv) {
             // Keep this value, and reset them in the state
             inputState->keyReleased_ = -1;
             const bool isModifier = origKey.isModifier();
-            if (keyEvent.isRelease()) {
+            // Don't trigger actions when using shift+click to select text
+            if (keyEvent.isRelease() &&
+                !keyEvent.origKey().states().test(KeyState::MousePressed)) {
                 int idx = 0;
                 for (auto &keyHandler : keyHandlers) {
                     if (keyReleased == idx &&


### PR DESCRIPTION
This should work better than the 250ms workaround.
MousePressed doesn't seem to be used elsewhere so could be a good fit for this purpose.
It's frontend's job to decide how this KeyState is set. On macOS, im doesn't receive mouse click event, but it can be determined by text selection change (although not all apps report it correctly, VSCode ✅ LibreOffice ❌).