### PR TITLE
Remove gvim from default NO_PREEDIT_APPS blocklist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ option(ENABLE_LIBUUID "Use libuuid for uuid generation" On)
 option(BUILD_SPELL_DICT "Build en_dict.fscd for English spell check" On)
 option(BUILD_SHARED_LIBS "Build library as shared libs" On)
 option(USE_SYSTEM_YOGA "Use system installed yoga library" Off)
-set(NO_PREEDIT_APPS "gvim.*,wps.*,wpp.*,et.*" CACHE STRING "Disable preedit for following app by default.")
+set(NO_PREEDIT_APPS "wps.*,wpp.*,et.*" CACHE STRING "Disable preedit for following app by default.")
 set(EVENT_LOOP_BACKEND "auto" CACHE STRING "Set the underlying event loop implementation, valid values are auto,systemd,libuv,none")
 
 if (ENABLE_EMOJI)


### PR DESCRIPTION
gvim was added to the default `NO_PREEDIT_APPS` list as a workaround for a memory leak around GTK XIM handling (fcitx/fcitx#364). The mechanism itself was introduced by @lilydjwg in fcitx/fcitx#125, and gvim has been on the default blocklist ever since — carried over from fcitx into fcitx5.

The root cause of the leak was an extra `g_object_ref(xic)` in Vim that had no matching unref. That has long been fixed upstream in Vim:

https://github.com/vim/vim/commit/f42ce78f770a68a8bb15209cc6def9b7763062f6

With that fix in place for many years, there is no longer a reason to exclude gvim from preedit by default. After more than a decade on the list, this PR finally drops gvim from the default entries so on-the-spot preedit works out of the box. The WPS Office entries (`wps.*,wpp.*,et.*`) are left untouched. Users can still exclude any application via the `FCITX_NO_PREEDIT_APPS` environment variable, and packagers can still override the default at build time with `-DNO_PREEDIT_APPS=...`.

cc @lilydjwg

Refs: fcitx/fcitx#364, fcitx/fcitx#125