### PR TITLE
build: Mark nlohmann_json as REQUIRED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if (ENABLE_KEYBOARD)
     find_package(XKBCommon REQUIRED COMPONENTS ${REQUIRED_XKBCOMMON_COMPONENTS})
     find_package(IsoCodes REQUIRED)
     find_package(XKeyboardConfig REQUIRED)
-    find_package(nlohmann_json)
+    find_package(nlohmann_json REQUIRED)
 
     set(DEFAULT_XKB_RULES_FILES "${XKEYBOARDCONFIG_XKBBASE}/rules/${DEFAULT_XKB_RULES}.xml")
     if (NOT EXISTS "${DEFAULT_XKB_RULES_FILES}" AND NOT APPLE)


### PR DESCRIPTION
Targets "keyboard" and "testisocodes" unconditionally link to nlohmann_json, so it should be marked as REQUIRED, or when building without the library CMake would complain,

CMake Error at src/im/keyboard/CMakeLists.txt:2 (target_link_libraries):
  Target "keyboard" links to:

    nlohmann_json::nlohmann_json

  but the target was not found.

Fixes: 70fe117d4458 ("replace json-c with nlohmann-json (#1439)")