### PR TITLE
fix: notify compositor when preedit becomes empty in waylandim v2

### DIFF
--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -685,7 +685,7 @@ void WaylandIMInputContextV2::updatePreeditDelegate(InputContext *ic) const {
     }
 
     // Validate not empty and within wayland limit.
-    if (preedit.textLength() > 0 &&
+    if (preedit.textLength() >= 0 &&
         preedit.textLength() < WaylandIMServerBase::safeStringLimit) {
         if (cursorStart < 0) {
             cursorStart = cursorEnd = preedit.textLength();


### PR DESCRIPTION
### Environment
- OS: Arch Linux, Linux 7.0
- Display: Wayland + niri
- fcitx5: 5.1.20
- Affected apps: Electron apps using wayland_v2 IM protocol (linuxqq, VS Code, etc.)

### Reproduction
1. Use an Electron app with Wayland IM protocol (e.g., linuxqq with `--ozone-platform=wayland`)
2. Type several characters (preedit appears)
3. Press Backspace repeatedly to delete
4. When only one character remains, press Backspace: the candidate window disappears, but the character remains displayed
5. Press Backspace once more: the character is finally deleted
<img width="720" height="713" alt="2026-06-25-200012-REGION" src="https://github.com/user-attachments/assets/7caff55e-7b17-4a34-bc21-620b3ee01916" />

### Root Cause
`updatePreeditDelegate` only calls `setPreeditString()` when `preedit.textLength() > 0`. When the last character is deleted, `textLength()` becomes 0, so the update is skipped. The Wayland compositor is never notified that the preedit is now empty, leaving the old preedit display on screen. A second Backspace is needed to trigger a state change that eventually clears it.

### Fix
Change `> 0` to `>= 0`. An empty preedit string is sent to the compositor, which correctly clears the display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input composition handling so empty preedit text is now processed correctly, helping avoid missed updates in text entry.
  * Kept the existing safety limit in place for longer preedit content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->