### PR TITLE
Fix StandardPaths::openPath on certain platform

### DIFF
--- a/src/lib/fcitx-utils/standardpath.h
+++ b/src/lib/fcitx-utils/standardpath.h
@@ -90,11 +90,12 @@ NotFilter<T> Not(T t) {
 }
 
 /// \brief Filter class that filters based on user file.
-struct FCITXUTILS_DEPRECATED_EXPORT User{
+struct FCITXUTILS_DEPRECATED_EXPORT User {
     bool operator()(const std::string & /*unused*/,
-                    const std::string & /*unused*/, bool isUser){return isUser;
-} // namespace filter
-}; // namespace fcitx
+                    const std::string & /*unused*/, bool isUser) {
+        return isUser;
+    }
+};
 
 /// \brief Filter class that filters file based on prefix
 struct FCITXUTILS_DEPRECATED_EXPORT Prefix {

--- a/src/lib/fcitx-utils/standardpaths.cpp
+++ b/src/lib/fcitx-utils/standardpaths.cpp
@@ -252,12 +252,15 @@ UnixFD StandardPaths::openPath(const std::filesystem::path &path,
                                std::optional<int> flags,
                                std::optional<mode_t> mode) {
     int f = flags.value_or(O_RDONLY);
+
+    auto openFunc = [](auto path, int flag, auto... extra) {
 #ifdef _WIN32
-    f |= _O_BINARY;
-    auto openFunc = ::_wopen;
+        flag |= _O_BINARY;
+        return ::_wopen(path, flag, extra...);
 #else
-    auto openFunc = ::open;
+        return ::open(path, flag, extra...);
 #endif
+    };
     if (mode.has_value()) {
         return UnixFD::own(openFunc(path.c_str(), f, mode.value()));
     }


### PR DESCRIPTION
Certain platform there might be overload function to ::open(), use a
template function to wrap it instead of using function pointer.
Otherwise we would need to write the full signature of open, which is
undesirable since certain platform may have non-standard signature.
