### PR TITLE
priorities show the input method name instead of the label

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -402,9 +402,9 @@ void InstancePrivate::showInputMethodInformation(InputContext *ic) {
         auto subMode = engine->subMode(*entry, *ic);
         auto subModeLabel = engine->subModeLabel(*entry, *ic);
         auto name = globalConfig_.compactInputMethodInformation() &&
-                            !entry->label().empty()
-                        ? entry->label()
-                        : entry->name();
+                            !entry->name().empty()
+                        ? entry->name()
+                        : entry->label();
         if (globalConfig_.compactInputMethodInformation() &&
             !subModeLabel.empty()) {
             display = std::move(subModeLabel);


### PR DESCRIPTION
In fcitx4, the input method name is displayed by default. hope fcitx5 has the same display logic. If there is no input method name, then the input method label will be displayed.