### PR TITLE
replace delete this with safe async deletion in IBusInputContext

### DIFF
--- a/src/frontend/ibusfrontend/ibusfrontend.cpp
+++ b/src/frontend/ibusfrontend/ibusfrontend.cpp
@@ -343,7 +343,9 @@ public:
                        [this](const std::string &, const std::string &,
                               const std::string &newName) {
                            if (newName.empty()) {
-                               delete this;
+                               im_->instance()->eventDispatcher().schedule([this]() {
+                                   delete this;
+                               });
                            }
                        })),
           name_(sender) {


### PR DESCRIPTION
The previous code used 'delete this' in a service watcher callback, causing use-after-free when D-Bus clients disconnect unexpectedly.

Reproduction:
1. Start fcitx5 and IBus application (gedit)
2. Force kill: kill -9 $(pgrep gedit)
3. fcitx5 may crash due to use-after-free 