### PR TITLE
Fix relative symlink resolution in configuration files

### DIFF
--- a/src/lib/fcitx-utils/standardpaths_p.h
+++ b/src/lib/fcitx-utils/standardpaths_p.h
@@ -166,7 +166,11 @@ private:
         while (--maxDepth && std::filesystem::is_symlink(fullPath, ec)) {
             auto linked = std::filesystem::read_symlink(fullPath, ec);
             if (!ec) {
-                fullPath = linked;
+                if (linked.is_relative()) {
+                    fullPath = fullPath.parent_path() / linked;
+                } else {
+                    fullPath = linked;
+                }
             } else {
                 return path;
             }


### PR DESCRIPTION
Fixes fcitx5 failing to read/write config files through relative symlinks used by GNU Stow and similar dotfile managers.

Previously, relative symlink targets were treated as absolute paths, causing resolution to fail.  Now properly resolves them relative to the symlink's parent directory.

Tested with relative symlinks, absolute symlinks, and regular files.
