### PR TITLE
fix(emoji.mb): typo in quickphrase emoji

### DIFF
--- a/src/modules/quickphrase/quickphrase.d/emoji.mb
+++ b/src/modules/quickphrase/quickphrase.d/emoji.mb
@@ -24,7 +24,7 @@ effort (ง •̀_•́)ง
 bye (｡･ω･)ﾉ
 orz _(:з」∠)_
 throw_table (┙>∧<)┙へ┻┻
-blash o(///▽///)q
+blush o(///▽///)q
 sob >_<
 sob ( >﹏<。)
 bear (･ｪ-)


### PR DESCRIPTION
I was digging around and found this:
https://github.com/fcitx/fcitx5/blob/ebf24ddc8a2afe331df2b2f4cbe538f73a4a9b5f/src/modules/quickphrase/quickphrase.d/emoji.mb#L27
It looks like a typo rather than an intentional misspelling, so I went ahead and fixed it.