### PR TITLE
feat: notify missing input methods on startup

### DIFF
--- a/src/lib/fcitx/inputmethodmanager.cpp
+++ b/src/lib/fcitx/inputmethodmanager.cpp
@@ -69,6 +69,7 @@ public:
     Instance *instance_ = nullptr;
     std::unique_ptr<HandlerTableEntry<EventHandler>> eventWatcher_;
     int64_t timestamp_ = 0;
+    std::vector<std::string> missingInputMethods_;
 };
 
 bool checkEntry(const InputMethodEntry &entry,
@@ -111,6 +112,7 @@ void InputMethodManagerPrivate::loadConfig(
                     FCITX_WARN() << "Group Item " << item.name.value()
                                  << " in group " << groupConfig.name.value()
                                  << " is not valid. Removed.";
+                    missingInputMethods_.push_back(item.name.value());
                     continue;
                 }
                 group.inputMethodList().emplace_back(
@@ -236,6 +238,7 @@ void InputMethodManager::load(const std::function<void(InputMethodManager &)>
     d->loadStaticEntries(addonNames);
     d->loadDynamicEntries(addonNames);
 
+    d->missingInputMethods_.clear();
     d->loadConfig(buildDefaultGroupCallback);
     // groupOrder guarantee to be non-empty at this point.
     emit<InputMethodManager::CurrentGroupChanged>(d->groupOrder_.front());
@@ -455,6 +458,12 @@ InputMethodManager::entry(const std::string &name) const {
     FCITX_D();
     return findValue(d->entries_, name);
 }
+
+const std::vector<std::string> &InputMethodManager::missingInputMethods() const {
+    FCITX_D();
+    return d->missingInputMethods_;
+}
+
 bool InputMethodManager::foreachEntries(
     const std::function<bool(const InputMethodEntry &entry)> &callback) {
     FCITX_D();

--- a/src/lib/fcitx/inputmethodmanager.cpp
+++ b/src/lib/fcitx/inputmethodmanager.cpp
@@ -459,7 +459,8 @@ InputMethodManager::entry(const std::string &name) const {
     return findValue(d->entries_, name);
 }
 
-const std::vector<std::string> &InputMethodManager::missingInputMethods() const {
+const std::vector<std::string> &
+InputMethodManager::missingInputMethods() const {
     FCITX_D();
     return d->missingInputMethods_;
 }

--- a/src/lib/fcitx/inputmethodmanager.h
+++ b/src/lib/fcitx/inputmethodmanager.h
@@ -135,6 +135,13 @@ public:
     const InputMethodEntry *entry(const std::string &name) const;
 
     /**
+     * Return the names of input methods that are configured but not available.
+     *
+     * @since 5.1.13
+     */
+    const std::vector<std::string> &missingInputMethods() const;
+
+    /**
      * Enumerate all the input method entries.
      *
      * @return return true if the enumeration is done without interruption.

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1471,6 +1471,19 @@ void Instance::initialize() {
         return false;
     });
     d->notifications_ = d->addonManager_.addon("notifications", true);
+    if (d->notifications_ && !d->imManager_.missingInputMethods().empty()) {
+        std::string body;
+        for (const auto &im : d->imManager_.missingInputMethods()) {
+            if (!body.empty()) {
+                body += ", ";
+            }
+            body += im;
+        }
+        d->notifications_->call<INotifications::sendNotification>(
+            "fcitx", 0, "fcitx", _("Missing input methods"),
+            _("The following input methods are not available: {0}"),
+            std::vector<std::string>{body}, 0, nullptr, nullptr);
+    }
 }
 
 int Instance::exec() {


### PR DESCRIPTION
This PR implements a startup check to notify users if a previously configured input method is no longer available (e.g., after uninstalling an addon).

Fixes #516

### Proposed Changes

#### Core Library
1.  **InputMethodManager**:
    *   Tracks missing input method names during configuration loading.
    *   Provides a getter `missingInputMethods()` to retrieve this list.
2.  **Instance**:
    *   Checks for missing input methods during initialization.
    *   Triggers a system notification via the `notifications` addon if any are found.