### PR TITLE
log and use U+FFFD for invalid utf-8 in Text::append

### DIFF
--- a/src/lib/fcitx/text.cpp
+++ b/src/lib/fcitx/text.cpp
@@ -6,11 +6,18 @@
  */
 
 #include "text.h"
+#include <algorithm>
+#include <cstddef>
 #include <iterator>
-#include <stdexcept>
+#include <memory>
+#include <ostream>
+#include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
+#include "fcitx-utils/macros.h"
 #include "fcitx-utils/stringutils.h"
+#include "fcitx-utils/textformatflags.h"
 #include "fcitx-utils/utf8.h"
 
 namespace fcitx {
@@ -50,9 +57,7 @@ void Text::setCursor(int pos) {
 
 void Text::append(std::string str, TextFormatFlags flag) {
     FCITX_D();
-    if (!utf8::validate(str)) {
-        throw std::invalid_argument("Invalid utf8 string");
-    }
+    utf8::replaceInvalidInplace(str, '?');
     d->texts_.emplace_back(std::move(str), flag);
 }
 

--- a/test/testtext.cpp
+++ b/test/testtext.cpp
@@ -65,6 +65,9 @@ void test_normalize() {
 
     auto normalizedEmpty = empty.normalize();
     FCITX_ASSERT(normalizedEmpty.empty()) << normalizedEmpty;
+
+    Text invalid("\x8e\x30\xe4\xb8\x87");
+    FCITX_ASSERT(invalid.toString(), "?0万");
 }
 
 int main() {


### PR DESCRIPTION
* The exception is not caught inside libfcitx. It's generic enough so there is no meaningful way to catch it out of libfcitx, so fcitx app crashes, and I don't want users to encounter crash. They blame on me only.
* Text is for display. There are still ways to not hide the bug, wherever it is.

<img width="730" height="75" alt="" src="https://github.com/user-attachments/assets/b20e4fa0-2c4b-4a7b-a992-84ed53af56f9" />

<img width="578" height="56" alt="" src="https://github.com/user-attachments/assets/3681f291-b3e9-443e-9898-bc39139760fc" />
