### PR TITLE
fix(notificationitem): show current input method name in SNI tooltip

### DIFF
--- a/src/modules/notificationitem/notificationitem.cpp
+++ b/src/modules/notificationitem/notificationitem.cpp
@@ -112,22 +112,20 @@ public:
 
     std::string label() { return ""; }
 
-    std::string title() { return _("Input Method"); }
+    std::string title() {
+        const InputMethodEntry *imEntry = nullptr;
+        if (auto *ic = parent_->menu()->lastRelevantIc()) {
+            imEntry = parent_->instance()->inputMethodEntry(ic);
+        }
+        return imEntry ? imEntry->name() : _("Input Method");
+    }
 
     dbus::DBusStruct<
         std::string,
         std::vector<dbus::DBusStruct<int32_t, int32_t, std::vector<uint8_t>>>,
         std::string, std::string>
     tooltip() {
-
-        const InputMethodEntry *imEntry = nullptr;
-        if (auto *ic = parent_->menu()->lastRelevantIc()) {
-            imEntry = parent_->instance()->inputMethodEntry(ic);
-        }
-        std::string title =
-            imEntry == nullptr ? _("Input Method") : imEntry->name();
-        return {iconNamePropertyImpl(), iconPixmap(), std::move(title),
-                std::string()};
+        return {iconNamePropertyImpl(), iconPixmap(), title(), std::string()};
     }
 
     bool preferTextIcon(const std::string &label,

--- a/src/modules/notificationitem/notificationitem.cpp
+++ b/src/modules/notificationitem/notificationitem.cpp
@@ -119,13 +119,14 @@ public:
         std::vector<dbus::DBusStruct<int32_t, int32_t, std::vector<uint8_t>>>,
         std::string, std::string>
     tooltip() {
+
         const InputMethodEntry *imEntry = nullptr;
         if (auto *ic = parent_->menu()->lastRelevantIc()) {
             imEntry = parent_->instance()->inputMethodEntry(ic);
         }
-        std::string tipTitle =
-            imEntry ? imEntry->name() : _("Input Method");
-        return {iconNamePropertyImpl(), iconPixmap(), std::move(tipTitle),
+        std::string title =
+            imEntry == nullptr ? _("Input Method") : imEntry->name();
+        return {iconNamePropertyImpl(), iconPixmap(), std::move(title),
                 std::string()};
     }
 

--- a/src/modules/notificationitem/notificationitem.cpp
+++ b/src/modules/notificationitem/notificationitem.cpp
@@ -112,20 +112,21 @@ public:
 
     std::string label() { return ""; }
 
-    std::string title() {
-        const InputMethodEntry *imEntry = nullptr;
-        if (auto *ic = parent_->menu()->lastRelevantIc()) {
-            imEntry = parent_->instance()->inputMethodEntry(ic);
-        }
-        return imEntry ? imEntry->name() : _("Input Method");
-    }
+    std::string title() { return _("Input Method"); }
 
     dbus::DBusStruct<
         std::string,
         std::vector<dbus::DBusStruct<int32_t, int32_t, std::vector<uint8_t>>>,
         std::string, std::string>
     tooltip() {
-        return {iconNamePropertyImpl(), iconPixmap(), title(), std::string()};
+        const InputMethodEntry *imEntry = nullptr;
+        if (auto *ic = parent_->menu()->lastRelevantIc()) {
+            imEntry = parent_->instance()->inputMethodEntry(ic);
+        }
+        std::string tipTitle =
+            imEntry ? imEntry->name() : _("Input Method");
+        return {iconNamePropertyImpl(), iconPixmap(), std::move(tipTitle),
+                std::string()};
     }
 
     bool preferTextIcon(const std::string &label,
@@ -153,12 +154,13 @@ public:
     }
 
     void notifyNewTooltip() {
-        std::string currentTitle = title();
-        if (currentTitle.empty() || lastTitle_ == currentTitle) {
+        auto currentTooltip = tooltip();
+        const auto &tipTitle = std::get<2>(currentTooltip);
+        if (tipTitle.empty() || lastTitle_ == tipTitle) {
             return;
         }
         newToolTip();
-        lastTitle_ = std::move(currentTitle);
+        lastTitle_ = tipTitle;
     }
 
     void reset() {


### PR DESCRIPTION
## Summary
- Fix `notifyNewTooltip()` to compare actual tooltip content instead of the constant `title()` return value
- `notifyNewTooltip()` was comparing against `title()` which always returns `"Input Method"`, so `NewToolTip` D-Bus signal was never emitted and the tooltip never updated on input method switch