### PR TITLE
fix: correct CapsLock state tracking in waylandim v2

### DIFF
--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -558,10 +558,8 @@ void WaylandIMInputContextV2::modifiersCallback(uint32_t /*serial*/,
                           mods_locked, 0, 0, group);
     server_->instance()->updateXkbStateMask(
         server_->group()->display(), mods_depressed, mods_latched, mods_locked);
-    mask = xkb_state_serialize_mods(
-        server_->state_.get(),
-        static_cast<xkb_state_component>(XKB_STATE_MODS_DEPRESSED |
-                                         XKB_STATE_MODS_LATCHED));
+    mask = xkb_state_serialize_mods(server_->state_.get(),
+                                    XKB_STATE_MODS_EFFECTIVE);
 
     server_->modifiers_ = 0;
     if (mask & server_->stateMask_.shift_mask) {


### PR DESCRIPTION
### Environment
- OS: Arch Linux, Linux 7.0
- Display: Wayland + niri + xwayland-satellite 0.8.1
- fcitx5: 5.1.20
- IM engine: rime (may also affect other engines that use CapsLock state)

### Reproduction
1. Switch to rime (Chinese mode)
2. Press CapsLock to enable caps lock
3. Press CapsLock again to disable caps lock
4. Rime remains stuck in English (ASCII) mode — only restarting the IM or manually toggling via F4 menu recovers
<img width="720" height="242" alt="2026-06-25-195851-REGION" src="https://github.com/user-attachments/assets/41e6508e-a420-46bc-9d6e-705af93a558a" />

### Root Cause
`WaylandIMInputContextV2::modifiersCallback` serializes the modifier state using `XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED`. These flags only query held-down (Depressed) and latched (Latch) modifiers, omitting **locked** modifiers — the category CapsLock belongs to.

Wayland correctly reports `mods_locked` changes, and `xkb_state_update_mask()` correctly updates the internal XKB state. However, `xkb_state_serialize_mods()` reads back only Depressed | Latched, so `modifiers_` never contains `KeyState::CapsLock`. The engine receives key events with uppercase keysyms but no CapsLock modifier in the key states, confusing its internal state machine.

### Fix
Replace `XKB_STATE_MODS_DEPRESSED | XKB_STATE_MODS_LATCHED` with `XKB_STATE_MODS_EFFECTIVE`. `EFFECTIVE` includes all three modifier categories (Depressed | Latched | Locked), correctly reflecting CapsLock transitions in `modifiers_`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modifier-state reporting so keyboard shortcuts and modifier keys are reflected more accurately, including cases like Shift, Caps Lock, Ctrl, Alt, and Num Lock.
  * Updated how modifier updates are forwarded to the virtual keyboard, reducing inconsistencies when input state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->