### PR TITLE
fix: prevent XIM character leak in Xwayland apps under CJK locale

### DIFF
--- a/src/frontend/xim/xim.cpp
+++ b/src/frontend/xim/xim.cpp
@@ -660,7 +660,14 @@ void XIMServer::callback(xcb_im_client_t *client, xcb_im_input_context_t *xic,
             result = ic->keyEvent(event);
         }
         if (!result) {
-            xcb_im_forward_event(im(), xic, xevent);
+            if (!(event.isRelease() &&
+                  !event.key().states().testAny(
+                      KeyStates{KeyState::Ctrl, KeyState::Alt,
+                                KeyState::Super, KeyState::Shift}) &&
+                  !ic->inputPanel().preedit().toString().empty() &&
+                  Key::keySymToUnicode(event.key().sym()) > 0x20)) {
+                xcb_im_forward_event(im(), xic, xevent);
+            }
         }
         break;
     }


### PR DESCRIPTION
### Environment
- OS: Arch Linux, Linux 7.0
- Display: Wayland + niri + xwayland-satellite 0.8.1
- fcitx5: 5.1.20, xcb-imdkit: 1.0.9, libx11: 1.8.13
- Affected apps: Electron/Xwayland apps (Typora 0.11.18, linuxqq, VS Code)
- IM engines affected: rime, fcitx5-chinese-addons (pinyin)

### Reproduction
1. Set `LC_CTYPE=zh_CN.UTF-8` (apps with `LC_CTYPE=en_US.UTF-8` are unaffected)
2. Launch an Electron app via Xwayland with XIM (`XMODIFIERS=@im=fcitx`; no `GTK_IM_MODULE` set)
3. Activate fcitx5 and type pinyin rapidly
4. Random key presses bypass the IM and appear as raw ASCII in the document
<img width="720" height="275" alt="2026-06-25-195704-REGION" src="https://github.com/user-attachments/assets/110727da-d49a-4cd2-a515-a78681433cd0" />

### Root Cause
1. IM engines accept `KeyPress` events but reject `KeyRelease` events
2. The XIM frontend forwards rejected releases back to the client via `xcb_im_forward_event`
3. Internally, `xcb_im_forward_event` sets `client->sync = true`, causing the next `KeyPress` to be queued
4. On the client side, libx11 XIM implementation sets a `FABRICATED` flag during forward event processing, which should be consumed by a subsequent synthetic key event
5. Under `LC_CTYPE=zh_CN.UTF-8`, XIM encoding negotiation selects `COMPOUND_TEXT` instead of `UTF8_STRING`, introducing encoding overhead that widens the race window
6. A real key press arrives before the `FABRICATED` flag is cleared → `XFilterEvent` returns `NOTFILTERD` → the client commits the character directly → leak

`LC_CTYPE=en_US.UTF-8` negotiates `UTF8_STRING` encoding (zero overhead), making the race window too small to trigger.

### Fix
In the XIM frontend `XCB_XIM_FORWARD_EVENT` handler, skip forwarding `KeyRelease` events of regular printable characters while the IM is composing. These releases serve no purpose for the application — it only needs commit results and preedit state, both already correctly provided by the engine. Avoiding the forward prevents `client->sync` from being set, eliminating the root trigger of the race condition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input method key handling by suppressing forwarding of printable character key releases while preedit text is active and no Ctrl/Alt/Super/Shift modifiers are pressed.
  * Kept existing behavior unchanged for other key events, including shortcuts and non-printable keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->