### PR TITLE
Guard against possible empty description

### DIFF
--- a/src/im/keyboard/keyboard.cpp
+++ b/src/im/keyboard/keyboard.cpp
@@ -258,28 +258,32 @@ std::vector<InputMethodEntry> KeyboardEngine::listInputMethods() {
         const auto &layoutInfo = p.second;
         auto language = findBestLanguage(isoCodes, layoutInfo.description,
                                          layoutInfo.languages);
-        auto description =
-            _("Keyboard - {0}", D_("xkeyboard-config", layoutInfo.description));
+        auto description = !layoutInfo.description.empty()
+                               ? D_("xkeyboard-config", layoutInfo.description)
+                               : layoutInfo.name;
+        auto name = _("Keyboard - {0}", description);
         auto uniqueName = imNamePrefix + layoutInfo.name;
         if (uniqueName == "keyboard-us") {
             usExists = true;
         }
-        result.push_back(std::move(
-            InputMethodEntry(uniqueName, description, language, "keyboard")
-                .setLabel(layoutInfo.shortDescription.empty()
-                              ? layoutInfo.name
-                              : layoutInfo.shortDescription)
-                .setIcon("input-keyboard")
-                .setConfigurable(true)));
+        result.push_back(
+            std::move(InputMethodEntry(uniqueName, name, language, "keyboard")
+                          .setLabel(layoutInfo.shortDescription.empty()
+                                        ? layoutInfo.name
+                                        : layoutInfo.shortDescription)
+                          .setIcon("input-keyboard")
+                          .setConfigurable(true)));
         for (const auto &variantInfo : layoutInfo.variantInfos) {
             auto language = findBestLanguage(isoCodes, variantInfo.description,
                                              !variantInfo.languages.empty()
                                                  ? variantInfo.languages
                                                  : layoutInfo.languages);
-            auto description =
-                _("Keyboard - {0} - {1}",
-                  D_("xkeyboard-config", layoutInfo.description),
-                  D_("xkeyboard-config", variantInfo.description));
+            auto variantDescription =
+                !variantInfo.description.empty()
+                    ? D_("xkeyboard-config", variantInfo.description)
+                    : variantInfo.name;
+            auto name =
+                _("Keyboard - {0} - {1}", description, variantDescription);
             auto uniqueName = stringutils::concat(imNamePrefix, layoutInfo.name,
                                                   "-", variantInfo.name);
 
@@ -295,7 +299,7 @@ std::vector<InputMethodEntry> KeyboardEngine::listInputMethods() {
                     std::format("{0} ({1})", variantLabel, variantInfo.name);
             }
             result.push_back(std::move(
-                InputMethodEntry(uniqueName, description, language, "keyboard")
+                InputMethodEntry(uniqueName, name, language, "keyboard")
                     .setLabel(variantLabel)
                     .setIcon("input-keyboard")
                     .setConfigurable(true)));

--- a/src/im/keyboard/xkbrules.cpp
+++ b/src/im/keyboard/xkbrules.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <ranges>
 #include "fcitx-utils/stringutils.h"
 #include "xmlparser.h"
 
@@ -142,6 +143,12 @@ struct XkbRulesParseState : public XMLParser {
                 std::string name = info.name;
                 rules->layoutInfos_.emplace(std::move(name), std::move(info));
             } else {
+                if (iter->second.description.empty()) {
+                    iter->second.description = info.description;
+                }
+                if (iter->second.shortDescription.empty()) {
+                    iter->second.shortDescription = info.shortDescription;
+                }
                 iter->second.languages.insert(
                     iter->second.languages.end(),
                     std::make_move_iterator(info.languages.begin()),
@@ -160,7 +167,7 @@ bool XkbRules::read(const std::vector<std::filesystem::path> &directories,
     clear();
 
     bool success = false;
-    for (const auto &directory : directories) {
+    for (const auto &directory : directories | std::views::reverse) {
         const auto fileName = directory / "rules" / (name + ".xml");
 
         {

--- a/src/modules/dbus/dbusmodule.cpp
+++ b/src/modules/dbus/dbusmodule.cpp
@@ -298,7 +298,9 @@ public:
                 result.emplace_back();
                 auto &layoutItem = result.back();
                 std::get<0>(layoutItem) = layout;
-                std::get<1>(layoutItem) = D_("xkeyboard-config", description);
+                std::get<1>(layoutItem) =
+                    !description.empty() ? D_("xkeyboard-config", description)
+                                         : layout;
                 std::get<2>(layoutItem) = languages;
                 auto &variants = std::get<3>(layoutItem);
                 module_->keyboard()->call<IKeyboardEngine::foreachVariant>(
@@ -310,7 +312,9 @@ public:
                         auto &variantItem = variants.back();
                         std::get<0>(variantItem) = variant;
                         std::get<1>(variantItem) =
-                            D_("xkeyboard-config", description);
+                            !description.empty()
+                                ? D_("xkeyboard-config", description)
+                                : variant;
                         std::get<2>(variantItem) = languages;
                         return true;
                     });


### PR DESCRIPTION
1. reverse the order, load system layout before user.
2. fill description if it was empty when merge rules
3. if still empty, use layout or variant name instead of call gettext on
   empty string.

Fix #1543
