### PR TITLE
waylandim: expose raw zwp_input_method_v2 to external UI addons

### DIFF
--- a/src/frontend/waylandim/CMakeLists.txt
+++ b/src/frontend/waylandim/CMakeLists.txt
@@ -27,4 +27,4 @@ fcitx5_translate_desktop_file(${CMAKE_CURRENT_BINARY_DIR}/waylandim.conf.in wayl
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/waylandim.conf" DESTINATION "${FCITX_INSTALL_PKGDATADIR}/addon"
         COMPONENT config)
 
-fcitx5_export_module(WaylandIM TARGET waylandim BUILD_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}" HEADERS waylandim_public.h)
+fcitx5_export_module(WaylandIM TARGET waylandim BUILD_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}" HEADERS waylandim_public.h INSTALL)

--- a/src/frontend/waylandim/waylandim.cpp
+++ b/src/frontend/waylandim/waylandim.cpp
@@ -70,6 +70,10 @@ wayland::ZwpInputMethodV2 *WaylandIMModule::getInputMethodV2(InputContext *ic) {
         ->inputMethodV2();
 }
 
+zwp_input_method_v2 *WaylandIMModule::getInputMethodV2Raw(InputContext *ic) {
+    return wayland::rawPointer(getInputMethodV2(ic));
+}
+
 bool WaylandIMModule::hasKeyboardGrab(const std::string &display) const {
     if (const auto *server = findValue(servers_, display); server && *server) {
         if (server->get()->hasKeyboardGrab()) {

--- a/src/frontend/waylandim/waylandim.h
+++ b/src/frontend/waylandim/waylandim.h
@@ -63,6 +63,7 @@ public:
     Instance *instance() { return instance_; }
 
     wayland::ZwpInputMethodV2 *getInputMethodV2(InputContext *ic);
+    zwp_input_method_v2 *getInputMethodV2Raw(InputContext *ic);
 
     bool hasKeyboardGrab(const std::string &display) const;
 
@@ -75,6 +76,7 @@ public:
     const auto &config() const { return config_; }
 
     FCITX_ADDON_EXPORT_FUNCTION(WaylandIMModule, getInputMethodV2);
+    FCITX_ADDON_EXPORT_FUNCTION(WaylandIMModule, getInputMethodV2Raw);
     FCITX_ADDON_EXPORT_FUNCTION(WaylandIMModule, hasKeyboardGrab);
 
     AggregatedAppMonitor *appMonitor(const std::string &display);

--- a/src/frontend/waylandim/waylandim_public.h
+++ b/src/frontend/waylandim/waylandim_public.h
@@ -21,6 +21,13 @@ FCITX_ADDON_DECLARE_FUNCTION(
     WaylandIMModule, getInputMethodV2,
     fcitx::wayland::ZwpInputMethodV2 *(fcitx::InputContext *));
 
+// Raw zwp_input_method_v2 accessor for external UI addons (no internal
+// C++ wrapper needed): create the input popup surface yourself.
+struct zwp_input_method_v2;
+FCITX_ADDON_DECLARE_FUNCTION(
+    WaylandIMModule, getInputMethodV2Raw,
+    struct zwp_input_method_v2 *(fcitx::InputContext *));
+
 FCITX_ADDON_DECLARE_FUNCTION(WaylandIMModule, hasKeyboardGrab,
                              bool(const std::string &display));
 


### PR DESCRIPTION
## Summary

Expose the raw `zwp_input_method_v2` of the current input context to external
UI addons, and install the `WaylandIM` public module so they can link it.

This lets a third-party UI addon create a compositor-positioned
`zwp_input_popup_surface_v2` (caret tracking) on Wayland — currently impossible
outside the `waylandim` frontend, because the only accessor returns the internal
`fcitx::wayland::ZwpInputMethodV2` wrapper whose header is not installed.

## Changes

- Add `zwp_input_method_v2 *WaylandIMModule::getInputMethodV2Raw(InputContext *)`
  — a one-liner: `rawPointer(getInputMethodV2(ic))`.
- Export it as a published addon function.
- `INSTALL` the already-existing `WaylandIM` exported CMake module +
  `waylandim_public.h` (currently build-tree only).

## Compatibility

Purely additive: no signature/behaviour changes, no new dependencies. Existing
`getInputMethodV2` consumers are unaffected. This mirrors how the `wayland`
module already installs its `wayland_public.h`, making the input-method frontend
extensible the same way.

## Motivation

Built a predictive input method (engine + n-gram daemon + Qt Quick candidate
bar). The candidate bar needs caret positioning via `get_input_popup_surface`;
without this, it requires patching/forking fcitx5 per distro. This change lets
such UI addons ship as plain addons on any distro.
