### PR TITLE
Allow Enter key to commit selected candidate in quickphrase

### DIFF
--- a/src/modules/quickphrase/quickphrase.cpp
+++ b/src/modules/quickphrase/quickphrase.cpp
@@ -137,13 +137,24 @@ QuickPhrase::QuickPhrase(Instance *instance)
                     }
                 }
 
-                if (keyEvent.key().check(FcitxKey_space) &&
-                    !candidateList->empty()) {
+                auto commitCandidate = [&]() {
                     keyEvent.accept();
                     if (candidateList->cursorIndex() >= 0) {
                         candidateList->candidate(candidateList->cursorIndex())
                             .select(inputContext);
                     }
+                };
+
+                if (keyEvent.key().check(FcitxKey_space) &&
+                    !candidateList->empty()) {
+                    commitCandidate();
+                    return;
+                }
+
+                if ((keyEvent.key().check(FcitxKey_Return) ||
+                     keyEvent.key().check(FcitxKey_KP_Enter)) &&
+                    !candidateList->empty()) {
+                    commitCandidate();
                     return;
                 }
 


### PR DESCRIPTION
## Summary
- Allow Enter/Return key to commit the highlighted candidate in quickphrase, matching the existing Space key behavior
- Original Enter behavior (commit raw input buffer) remains as fallback when no candidates are present
- Extract `commitCandidate` lambda to avoid duplication between Space and Enter handling

Fixes #1443