### PR TITLE
Add an editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build*/
 .*
 !.git*
+!.editorconfig
 .git/
 *.tar.*
 *.kdev4


### PR DESCRIPTION
Add an .editorconfig file to automatically configure common editor properties. Various editors support this out of the box whereas plugins for most other editors exist.

See: https://editorconfig.org/