### PR TITLE
Ensure conn_ is valid

### DIFF
--- a/src/lib/fcitx-utils/dbus/libdbus/bus.cpp
+++ b/src/lib/fcitx-utils/dbus/libdbus/bus.cpp
@@ -604,7 +604,7 @@ dbus_bool_t DBusAddTimeout(DBusTimeout *timeout, void *data) {
         bus->timeWatchers_.emplace(
             timeout,
             bus->loop_->addTimeEvent(
-                CLOCK_MONOTONIC, now(CLOCK_MONOTONIC) + interval * 1000ULL, 0,
+                CLOCK_MONOTONIC, now(CLOCK_MONOTONIC) + (interval * 1000ULL), 0,
                 [timeout, ref](EventSourceTime *event, uint64_t) {
                     // Copy is required since the lambda may be deleted.
                     // NOLINTBEGIN(performance-unnecessary-copy-initialization)

--- a/src/lib/fcitx-utils/dbus/libdbus/bus_p.h
+++ b/src/lib/fcitx-utils/dbus/libdbus/bus_p.h
@@ -81,11 +81,13 @@ public:
         if (!conn_) {
             return;
         }
-        dbus_connection_ref(conn_.get());
-        while (dbus_connection_dispatch(conn_.get()) ==
-               DBUS_DISPATCH_DATA_REMAINS) {
+        auto *conn = conn_.get();
+        dbus_connection_ref(conn);
+        auto ref = this->watch();
+        while (ref.isValid() &&
+               dbus_connection_dispatch(conn) == DBUS_DISPATCH_DATA_REMAINS) {
         }
-        dbus_connection_unref(conn_.get());
+        dbus_connection_unref(conn);
     }
 
     static bool needWatchService(const MatchRule &rule) {


### PR DESCRIPTION
If ~Bus() is called during dbus_connection_dispatch, conn_ may be reset
to null on libc++'s unique_ptr. This will lead to
dbus_connection_dispatch(null) on the next call. This happens in
notificationitem when privateBus_'s async call returns error. Since
dbus_connection_ref is called anyway, use on-stack raw pointer instead.
Also, check if BusPrivate is still valid and break earlier if destructor
is already called.

Fix #1397
