### PR TITLE
Disallow customization to default/default-dark

### DIFF
--- a/src/ui/classic/classicui.cpp
+++ b/src/ui/classic/classicui.cpp
@@ -274,7 +274,10 @@ const Configuration *ClassicUI::getConfig() const {
     for (const auto &[themeName, _] : themeDirs) {
         auto file = StandardPaths::global().open(
             StandardPathsType::PkgData,
-            std::filesystem::path("themes") / themeName / "theme.conf");
+            std::filesystem::path("themes") / themeName / "theme.conf",
+            Theme::isSystemThemeName(themeName.string())
+                ? StandardPathsMode::System
+                : StandardPathsMode::Default);
         if (file.fd() < 0) {
             continue;
         }
@@ -496,6 +499,10 @@ void ClassicUI::setSubConfig(const std::string &path,
     }
     auto name = path.substr(6);
     if (name.empty()) {
+        return;
+    }
+
+    if (Theme::isSystemThemeName(name)) {
         return;
     }
 

--- a/src/ui/classic/classicui.h
+++ b/src/ui/classic/classicui.h
@@ -85,7 +85,8 @@ struct ThemeAnnotation : public EnumAnnotation {
                                   themes_[i].first);
             config.setValueByPath("EnumI18n/" + std::to_string(i),
                                   themes_[i].second);
-            if (themes_[i].first != PlasmaThemeName || !plasmaTheme_) {
+            if (themes_[i].first != PlasmaThemeName &&
+                !Theme::isSystemThemeName(themes_[i].first)) {
                 config.setValueByPath(
                     "SubConfigPath/" + std::to_string(i),
                     stringutils::concat("fcitx://config/addon/classicui/theme/",

--- a/src/ui/classic/theme.cpp
+++ b/src/ui/classic/theme.cpp
@@ -234,8 +234,6 @@ cairo_surface_t *loadImage(UnixFD &file, const std::filesystem::path &path) {
     return surface;
 }
 
-} // namespace
-
 const std::vector<std::string> &gdkPixbufSupportedFormats() {
     const static std::vector<std::string> formats = []() {
         std::unordered_set<std::string> exts;
@@ -265,6 +263,8 @@ const std::vector<std::string> &gdkPixbufSupportedFormats() {
     return formats;
 }
 
+} // namespace
+
 ThemeImage::ThemeImage(const IconTheme &iconTheme, const std::string &icon,
                        const std::string &label, uint32_t size,
                        const ClassicUI *classicui)
@@ -291,15 +291,16 @@ ThemeImage::ThemeImage(const IconTheme &iconTheme, const std::string &icon,
     }
 }
 
-ThemeImage::ThemeImage(const std::string &name,
-                       const BackgroundImageConfig &cfg, const Color &color,
-                       const Color &borderColor) {
+ThemeImage::ThemeImage(const Theme &theme, const BackgroundImageConfig &cfg,
+                       const Color &color, const Color &borderColor) {
     if (!cfg.image->empty()) {
         std::filesystem::path imagePath;
         auto imageFile = StandardPaths::global().open(
             StandardPathsType::PkgData,
-            std::filesystem::path("themes") / name / *cfg.image,
-            StandardPathsMode::Default, &imagePath);
+            std::filesystem::path("themes") / theme.name() / *cfg.image,
+            theme.isSystemTheme() ? StandardPathsMode::Default
+                                  : StandardPathsMode::User,
+            &imagePath);
         image_.reset(loadImage(imageFile, imagePath));
         if (image_ &&
             cairo_surface_status(image_.get()) != CAIRO_STATUS_SUCCESS) {
@@ -312,8 +313,10 @@ ThemeImage::ThemeImage(const std::string &name,
         std::filesystem::path imagePath;
         auto imageFile = StandardPaths::global().open(
             StandardPathsType::PkgData,
-            std::filesystem::path("themes") / name / *cfg.overlay,
-            StandardPathsMode::Default, &imagePath);
+            std::filesystem::path("themes") / theme.name() / *cfg.overlay,
+            theme.isSystemTheme() ? StandardPathsMode::System
+                                  : StandardPathsMode::Default,
+            &imagePath);
         overlay_.reset(loadImage(imageFile, imagePath));
         if (overlay_ &&
             cairo_surface_status(overlay_.get()) != CAIRO_STATUS_SUCCESS) {
@@ -360,13 +363,15 @@ ThemeImage::ThemeImage(const std::string &name,
     }
 }
 
-ThemeImage::ThemeImage(const std::string &name, const ActionImageConfig &cfg) {
+ThemeImage::ThemeImage(const Theme &theme, const ActionImageConfig &cfg) {
     if (!cfg.image->empty()) {
         std::filesystem::path imagePath;
         auto imageFile = StandardPaths::global().open(
             StandardPathsType::PkgData,
-            std::filesystem::path("themes") / name / *cfg.image,
-            StandardPathsMode::Default, &imagePath);
+            std::filesystem::path("themes") / theme.name() / *cfg.image,
+            theme.isSystemTheme() ? StandardPathsMode::System
+                                  : StandardPathsMode::Default,
+            &imagePath);
         image_.reset(loadImage(imageFile, imagePath));
         if (image_ &&
             cairo_surface_status(image_.get()) != CAIRO_STATUS_SUCCESS) {
@@ -425,6 +430,10 @@ Theme::Theme() : iconTheme_(IconTheme::defaultIconThemeName()) {}
 
 Theme::~Theme() {}
 
+bool Theme::isSystemThemeName(std::string_view themeName) {
+    return themeName == "default" || themeName == "default-dark";
+}
+
 const ThemeImage &Theme::loadBackground(const BackgroundImageConfig &cfg) {
     if (auto *image = findValue(backgroundImageTable_, &cfg)) {
         return *image;
@@ -454,7 +463,7 @@ const ThemeImage &Theme::loadBackground(const BackgroundImageConfig &cfg) {
 
     auto result = backgroundImageTable_.emplace(
         std::piecewise_construct, std::forward_as_tuple(&cfg),
-        std::forward_as_tuple(name_, cfg, color, borderColor));
+        std::forward_as_tuple(*this, cfg, color, borderColor));
     assert(result.second);
     return result.first->second;
 }
@@ -466,7 +475,7 @@ const ThemeImage &Theme::loadAction(const ActionImageConfig &cfg) {
 
     auto result = actionImageTable_.emplace(std::piecewise_construct,
                                             std::forward_as_tuple(&cfg),
-                                            std::forward_as_tuple(name_, cfg));
+                                            std::forward_as_tuple(*this, cfg));
     assert(result.second);
     return result.first->second;
 }
@@ -759,6 +768,7 @@ void Theme::reset() {
 
 void Theme::load(std::string_view name) {
     reset();
+    isSystemTheme_ = isSystemThemeName(name);
     ThemeConfig config;
     copyHelper(config);
     // Reset the default value to state.
@@ -777,15 +787,19 @@ void Theme::load(std::string_view name) {
         copyHelper(config);
     }
     syncDefaultValueToCurrent();
-    if (auto themeConfigFile = StandardPaths::global().open(
-            StandardPathsType::PkgData,
-            std::filesystem::path("themes") / name / "theme.conf",
-            StandardPathsMode::User);
-        themeConfigFile.isValid()) {
-        // Has user file, load user file data.
-        RawConfig themeConfig;
-        readFromIni(themeConfig, themeConfigFile.fd());
-        Configuration::load(themeConfig, true);
+    if (!isSystemTheme_) {
+        // For system theme, we don't load user file, as user file is only for
+        // custom theme.
+        if (auto themeConfigFile = StandardPaths::global().open(
+                StandardPathsType::PkgData,
+                std::filesystem::path("themes") / name / "theme.conf",
+                StandardPathsMode::User);
+            themeConfigFile.isValid()) {
+            // Has user file, load user file data.
+            RawConfig themeConfig;
+            readFromIni(themeConfig, themeConfigFile.fd());
+            Configuration::load(themeConfig, true);
+        }
     }
     name_ = name;
     maskConfig_ = *inputPanel->background;
@@ -797,6 +811,7 @@ void Theme::load(std::string_view name) {
 
 void Theme::load(std::string_view name, const RawConfig &rawConfig) {
     reset();
+    isSystemTheme_ = isSystemThemeName(name);
     Configuration::load(rawConfig, true);
     name_ = name;
 }

--- a/src/ui/classic/theme.h
+++ b/src/ui/classic/theme.h
@@ -227,12 +227,13 @@ FCITX_CONFIGURATION(ThemeConfig,
 
 class ClassicUI;
 class ClassicUIConfig;
+class Theme;
 
 class ThemeImage {
 public:
-    ThemeImage(const std::string &name, const BackgroundImageConfig &cfg,
+    ThemeImage(const Theme &theme, const BackgroundImageConfig &cfg,
                const Color &color, const Color &borderColor);
-    ThemeImage(const std::string &name, const ActionImageConfig &cfg);
+    ThemeImage(const Theme &theme, const ActionImageConfig &cfg);
     ThemeImage(const IconTheme &iconTheme, const std::string &icon,
                const std::string &label, uint32_t size,
                const ClassicUI *classicui);
@@ -290,7 +291,7 @@ public:
     Theme();
     ~Theme();
 
-    const std::string &name() { return name_; }
+    const std::string &name() const { return name_; }
     void load(std::string_view name);
     void load(std::string_view name, const RawConfig &rawConfig);
     const ThemeImage &loadImage(const std::string &icon,
@@ -355,6 +356,10 @@ public:
     const auto &menuText() const { return menuText_; }
     const auto &menuSelectedItemText() const { return menuSelectedItemText_; }
 
+    bool isSystemTheme() const { return isSystemTheme_; }
+
+    static bool isSystemThemeName(std::string_view themeName);
+
 private:
     void reset();
 
@@ -388,6 +393,8 @@ private:
     Color menuSeparator_;
     Color menuText_;
     Color menuSelectedItemText_;
+
+    bool isSystemTheme_ = false;
 };
 
 inline void cairoSetSourceColor(cairo_t *cr, const Color &color) {


### PR DESCRIPTION
We once accidentally break user theme when transition away from the png file.
Seems to be a better idea to keep two default theme usable.
