### PR TITLE
For Alt + Key, also handled as if Ctrl is used.

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1025,7 +1025,8 @@ Instance::Instance(int argc, char **argv) {
                             utf32 == '\x7f') {
                             return;
                         }
-                        if (keyEvent.key().states().test(KeyState::Ctrl) ||
+                        if (keyEvent.key().states().testAny(
+                                KeyStates{KeyState::Ctrl, KeyState::Alt}) ||
                             keyEvent.rawKey().sym() ==
                                 keyEvent.origKey().sym()) {
                             return;
@@ -1033,7 +1034,8 @@ Instance::Instance(int argc, char **argv) {
                         FCITX_KEYTRACE() << "Will commit char: " << utf32;
                         ic->commitString(utf8::UCS4ToUTF8(utf32));
                         keyEvent.filterAndAccept();
-                    } else if (!keyEvent.key().states().test(KeyState::Ctrl) &&
+                    } else if (!keyEvent.key().states().testAny(
+                                   KeyStates{KeyState::Ctrl, KeyState::Alt}) &&
                                keyEvent.rawKey().sym() !=
                                    keyEvent.origKey().sym() &&
                                Key::keySymToUnicode(keyEvent.origKey().sym()) !=


### PR DESCRIPTION
Alt + Key may just type Key is mainly a Qt specific behavior, gtk
doesn't to the same, so we could assume this is not behavior we'd
like to support. AltGr is effectively Shift, so not being
considered.
