### PR TITLE
Check Disable capability when the focus-in IM info timer fires

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1079,19 +1079,26 @@ Instance::Instance(int argc, char **argv) {
                 inputContext->showVirtualKeyboard();
             }
 
-            if (!d->globalConfig_.showInputMethodInformationWhenFocusIn() ||
-                icEvent.inputContext()->capabilityFlags().test(
-                    CapabilityFlag::Disable)) {
+            if (!d->globalConfig_.showInputMethodInformationWhenFocusIn()) {
                 return;
             }
             // Give some time because the cursor location may need some time
-            // to be updated.
+            // to be updated. Do not check the Disable capability here:
+            // clients may update the capability for the newly focused
+            // widget shortly after the focus in, so check it when the
+            // timer fires instead. This avoids showing the information
+            // of the fallback keyboard layout for input contexts that
+            // are about to be disabled, and keeps showing it for input
+            // contexts that are about to be enabled.
             d->focusInImInfoTimer_ = d->eventLoop_.addTimeEvent(
                 CLOCK_MONOTONIC, now(CLOCK_MONOTONIC) + 30000, 0,
                 [d, icRef = icEvent.inputContext()->watch()](EventSourceTime *,
                                                              uint64_t) {
-                    // Check if ic is still valid and has focus.
-                    if (auto *ic = icRef.get(); ic && ic->hasFocus()) {
+                    // Check if ic is still valid, has focus and is not
+                    // disabled.
+                    if (auto *ic = icRef.get();
+                        ic && ic->hasFocus() &&
+                        !ic->capabilityFlags().test(CapabilityFlag::Disable)) {
                         d->showInputMethodInformation(ic);
                     }
                     return true;


### PR DESCRIPTION
## Problem

The `showInputMethodInformationWhenFocusIn` popup is armed in the FocusIn handler but displayed 30ms later. Clients send the capability update for the newly focused widget shortly *after* the focus-in — fcitx5-qt, for example, re-focuses the input context on widget focus changes within a window and then updates `CapabilityFlag::Disable` via `SetCapability` about a millisecond later.

Checking the `Disable` capability only at arm time therefore races with that update in both directions:

1. Focus moves from a text widget to a non-input widget: at focus-in the context still looks enabled, so the popup is armed; by the time it fires, the context is disabled and `inputMethod()` returns the fallback `keyboard-<default layout>`. The popup shows the fallback layout name even though the user never switched input methods — it looks like the input method spontaneously changed, and you cannot type in that widget anyway.
2. Focus moves from a non-input widget to a text widget: at focus-in the context still carries the stale `Disable` flag, so the popup is suppressed — even though the input method information would now be accurate and useful.

The asymmetry means users only ever see the misleading fallback-layout popups and never the correct ones. Easy to observe in KeePassXC (Qt) with the fcitx platform input context: clicking between the entry list and the search field shows the fallback layout name on every click while typing correctly uses the active input method.

## Fix

Arm the timer whenever `showInputMethodInformationWhenFocusIn` is enabled, and check the `Disable` capability when the timer fires (alongside the existing validity and focus checks).

## Verification

Scripted both races over the D-Bus frontend (single connection; `SetSupportedCapability(0x1ffffffffff)`; profile with default layout `us`, default IM `keyboard-fr`, `ActiveByDefault=True`, `showInputMethodInformationWhenFocusIn=True`; popup observed via the `UpdateClientSideUI` signal with `CapabilityFlag::ClientSideInputPanel` set):

- FocusIn with enabled capability, `Disable` added 2ms later: before the patch a popup with the fallback layout appears; after the patch no popup.
- FocusIn with stale `Disable` capability, cleared 2ms later: before the patch no popup; after the patch a popup with the active input method appears.