### PR TITLE
Fix the incorrect judgment of the return value of mmap

### DIFF
--- a/src/lib/fcitx-utils/library.cpp
+++ b/src/lib/fcitx-utils/library.cpp
@@ -186,7 +186,7 @@ bool Library::findData(const char *slug, const char *magic, size_t lenOfMagic,
         void *needunmap = nullptr;
         needunmap = data;
 #endif
-        if (!data) {
+        if (data == MAP_FAILED) {
             data = malloc(statbuf.st_size);
             needfree.reset(data);
             if (!data) {

--- a/src/lib/fcitx-utils/library.cpp
+++ b/src/lib/fcitx-utils/library.cpp
@@ -184,9 +184,13 @@ bool Library::findData(const char *slug, const char *magic, size_t lenOfMagic,
         data =
             mmap(nullptr, statbuf.st_size, PROT_READ, MAP_PRIVATE, fd.fd(), 0);
         void *needunmap = nullptr;
-        needunmap = data;
+        if (data != MAP_FAILED) {
+            needunmap = data;
+        } else {
+            data = nullptr;
+        }
 #endif
-        if (data == MAP_FAILED) {
+        if (!data) {
             data = malloc(statbuf.st_size);
             needfree.reset(data);
             if (!data) {

--- a/src/lib/fcitx/icontheme.cpp
+++ b/src/lib/fcitx/icontheme.cpp
@@ -231,7 +231,7 @@ public:
 
         memory_ = static_cast<uint8_t *>(
             mmap(nullptr, st.st_size, PROT_READ, MAP_SHARED, fd.fd(), 0));
-        if (!memory_) {
+        if (memory_ == MAP_FAILED) {
             // Failed to mmap is not critical here.
             return;
         }
@@ -302,14 +302,14 @@ public:
     }
 
     uint16_t readWord(uint32_t offset) const {
-        if (offset > size_ - 2 || (offset % 2)) {
+        if (offset + 2 > size_ || (offset % 2)) {
             isValid_ = false;
             return 0;
         }
         return memory_[offset + 1] | memory_[offset] << 8;
     }
     uint32_t readDoubleWord(unsigned int offset) const {
-        if (offset > size_ - 4 || (offset % 4)) {
+        if (offset + 4 > size_ || (offset % 4)) {
             isValid_ = false;
             return 0;
         }


### PR DESCRIPTION
1. Fix the incorrect judgment of the return value of mmap
2. Avoid potential risks of numerical underflow