### PR TITLE
Fix crashlog being inconsistent type in main/errorhandler.

### DIFF
--- a/src/server/errorhandler.h
+++ b/src/server/errorhandler.h
@@ -16,23 +16,15 @@
 #ifndef SIGUNUSED
 #define SIGUNUSED 29
 #endif
-/* ***********************************************************
-// Data structures
-// *********************************************************** */
 
-/* ***********************************************************
-// Functions
-// *********************************************************** */
+namespace fcitx {
 
 //
 // Set Posix Signal Handler
 //
 //
-void SetMyExceptionHandler(void);
+void SetMyExceptionHandler(int pipeFd);
 
-//
-// Process Posix signal
-//
-void OnException(int signo);
+} // namespace fcitx
 
 #endif


### PR DESCRIPTION
Refactor to remove global variable usage so similar thing won't happen
in the future.
