### PR TITLE
Add TabbedCandidateList interface

### DIFF
--- a/src/lib/fcitx/candidatelist.cpp
+++ b/src/lib/fcitx/candidatelist.cpp
@@ -88,6 +88,8 @@ public:
 
 ActionableCandidateList::~ActionableCandidateList() = default;
 
+TabbedCandidateList::~TabbedCandidateList() = default;
+
 class CandidateListPrivate {
 public:
     BulkCandidateList *bulk_ = nullptr;
@@ -97,6 +99,7 @@ public:
     BulkCursorCandidateList *bulkCursor_ = nullptr;
     CursorModifiableCandidateList *cursorModifiable_ = nullptr;
     ActionableCandidateList *actionable_ = nullptr;
+    TabbedCandidateList *tabbed_ = nullptr;
 };
 
 CandidateList::CandidateList()
@@ -141,6 +144,11 @@ ActionableCandidateList *CandidateList::toActionable() const {
     return d->actionable_;
 }
 
+TabbedCandidateList *CandidateList::toTabbed() const {
+    FCITX_D();
+    return d->tabbed_;
+}
+
 void CandidateList::setBulk(BulkCandidateList *list) {
     FCITX_D();
     d->bulk_ = list;
@@ -174,6 +182,11 @@ void CandidateList::setBulkCursor(BulkCursorCandidateList *list) {
 void CandidateList::setActionable(ActionableCandidateList *list) {
     FCITX_D();
     d->actionable_ = list;
+}
+
+void CandidateList::setTabbed(TabbedCandidateList *list) {
+    FCITX_D();
+    d->tabbed_ = list;
 }
 
 class CandidateWordPrivate {
@@ -364,6 +377,8 @@ public:
     CursorPositionAfterPaging cursorPositionAfterPaging_ =
         CursorPositionAfterPaging::DonotChange;
     std::unique_ptr<ActionableCandidateList> actionable_;
+
+    std::unique_ptr<TabbedCandidateList> tabbed_;
 
     int size() const {
         auto start = currentPage_ * pageSize_;
@@ -761,6 +776,13 @@ void CommonCandidateList::setActionableImpl(
     FCITX_D();
     d->actionable_ = std::move(actionable);
     setActionable(d->actionable_.get());
+}
+
+void CommonCandidateList::setTabbedImpl(
+    std::unique_ptr<TabbedCandidateList> tabbed) {
+    FCITX_D();
+    d->tabbed_ = std::move(tabbed);
+    setTabbed(d->tabbed_.get());
 }
 
 } // namespace fcitx

--- a/src/lib/fcitx/candidatelist.h
+++ b/src/lib/fcitx/candidatelist.h
@@ -27,6 +27,7 @@ class CursorMovableCandidateList;
 class CursorModifiableCandidateList;
 class BulkCursorCandidateList;
 class ActionableCandidateList;
+class TabbedCandidateList;
 
 class CandidateListPrivate;
 
@@ -122,6 +123,14 @@ public:
     BulkCursorCandidateList *toBulkCursor() const;
     ActionableCandidateList *toActionable() const;
 
+    /**
+     * Cast to TabbedCandidateList if available.
+     *
+     * @return TabbedCandidateList pointer or nullptr.
+     * @since 5.1.20
+     */
+    TabbedCandidateList *toTabbed() const;
+
 protected:
     void setPageable(PageableCandidateList *list);
     void setBulk(BulkCandidateList *list);
@@ -130,6 +139,14 @@ protected:
     void setCursorModifiable(CursorModifiableCandidateList *list);
     void setBulkCursor(BulkCursorCandidateList *list);
     void setActionable(ActionableCandidateList *list);
+
+    /**
+     * Set the TabbedCandidateList implementation.
+     *
+     * @param list pointer to TabbedCandidateList.
+     * @since 5.1.20
+     */
+    void setTabbed(TabbedCandidateList *list);
 
 private:
     std::unique_ptr<CandidateListPrivate> d_ptr;
@@ -244,6 +261,32 @@ public:
      * Trigger the action based on the index returned from candidateActions.
      */
     virtual void triggerAction(const CandidateWord &candidate, int id) = 0;
+};
+
+/**
+ * Interface for tab-related actions on candidate list.
+ *
+ * @since 5.1.20
+ */
+class FCITXCORE_EXPORT TabbedCandidateList {
+public:
+    virtual ~TabbedCandidateList();
+
+    /**
+     * Return a list of tab actions.
+     *
+     * @return vector of CandidateAction.
+     * @since 5.1.20
+     */
+    virtual std::vector<CandidateAction> tabActions() const = 0;
+
+    /**
+     * Trigger the tab action based on the index returned from tabActions.
+     *
+     * @param id action index.
+     * @since 5.1.20
+     */
+    virtual void triggerTabAction(int id) = 0;
 };
 
 class DisplayOnlyCandidateListPrivate;
@@ -373,6 +416,14 @@ public:
      * @since 5.1.10
      */
     void setActionableImpl(std::unique_ptr<ActionableCandidateList> actionable);
+
+    /**
+     * Set an optional implementation of tabbed candidate list.
+     *
+     * @param tabbed pointer to TabbedCandidateList.
+     * @since 5.1.20
+     */
+    void setTabbedImpl(std::unique_ptr<TabbedCandidateList> tabbed);
 
 private:
     void fixAfterUpdate();

--- a/test/testcandidatelist.cpp
+++ b/test/testcandidatelist.cpp
@@ -5,10 +5,13 @@
  *
  */
 
+#include <memory>
 #include <stdexcept>
 #include "fcitx-utils/log.h"
 #include "fcitx/candidateaction.h"
 #include "fcitx/candidatelist.h"
+
+namespace {
 
 using namespace fcitx;
 int selected = 0;
@@ -366,6 +369,59 @@ void test_candidateaction() {
     }
 }
 
+class TestTabbedCandidateList : public TabbedCandidateList {
+public:
+    TestTabbedCandidateList() = default;
+
+    std::vector<CandidateAction> tabActions() const override {
+        std::vector<CandidateAction> actions;
+        CandidateAction action;
+        action.setText("Tab1");
+        action.setId(0);
+        actions.push_back(std::move(action));
+        return actions;
+    }
+
+    void triggerTabAction(int id) override { triggeredId_ = id; }
+
+    int triggeredId() const { return triggeredId_; }
+
+private:
+    int triggeredId_ = -1;
+};
+
+void test_tabbed() {
+    CommonCandidateList candidatelist;
+    candidatelist.setSelectionKey(
+        Key::keyListFromString("1 2 3 4 5 6 7 8 9 0"));
+    candidatelist.setPageSize(5);
+    for (int i = 0; i < 10; i++) {
+        candidatelist.append<TestCandidateWord>(i);
+    }
+
+    FCITX_ASSERT(candidatelist.toTabbed() == nullptr);
+
+    auto tabbed = std::make_unique<TestTabbedCandidateList>();
+    CandidateList *list = &candidatelist;
+    FCITX_ASSERT(list->toTabbed() == nullptr);
+
+    candidatelist.setTabbedImpl(std::move(tabbed));
+    FCITX_ASSERT(candidatelist.toTabbed() != nullptr);
+    FCITX_ASSERT(list->toTabbed() != nullptr);
+
+    auto actions = candidatelist.toTabbed()->tabActions();
+    FCITX_ASSERT(actions.size() == 1);
+    FCITX_ASSERT(actions[0].text() == "Tab1");
+    FCITX_ASSERT(actions[0].id() == 0);
+
+    candidatelist.toTabbed()->triggerTabAction(0);
+    FCITX_ASSERT(
+        static_cast<TestTabbedCandidateList *>(candidatelist.toTabbed())
+            ->triggeredId() == 0);
+}
+
+} // namespace
+
 int main() {
     test_basic();
     test_faulty_placeholder();
@@ -373,5 +429,6 @@ int main() {
     test_comment();
     test_cursor();
     test_candidateaction();
+    test_tabbed();
     return 0;
 }


### PR DESCRIPTION
## Summary
- Add `TabbedCandidateList` interface with `tabActions()` and `triggerTabAction()` methods
- Add `toTabbed()` and `setTabbed()` methods to `CandidateList` for optional implementation
- Add `setTabbedImpl()` to `CommonCandidateList` to set the optional implementation

## Changes
- `candidatelist.h`: Add interface and method declarations with doxygen comments
- `candidatelist.cpp`: Implement the new methods
- `testcandidatelist.cpp`: Add test for the new functionality

@since 5.1.20