### PR TITLE
chore: unify and improve configuration strings (#1383)

### DIFF
--- a/src/im/keyboard/keyboard.h
+++ b/src/im/keyboard/keyboard.h
@@ -47,8 +47,8 @@ FCITX_CONFIG_ENUM_NAME_WITH_I18N(ChooseModifier, N_("None"), N_("Alt"),
 
 FCITX_CONFIGURATION(
     KeyboardEngineConfig,
-    Option<int, IntConstrain> pageSize{this, "PageSize", _("Page size"), 5,
-                                       IntConstrain(3, 10)};
+    Option<int, IntConstrain> pageSize{
+        this, "PageSize", _("Candidates per page"), 5, IntConstrain(3, 10)};
     KeyListOption prevCandidate{
         this,
         "PrevCandidate",

--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -176,8 +176,9 @@ FCITX_CONFIGURATION(
                   "the timeout. -1 means there is no limit.")}};);
 
 FCITX_CONFIGURATION(
-    BehaviorConfig, Option<bool> activeByDefault{this, "ActiveByDefault",
-                                                 _("Active By Default")};
+    BehaviorConfig,
+    Option<bool> activeByDefault{this, "ActiveByDefault",
+                                 _("Activate input method by default")};
     OptionWithAnnotation<PropertyPropagatePolicy,
                          PropertyPropagatePolicyI18NAnnotation>
         resetStateWhenFocusIn{this, "resetStateWhenFocusIn",
@@ -204,7 +205,7 @@ FCITX_CONFIGURATION(
         this, "ShowFirstInputMethodInformation",
         _("Show first input method information"), true};
     Option<int, IntConstrain> defaultPageSize{this, "DefaultPageSize",
-                                              _("Default page size"), 5,
+                                              _("Candidates per page"), 5,
                                               IntConstrain(1, 10)};
     ConditionalHidden<!hasKeyboard,
                       OptionWithAnnotation<bool, ToolTipAnnotation>>
@@ -215,7 +216,7 @@ FCITX_CONFIGURATION(
             false,
             {},
             {},
-            {_("Whether to override the XKB option from display server. It "
+            {_("Override the XKB option from display server. It "
                "will not affect the XKB option send to display, but just the "
                "XKB options for custom XKB layout. This is a workaround when "
                "there is no way to get the current XKB option from Wayland "

--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -205,7 +205,7 @@ FCITX_CONFIGURATION(
         this, "ShowFirstInputMethodInformation",
         _("Show first input method information"), true};
     Option<int, IntConstrain> defaultPageSize{this, "DefaultPageSize",
-                                              _("Candidates per page"), 5,
+                                              _("Default Candidates per page"), 5,
                                               IntConstrain(1, 10)};
     ConditionalHidden<!hasKeyboard,
                       OptionWithAnnotation<bool, ToolTipAnnotation>>

--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -205,8 +205,8 @@ FCITX_CONFIGURATION(
         this, "ShowFirstInputMethodInformation",
         _("Show first input method information"), true};
     Option<int, IntConstrain> defaultPageSize{this, "DefaultPageSize",
-                                              _("Default Candidates per page"), 5,
-                                              IntConstrain(1, 10)};
+                                              _("Default Candidates per page"),
+                                              5, IntConstrain(1, 10)};
     ConditionalHidden<!hasKeyboard,
                       OptionWithAnnotation<bool, ToolTipAnnotation>>
         overrideXkbOption{

--- a/src/modules/wayland/waylandmodule.cpp
+++ b/src/modules/wayland/waylandmodule.cpp
@@ -678,7 +678,7 @@ void WaylandModule::selfDiagnose() {
                 _("Fcitx should be launched by KWin under KDE Wayland in order "
                   "to use Wayland input method frontend. This can improve the "
                   "experience when using Fcitx on Wayland. To "
-                  "configure this, you need to go to \"System Settings\" -> "
+                  "configure this, you need to go to \"System Settings\" > "
                   "\"Virtual "
                   "keyboard\" and select \"Fcitx 5\" from it. You may also "
                   "need to disable tools that launches input method, such as "


### PR DESCRIPTION
This PR addresses remaining string inconsistencies in the Fcitx5 core and keyboard engine as identified in issue #1383.

### Changes:
- **Unified Terminology:** Changed "page size" to "Candidates per page" in `globalconfig.cpp` and `keyboard.h`.
- **Description Cleanup:** Removed "Whether" from boolean option tooltips in `globalconfig.cpp` for a more direct tone.
- **Clarity Improvement:** Clarified "Active By Default" to "Activate input method by default".
- **UI Symbol Fix:** Replaced `->` with `>` in the Wayland diagnosis message in `waylandmodule.cpp`.

These updates ensure a more consistent and professional UI experience across the Fcitx5 ecosystem.