### PR TITLE
Move keyboard grab reset after virtual keyboard reset when deactivating

### DIFF
--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -170,7 +170,6 @@ WaylandIMInputContextV2::WaylandIMInputContextV2(
         ++serial_;
         if (pendingDeactivate_) {
             pendingDeactivate_ = false;
-            keyboardGrab_.reset();
             repeatInfo_.reset();
             // This is the only place we update wayland xkb mask, so it is ok to
             // reset it to 0. This breaks the caps lock or num lock. But we have
@@ -196,6 +195,7 @@ WaylandIMInputContextV2::WaylandIMInputContextV2(
                 vk_.reset();
                 vkReady_ = false;
             }
+            keyboardGrab_.reset();
         }
         if (pendingActivate_) {
             pendingActivate_ = false;


### PR DESCRIPTION
On hyprland, closing a virtual keyboard causes it to send release events for all keys that are still pressed. Currently fcitx5 close its vk after closing its hardware keyboard grab, meaning the release events end up being sent to the wrong place.

(while fcitx5 does try to release all the pressed key before closing its vk, the code is ?seemingly not triggered? when switching window focus. It's also after closing the keyboard grab so it wouldn't do the expected thing for this issue.)

As an example this fixes issue like [this one](https://github.com/H3rmt/hyprshell/issues/294)

Repo steps for a quick test:

1. run `wev`
2. focus on another window with text field active (fcitx5 running and active)
3. hold down a key then switch focus to `wev` while holding the key

Expected result (after this pr)
`wev` shows no key release event immediately.

Current result:
`wev` shows a key release event immediately even though the key is still pressed.
