### PR TITLE
ibusfrontend: populate program name from CreateInputContext args or /proc

### DIFF
--- a/src/frontend/dbusfrontend/dbusfrontend.cpp
+++ b/src/frontend/dbusfrontend/dbusfrontend.cpp
@@ -25,7 +25,6 @@
 #include "fcitx-utils/flags.h"
 #include "fcitx-utils/key.h"
 #include "fcitx-utils/log.h"
-#include "fcitx-utils/misc.h"
 #include "fcitx-utils/misc_p.h"
 #include "fcitx-utils/rect.h"
 #include "fcitx/addonfactory.h"
@@ -124,9 +123,8 @@ class DBusInputContext1 : public InputContext,
 public:
     DBusInputContext1(int id, InputContextManager &icManager, InputMethod1 *im,
                       const std::string &sender,
-                      const std::unordered_map<std::string, std::string> &args,
-                      std::string programName = {})
-        : InputContext(icManager, std::move(programName)),
+                      const std::unordered_map<std::string, std::string> &args)
+        : InputContext(icManager, getArgument(args, "program")),
           path_("/org/freedesktop/portal/inputcontext/" + std::to_string(id)),
           im_(im), handler_(im_->serviceWatcher().watchService(
                        sender,
@@ -536,101 +534,14 @@ InputMethod1::createInputContext(
     }
 
     auto sender = currentMessage()->sender();
-    auto icIdx = module_->nextIcIdx();
+    auto *ic = new DBusInputContext1(module_->nextIcIdx(),
+                                     instance_->inputContextManager(), this,
+                                     sender, strMap);
 
-    // Look up the sender's PID asynchronously so we can use getProcessName()
-    // to populate the program name.  The client-provided "program" argument
-    // is intentionally ignored: some toolkits (e.g. Qt) hard-code it to a
-    // fixed string.  getProcessName() handles platforms without /proc via
-    // libkvm.  In Flatpak environments the PID belongs to xdg-dbus-proxy, but
-    // each sandboxed app has its own proxy so grouping still works correctly.
-    auto getPidMsg = bus_->createMethodCall(
-        "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
-        "GetConnectionUnixProcessID");
-    if (!getPidMsg) {
-        auto *ic = new DBusInputContext1(
-            icIdx, instance_->inputContextManager(), this, sender, strMap);
-        bus_->addObjectVTable(ic->path().path(),
-                              FCITX_INPUTCONTEXT_DBUS_INTERFACE, *ic);
-        return std::make_tuple(
-            ic->path(),
-            std::vector<uint8_t>(ic->uuid().begin(), ic->uuid().end()));
-    }
-    getPidMsg << sender;
-
-    struct AsyncState {
-        TrackableObjectReference<dbus::ObjectVTableBase> imWatcher;
-        std::string sender;
-        std::unordered_map<std::string, std::string> strMap;
-        int icIdx;
-        std::shared_ptr<std::unique_ptr<dbus::Slot>> slotHolder;
-        std::shared_ptr<dbus::Message> originalMsg;
-    };
-    auto state = std::make_shared<AsyncState>();
-    state->imWatcher = this->watch();
-    state->sender = std::move(sender);
-    state->strMap = std::move(strMap);
-    state->icIdx = icIdx;
-    state->slotHolder = std::make_shared<std::unique_ptr<dbus::Slot>>();
-
-    auto getPidMsgHolder =
-        std::make_shared<dbus::Message>(std::move(getPidMsg));
-
-    throw dbus::MethodCallDefer([state,
-                                 getPidMsgHolder](dbus::Message originalMsg) {
-        state->originalMsg =
-            std::make_shared<dbus::Message>(std::move(originalMsg));
-
-        *state->slotHolder = getPidMsgHolder->callAsync(
-            0, [state](dbus::Message &reply) -> bool {
-                auto slot = std::move(*state->slotHolder);
-
-                if (!state->imWatcher.isValid()) {
-                    return false;
-                }
-                auto *im = static_cast<InputMethod1 *>(state->imWatcher.get());
-
-                pid_t pid = 0;
-                if (!reply.isError()) {
-                    reply >> pid;
-                }
-
-                std::string programName;
-                if (pid > 0) {
-                    programName = getProcessName(pid);
-                }
-
-                auto *ic = new DBusInputContext1(
-                    state->icIdx, im->instance_->inputContextManager(), im,
-                    state->sender, state->strMap, std::move(programName));
-                im->bus_->addObjectVTable(
-                    ic->path().path(), FCITX_INPUTCONTEXT_DBUS_INTERFACE, *ic);
-
-                auto response = state->originalMsg->createReply();
-                response << ic->path()
-                         << std::vector<uint8_t>(ic->uuid().begin(),
-                                                 ic->uuid().end());
-                response.send();
-                return true;
-            });
-
-        if (!*state->slotHolder) {
-            if (!state->imWatcher.isValid()) {
-                return;
-            }
-            auto *im = static_cast<InputMethod1 *>(state->imWatcher.get());
-            auto *ic = new DBusInputContext1(
-                state->icIdx, im->instance_->inputContextManager(), im,
-                state->sender, state->strMap);
-            im->bus_->addObjectVTable(ic->path().path(),
-                                      FCITX_INPUTCONTEXT_DBUS_INTERFACE, *ic);
-            auto response = state->originalMsg->createReply();
-            response << ic->path()
-                     << std::vector<uint8_t>(ic->uuid().begin(),
-                                             ic->uuid().end());
-            response.send();
-        }
-    });
+    bus_->addObjectVTable(ic->path().path(), FCITX_INPUTCONTEXT_DBUS_INTERFACE,
+                          *ic);
+    return std::make_tuple(
+        ic->path(), std::vector<uint8_t>(ic->uuid().begin(), ic->uuid().end()));
 }
 
 std::tuple<std::vector<DBusBlockedEvent>, bool>

--- a/src/frontend/ibusfrontend/ibusfrontend.cpp
+++ b/src/frontend/ibusfrontend/ibusfrontend.cpp
@@ -49,6 +49,7 @@
 #include "fcitx-utils/standardpaths.h"
 #include "fcitx-utils/stringutils.h"
 #include "fcitx-utils/textformatflags.h"
+#include "fcitx-utils/trackableobject.h"
 #include "fcitx-utils/unixfd.h"
 #include "fcitx-utils/utf8.h"
 #include "fcitx-utils/uuid_p.h"
@@ -314,7 +315,7 @@ private:
 
     IBusFrontendModule *module_;
     Instance *instance_;
-    int icIdx = 0;
+    int icIdx_ = 0;
     dbus::Bus *bus_;
     std::unique_ptr<dbus::ServiceWatcher> watcher_;
 };
@@ -724,86 +725,46 @@ void IBusService::destroyDBus() {
 }
 
 dbus::ObjectPath
-IBusFrontend::createInputContext(const std::string & /*args*/) {
+IBusFrontend::createInputContext(const std::string & /* unused */) {
+    auto slotHolder = std::make_shared<std::unique_ptr<dbus::Slot>>();
     auto sender = currentMessage()->sender();
+    auto pendingReply =
+        std::make_shared<dbus::Message>(currentMessage()->createReply());
 
-    auto getPidMsg = bus_->createMethodCall(
+    auto msg = bus()->createMethodCall(
         "org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus",
         "GetConnectionUnixProcessID");
-    if (!getPidMsg) {
-        auto *ic = new IBusInputContext(
-            icIdx++, instance_->inputContextManager(), this, sender, "");
-        ic->setFocusGroup(instance_->defaultFocusGroup());
-        return ic->path();
-    }
-    getPidMsg << sender;
 
-    struct AsyncState {
-        TrackableObjectReference<dbus::ObjectVTableBase> imWatcher;
-        std::string sender;
-        int icIdx;
-        std::shared_ptr<std::unique_ptr<dbus::Slot>> slotHolder;
-        std::shared_ptr<dbus::Message> originalMsg;
-    };
-    auto state = std::make_shared<AsyncState>();
-    state->imWatcher = this->watch();
-    state->sender = std::move(sender);
-    state->icIdx = icIdx++;
-    state->slotHolder = std::make_shared<std::unique_ptr<dbus::Slot>>();
-
-    auto getPidMsgHolder =
-        std::make_shared<dbus::Message>(std::move(getPidMsg));
-
-    throw dbus::MethodCallDefer([state,
-                                 getPidMsgHolder](dbus::Message originalMsg) {
-        state->originalMsg =
-            std::make_shared<dbus::Message>(std::move(originalMsg));
-
-        *state->slotHolder = getPidMsgHolder->callAsync(
-            0, [state](dbus::Message &reply) -> bool {
-                auto slot = std::move(*state->slotHolder);
-
-                if (!state->imWatcher.isValid()) {
-                    return false;
-                }
-                auto *im = static_cast<IBusFrontend *>(state->imWatcher.get());
-
-                pid_t pid = 0;
-                if (!reply.isError()) {
-                    reply >> pid;
-                }
-
-                std::string programName;
-                if (pid > 0) {
-                    programName = getProcessName(pid);
-                }
-
-                auto *ic = new IBusInputContext(
-                    state->icIdx, im->instance()->inputContextManager(), im,
-                    state->sender, std::move(programName));
-                ic->setFocusGroup(im->instance()->defaultFocusGroup());
-
-                auto response = state->originalMsg->createReply();
-                response << ic->path();
-                response.send();
-                return true;
-            });
-
-        if (!*state->slotHolder) {
-            if (!state->imWatcher.isValid()) {
-                return;
-            }
-            auto *im = static_cast<IBusFrontend *>(state->imWatcher.get());
-            auto *ic = new IBusInputContext(
-                state->icIdx, im->instance()->inputContextManager(), im,
-                state->sender, "");
-            ic->setFocusGroup(im->instance()->defaultFocusGroup());
-
-            auto response = state->originalMsg->createReply();
-            response << ic->path();
-            response.send();
+    msg << sender;
+    *slotHolder = msg.callAsync(1000000, [this, watcher = this->watch(), sender,
+                                          pendingReply,
+                                          slotHolder](dbus::Message &pidReply) {
+        if (!*slotHolder) {
+            return true;
         }
+
+        // Check if ibus frontend is still alive.
+        if (watcher.isValid()) {
+            uint32_t pid = 0;
+            if (pidReply.type() == dbus::MessageType::Reply &&
+                pidReply.signature() == "u") {
+                pidReply >> pid;
+            }
+            FCITX_IBUS_DEBUG() << "Pid of sender " << sender << " is " << pid;
+
+            auto *ic = new IBusInputContext(
+                icIdx_++, instance_->inputContextManager(), this, sender,
+                (pid ? getProcessName(pid) : ""));
+            ic->setFocusGroup(instance_->defaultFocusGroup());
+            *pendingReply << ic->path();
+            pendingReply->send();
+        }
+        // Make sure the slot is free'd after return.
+        slotHolder->reset();
+        return true;
     });
+
+    throw dbus::MethodCallNoReply{};
 }
 
 IBusFrontendModule::IBusFrontendModule(Instance *instance)

--- a/src/lib/fcitx-utils/dbus/objectvtable.cpp
+++ b/src/lib/fcitx-utils/dbus/objectvtable.cpp
@@ -14,6 +14,8 @@
 
 namespace fcitx::dbus {
 
+MethodCallNoReply::MethodCallNoReply() = default;
+
 ObjectVTableMethod::ObjectVTableMethod(ObjectVTableBase *vtable,
                                        const std::string &name,
                                        const std::string &signature,

--- a/src/lib/fcitx-utils/dbus/objectvtable.h
+++ b/src/lib/fcitx-utils/dbus/objectvtable.h
@@ -64,33 +64,16 @@ private:
 };
 
 /**
- * An exception to defer the D-Bus method call reply.
+ * An exception to not reply a the D-Bus method call.
  *
- * Throw this exception from a registered method handler to defer the reply.
- * The provided callback will be called with the original D-Bus message and is
- * responsible for eventually sending the reply (e.g. after an async operation
- * completes).
- *
- * E.g.
- * @code
- * throw dbus::MethodCallDefer([](Message msg) {
- *     // ... set up async operation, send reply from its callback ...
- * });
- * @endcode
+ * This can be useful if there is a cascade of method calls and you want to
+ * reply later.
  */
-class FCITXUTILS_EXPORT MethodCallDefer : public std::exception {
+class FCITXUTILS_EXPORT MethodCallNoReply : public std::exception {
 public:
-    using DeferCallback = std::function<void(Message)>;
+    explicit MethodCallNoReply();
 
-    explicit MethodCallDefer(DeferCallback callback)
-        : callback_(std::move(callback)) {}
-
-    const char *what() const noexcept override { return "MethodCallDefer"; }
-
-    DeferCallback &callback() { return callback_; }
-
-private:
-    DeferCallback callback_;
+    const char *what() const noexcept override { return "MethodCallNoReply"; }
 };
 
 class ObjectVTableMethodPrivate;
@@ -449,19 +432,11 @@ public:
             auto reply = msg.createReply();
             reply << helper.ret;
             reply.send();
-        } catch (const ::fcitx::dbus::MethodCallError &error) {
+        } catch (const MethodCallError &error) {
             auto reply = msg.createError(error.name(), error.what());
             reply.send();
-        } catch (::fcitx::dbus::MethodCallDefer &defer) {
-            // Clear current message before passing it to the deferred callback.
-            if (watcher.isValid()) {
-                watcher.get()->setCurrentMessage(nullptr);
-            }
-            auto &cb = defer.callback();
-            if (cb) {
-                cb(std::move(msg));
-            }
-            return true;
+        } catch (
+            const MethodCallNoReply &noReply) { // NOLINT(bugprone-empty-catch)
         }
         if (watcher.isValid()) {
             watcher.get()->setCurrentMessage(nullptr);

--- a/test/testdbus.cpp
+++ b/test/testdbus.cpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <thread>
 #include <tuple>
+#include <utility>
 #include <vector>
 #include "fcitx-utils/dbus/bus.h"
 #include "fcitx-utils/dbus/matchrule.h"
@@ -22,6 +23,8 @@
 
 using namespace fcitx::dbus;
 using namespace fcitx;
+
+namespace {
 
 class TestObject : public ObjectVTable<TestObject> {
     void test1() {}
@@ -302,58 +305,40 @@ void test_delete() {
     loop.exec();
 }
 
-// Test MethodCallDefer: method defers its reply until an async call completes.
-class DeferTestObject : public ObjectVTable<DeferTestObject> {
-    std::string testDefer(const std::string &input) {
-        auto slotHolder = std::make_shared<std::unique_ptr<Slot>>();
-        auto *bus = this->bus();
-
-        throw MethodCallDefer([input, slotHolder, bus](Message originalMsg) {
-            auto callMsg = bus->createMethodCall(
-                "org.freedesktop.DBus", "/non/existing",
-                "org.freedesktop.DBus.Introspectable", "Introspect");
-
-            *slotHolder = callMsg.callAsync(
-                0,
-                [input, slotHolder,
-                 originalMsg = std::make_shared<Message>(std::move(
-                     originalMsg))](Message & /*unused*/) mutable -> bool {
-                    auto slot = std::move(*slotHolder);
-                    auto reply = originalMsg->createReply();
-                    reply << ("deferred:" + input);
-                    reply.send();
-                    return true;
-                });
-        });
-    }
-
-private:
-    FCITX_OBJECT_VTABLE_METHOD(testDefer, "testDefer", "s", "s");
-};
-
 #define DEFER_TEST_SERVICE "org.fcitx.Fcitx.TestDBusDefer"
 #define DEFER_TEST_INTERFACE "org.fcitx.Fcitx.TestDBusDefer.Interface"
 
-void test_defer_client() {
-    Bus clientBus(BusType::Session);
-    EventLoop loop;
-    clientBus.attachEventLoop(&loop);
+// Test MethodCallDefer: method defers its reply until an async call completes.
+class DeferTestObject : public ObjectVTable<DeferTestObject> {
+    std::string testDefer() {
+        auto slotHolder = std::make_shared<std::unique_ptr<Slot>>();
+        auto *bus = this->bus();
 
-    auto msg = clientBus.createMethodCall(DEFER_TEST_SERVICE, "/defertest",
-                                          DEFER_TEST_INTERFACE, "testDefer");
-    msg << std::string("hello");
-    // Use a generous timeout: the server must do an async call first.
-    auto slot = msg.callAsync(5000000, [&loop](Message &reply) {
-        FCITX_ASSERT(reply.type() == MessageType::Reply) << reply.errorName();
-        std::string ret;
-        reply >> ret;
-        FCITX_INFO() << "testDefer reply: " << ret;
-        FCITX_ASSERT(ret == "deferred:hello") << ret;
-        loop.exit();
-        return true;
-    });
-    loop.exec();
-}
+        auto msg = bus->createMethodCall(DEFER_TEST_SERVICE, "/defertest",
+                                         DEFER_TEST_INTERFACE, "justReturn");
+        auto reply = std::make_shared<Message>(currentMessage()->createReply());
+        *slotHolder = msg.callAsync(0,
+                                    [reply = std::move(reply),
+                                     slotHolder](Message &msg) mutable -> bool {
+                                        FCITX_ASSERT(*slotHolder);
+                                        FCITX_ASSERT(!msg.isError());
+                                        std::string returnValue;
+                                        msg >> returnValue;
+                                        *reply << returnValue;
+                                        reply->send();
+                                        slotHolder->reset();
+                                        return true;
+                                    });
+
+        throw MethodCallNoReply();
+    }
+
+    std::string justReturn() { return "justReturn"; }
+
+private:
+    FCITX_OBJECT_VTABLE_METHOD(testDefer, "testDefer", "", "s");
+    FCITX_OBJECT_VTABLE_METHOD(justReturn, "justReturn", "", "s");
+};
 
 void test_defer() {
     Bus bus(BusType::Session);
@@ -366,18 +351,21 @@ void test_defer() {
     DeferTestObject obj;
     FCITX_ASSERT(bus.addObjectVTable("/defertest", DEFER_TEST_INTERFACE, obj));
 
-    std::unique_ptr<EventSourceTime> s(
-        loop.addTimeEvent(CLOCK_MONOTONIC, now(CLOCK_MONOTONIC) + 2000000, 0,
-                          [&loop](EventSource *, uint64_t) {
-                              loop.exit();
-                              return false;
-                          }));
-
-    std::thread thread(test_defer_client);
-
+    auto msg = bus.createMethodCall(DEFER_TEST_SERVICE, "/defertest",
+                                    DEFER_TEST_INTERFACE, "testDefer");
+    // Use a generous timeout: the server must do an async call first.
+    auto slot = msg.callAsync(5000000, [&loop](Message &reply) {
+        FCITX_ASSERT(!reply.isError()) << reply.errorName();
+        std::string ret;
+        reply >> ret;
+        FCITX_ASSERT(ret == "justReturn") << ret;
+        loop.exit();
+        return true;
+    });
     loop.exec();
-    thread.join();
 }
+
+} // namespace
 
 int main() {
     test_client();


### PR DESCRIPTION
The IBus protocol's CreateInputContext method accepts a string argument that is intended to carry the client application name (e.g. "firefox", "wezterm", "code").  However the argument was silently ignored and the InputContext was always created with an empty program name.

This prevents input-method engines from implementing per-application behaviour such as persisting the last-used input mode.

Fix by using the argument directly when non-empty.  As a fallback for clients that pass an empty string (several Qt/Electron applications), query the caller's PID via D-Bus GetConnectionUnixProcessID and read the process name from /proc/<pid>/comm.