### PR TITLE
reset input context on toggle preedit

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -869,6 +869,8 @@ Instance::Instance(int argc, char **argv) {
             if (!keyEvent.isRelease() &&
                 keyEvent.key().checkKeyList(
                     d->globalConfig_.togglePreeditKeys())) {
+                // Clear client preedit on disable.
+                ic->reset();
                 ic->setEnablePreedit(!ic->isPreeditEnabled());
                 if (d->notifications_) {
                     d->notifications_->call<INotifications::showTip>(


### PR DESCRIPTION
To avoid leftover on disable

<img width="460" height="88" alt="" src="https://github.com/user-attachments/assets/e277fd65-8f5c-4a57-888b-1cb87dea2899" />