### PR TITLE
[wayland] Do not show layout override warning when override is disabled

### DIFF
--- a/src/modules/wayland/waylandmodule.cpp
+++ b/src/modules/wayland/waylandmodule.cpp
@@ -718,23 +718,27 @@ void WaylandModule::selfDiagnose() {
 
         // layout diagnosis only when overriding is enabled
         if (*config_.allowOverrideXKB) {
-            std::unordered_set<std::string> groupLayouts;
+            std::optional<std::string> firstLayout;
             for (const auto &groupName :
                  instance_->inputMethodManager().groups()) {
                 if (const auto *group =
                         instance_->inputMethodManager().group(groupName)) {
-                    groupLayouts.insert(group->defaultLayout());
-                }
-                if (groupLayouts.size() >= 2) {
-                    messages.push_back(
-                        _("Sending keyboard layout configuration to wayland "
-                          "compositor from Fcitx is "
-                          "not yet supported on current desktop. You may still "
-                          "use "
-                          "Fcitx's internal layout conversion by adding layout "
-                          "as "
-                          "input method to the input method group."));
-                    break;
+                    const auto &layout = group->defaultLayout();
+                    if (!firstLayout) {
+                        firstLayout = layout;
+                    } else if (layout != *firstLayout) {
+                        messages.push_back(_(
+                            "Sending keyboard layout configuration to wayland "
+                            "compositor from Fcitx is "
+                            "not yet supported on current desktop. You may "
+                            "still "
+                            "use "
+                            "Fcitx's internal layout conversion by adding "
+                            "layout "
+                            "as "
+                            "input method to the input method group."));
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pull request consists of two commits:

1. Prevents the Wayland self-diagnose routine from issuing layout override warnings when "allow overriding system XKB settings" is disabled by the user. Previously, users would receive a confusing message about "sending keyboard layout configuration" even if layout override was explicitly disabled.

2. Refactors the layout diversity check logic in the same routine by replacing `std::unordered_set<std::string>` with `std::optional<std::string>`, which improves performance and clarity.

These changes improve both user experience and internal structure consistency, especially on non-KDE/GNOME compositors (e.g., Hyprland).

Tested with Fcitx5 under Arch Linux with Hyprland and verified the warning is correctly suppressed when override is disabled.

<img width="326" height="179" alt="2025-07-21-220818_hyprshot" src="https://github.com/user-attachments/assets/69c0c2e5-4a1c-4d72-9610-af7a3d12ebba" />
