### PR TITLE
Take AllowInputMethodForPassword into account in shouldSwitchIM

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -129,14 +129,23 @@ void initAsDaemon() {
 #endif
 }
 
+// Whether the input context is forced to the fallback keyboard input
+// method. Password fields only count when input method is not allowed for
+// password fields, since otherwise they use the regular input method. This
+// must mirror the condition in Instance::inputMethod().
+bool isInputMethodDisabled(const CapabilityFlags &flags,
+                           bool allowInputMethodForPassword) {
+    return flags.test(CapabilityFlag::Disable) ||
+           (flags.test(CapabilityFlag::Password) &&
+            !allowInputMethodForPassword);
+}
+
 // Switch IM when these capabilities change.
 bool shouldSwitchIM(const CapabilityFlags &oldFlags,
-                    const CapabilityFlags &newFlags) {
-    const bool oldDisable = oldFlags.testAny(
-        CapabilityFlags{CapabilityFlag::Password, CapabilityFlag::Disable});
-    const bool newDisable = newFlags.testAny(
-        CapabilityFlags{CapabilityFlag::Password, CapabilityFlag::Disable});
-    return oldDisable != newDisable;
+                    const CapabilityFlags &newFlags,
+                    bool allowInputMethodForPassword) {
+    return isInputMethodDisabled(oldFlags, allowInputMethodForPassword) !=
+           isInputMethodDisabled(newFlags, allowInputMethodForPassword);
 }
 
 } // namespace
@@ -711,14 +720,16 @@ Instance::Instance(int argc, char **argv) {
 
     d->eventWatchers_.emplace_back(d->watchEvent(
         EventType::InputContextCapabilityAboutToChange,
-        EventWatcherPhase::ReservedFirst, [this](Event &event) {
+        EventWatcherPhase::ReservedFirst, [this, d](Event &event) {
             auto &capChanged =
                 static_cast<CapabilityAboutToChangeEvent &>(event);
             if (!capChanged.inputContext()->hasFocus()) {
                 return;
             }
 
-            if (!shouldSwitchIM(capChanged.oldFlags(), capChanged.newFlags())) {
+            if (!shouldSwitchIM(
+                    capChanged.oldFlags(), capChanged.newFlags(),
+                    d->globalConfig_.allowInputMethodForPassword())) {
                 return;
             }
 
@@ -730,13 +741,15 @@ Instance::Instance(int argc, char **argv) {
         }));
     d->eventWatchers_.emplace_back(d->watchEvent(
         EventType::InputContextCapabilityChanged,
-        EventWatcherPhase::ReservedFirst, [this](Event &event) {
+        EventWatcherPhase::ReservedFirst, [this, d](Event &event) {
             auto &capChanged = static_cast<CapabilityChangedEvent &>(event);
             if (!capChanged.inputContext()->hasFocus()) {
                 return;
             }
 
-            if (!shouldSwitchIM(capChanged.oldFlags(), capChanged.newFlags())) {
+            if (!shouldSwitchIM(
+                    capChanged.oldFlags(), capChanged.newFlags(),
+                    d->globalConfig_.allowInputMethodForPassword())) {
                 return;
             }
 


### PR DESCRIPTION
## Problem

`shouldSwitchIM()` treats `Password` and `Disable` capabilities as a single "input method disabled" class. That matches `Instance::inputMethod()` only when `AllowInputMethodForPassword` is off. With the option enabled, a password field keeps using the regular input method, while `Disable` still forces the `keyboard-<default layout>` fallback.

Consequently, when a focused input context's capability changes from `Password` to `Disable` — e.g. a Qt client moving focus from a password field to a non-input widget in the same window, which is exactly what KeePassXC's unlock flow does — `shouldSwitchIM()` reports no change, no `InputContextSwitchInputMethodEvent` is emitted, the engine is not re-activated, and `InputState::lastIM_` goes stale. The next focus-out aborts:

```
fcitx5: src/lib/fcitx/instance.cpp:2490: void fcitx::Instance::deactivateInputMethod(fcitx::InputContextEvent&): Assertion `entry->uniqueName() == inputState->lastIM_' failed.
```

In builds without assertions, it calls deactivate on the wrong engine instead.

Observed in the wild on Arch Linux (fcitx5 5.1.19) every time a KeePassXC database is unlocked while using the fcitx Qt platform input context with `AllowInputMethodForPassword=True` (core dump shows `lastIM_="keyboard-us"` vs. computed entry `keyboard-jcdv`, capability flags containing `Disable`).

## Reproduction

Config: `ActiveByDefault=True`, `AllowInputMethodForPassword=True`; one group with default layout `us` and input methods `keyboard-us` + `keyboard-fr`, default IM `keyboard-fr`. Over the D-Bus frontend, on a single connection:

1. `CreateInputContext`, `SetSupportedCapability(0x1ffffffffff)`, `SetCapability(Password)`, `FocusIn` → activates `keyboard-fr`, `lastIM_ = keyboard-fr`
2. `SetCapability(Disable)` → no switch event (the bug); effective IM is now `keyboard-us`
3. `FocusOut` → assertion failure

## Fix

Evaluate the disabled state in `shouldSwitchIM()` with the same condition `Instance::inputMethod()` uses, including `AllowInputMethodForPassword`.

Verified with the reproducer above: the assertion no longer fires and `CurrentInputMethod` correctly reports the fallback IM after the Password→Disable transition. With the option at its default value the predicate is unchanged, and the reproducer behaves identically on patched and unpatched builds.