### PR TITLE
fix: anchor candidate panel at cursor bottom to prevent covering input fields on GNOME Shell/Wayland

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ if (ENABLE_WAYLAND)
     set(REQUIRED_WAYLAND_COMPONENTS Client Cursor)
     find_package(Wayland 1.22 REQUIRED COMPONENTS ${REQUIRED_WAYLAND_COMPONENTS})
     find_package(WaylandScanner REQUIRED)
-    find_package(WaylandProtocols 1.46 REQUIRED)
+    find_package(WaylandProtocols 1.45 REQUIRED)
     pkg_check_modules(Gio IMPORTED_TARGET gio-2.0)
 
     if (USE_SYSTEM_PLASMA_WAYLAND_PROTOCOLS)

--- a/src/lib/fcitx/inputcontext.cpp
+++ b/src/lib/fcitx/inputcontext.cpp
@@ -268,6 +268,12 @@ void InputContext::setCursorRect(Rect rect, double scale) {
     if (d->cursorRect_ == rect && d->scale_ == scale) {
         return;
     }
+    FCITX_INFO() << "[CursorRect] program=" << program()
+                 << " frontend=" << frontendName()
+                 << " display=" << display()
+                 << " oldRect=" << d->cursorRect_
+                 << " newRect=" << rect
+                 << " scale=" << scale;
     d->cursorRect_ = rect;
     d->scale_ = scale;
     d->emplaceEvent<CursorRectChangedEvent>(this);

--- a/src/ui/classic/classicui.cpp
+++ b/src/ui/classic/classicui.cpp
@@ -456,10 +456,11 @@ void ClassicUI::update(UserInterfaceComponent component,
             ui = uiPtr->get();
         }
     }
-    CLASSICUI_DEBUG() << "Update component: " << static_cast<int>(component)
+    CLASSICUI_INFO() << "Update component: " << static_cast<int>(component)
                       << " for IC program:" << inputContext->program()
                       << " frontend:" << inputContext->frontendName()
                       << " display:" << inputContext->display()
+                      << " cursorRect:" << inputContext->cursorRect()
                       << " ui:" << (ui ? ui->name() : "(not available)");
 
     if (ui) {

--- a/src/ui/classic/inputwindow.cpp
+++ b/src/ui/classic/inputwindow.cpp
@@ -457,6 +457,11 @@ std::pair<int, int> InputWindow::update(InputContext *inputContext) {
             visible_ = false;
         }
     }
+    CLASSICUI_INFO() << "[InputWindow] nCandidates=" << nCandidates_
+                     << " upperLen=" << pango_layout_get_character_count(upperLayout_.get())
+                     << " lowerLen=" << pango_layout_get_character_count(lowerLayout_.get())
+                     << " visible=" << (visible_ ? "yes" : "no")
+                     << " size=" << width << "x" << height;
     return {width, height};
 }
 

--- a/src/ui/classic/waylandinputwindow.cpp
+++ b/src/ui/classic/waylandinputwindow.cpp
@@ -146,17 +146,20 @@ void WaylandInputWindow::resetPanel() { panelSurface_.reset(); }
 void WaylandInputWindow::update(fcitx::InputContext *ic) {
     const auto oldVisible = visible();
     auto [width, height] = InputWindow::update(ic);
-    CLASSICUI_DEBUG() << "Wayland Input Window visible:" << visible()
-                      << " for IC program:"
-                      << (ic ? ic->program() : std::string("-")) << " frontend:"
-                      << (ic ? ic->frontendName() : std::string("-"));
+    CLASSICUI_INFO() << "[WaylandUpdate] visible:" << visible()
+                      << " oldVisible:" << oldVisible
+                      << " program:" << (ic ? ic->program() : std::string("-"))
+                      << " frontend:" << (ic ? ic->frontendName() : std::string("-"))
+                      << " display:" << (ic ? ic->display() : std::string("-"))
+                      << " cursorRect:" << (ic ? ic->cursorRect() : Rect())
+                      << " size:" << width << "x" << height;
     if (!oldVisible && !visible()) {
-        CLASSICUI_DEBUG() << "Wayland Input Window has been hidden.";
+        CLASSICUI_INFO() << "[WaylandUpdate] Window has been hidden, skip.";
         return;
     }
 
     if (!visible()) {
-        CLASSICUI_DEBUG() << "Hide Wayland Input Window.";
+        CLASSICUI_INFO() << "[WaylandUpdate] Hide window.";
         hoverIndex_ = -1;
         window_->hide();
         repaintIC_.unwatch();
@@ -169,8 +172,9 @@ void WaylandInputWindow::update(fcitx::InputContext *ic) {
 
     assert(!visible() || ic != nullptr);
 
-    CLASSICUI_DEBUG()
-        << "Wayland Input Window is visible, ensure surface is created.";
+    CLASSICUI_INFO()
+        << "[WaylandUpdate] Window is visible, ensuring surface. frontend="
+        << (ic ? ic->frontendName() : "null");
     initPanel();
     if (ic->frontendName() == "wayland_v2") {
         if (!panelSurfaceV2_ || ic != v2IC_.get()) {
@@ -205,7 +209,7 @@ void WaylandInputWindow::update(fcitx::InputContext *ic) {
         }
     }
     if (!panelSurface_ && !panelSurfaceV2_) {
-        CLASSICUI_DEBUG() << "No Panel surface available, return.";
+        CLASSICUI_INFO() << "[WaylandUpdate] No panel surface available.";
         return;
     }
 

--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -19,6 +19,7 @@
 #include <xcb/xproto.h>
 #include "fcitx-utils/rect.h"
 #include "fcitx/inputcontext.h"
+#include "common.h"
 #include "inputwindow.h"
 #include "theme.h"
 #include "xcb_public.h"
@@ -96,6 +97,15 @@ int XCBInputWindow::calculatePositionX(const Rect &cursorRect,
     // exclude shadow border width
     x -= leftSW;
 
+    CLASSICUI_INFO() << "[PositionX] cursorRect=" << cursorRect
+                     << " windowWidth=" << width()
+                     << " actualWidth=" << actualWidth
+                     << " leftShadow=" << leftSW
+                     << " rightShadow=" << rightSW
+                     << " closestScreen="
+                     << (closestScreen ? *closestScreen : Rect())
+                     << " finalX=" << x;
+
     return x;
 }
 
@@ -111,6 +121,7 @@ int XCBInputWindow::calculatePositionY(const Rect &cursorRect,
     int actualHeight = height() - topSW - bottomSW;
     actualHeight = actualHeight <= 0 ? height() : actualHeight;
 
+    bool flipped = false;
     if (closestScreen != nullptr) {
         int h = cursorRect.height();
         int newY;
@@ -133,6 +144,7 @@ int XCBInputWindow::calculatePositionY(const Rect &cursorRect,
             if (newY < closestScreen->top()) {
                 newY = closestScreen->top();
             }
+            flipped = true;
         }
 
         y = newY;
@@ -141,11 +153,23 @@ int XCBInputWindow::calculatePositionY(const Rect &cursorRect,
     // exclude shadow border width
     y -= topSW;
 
+    CLASSICUI_INFO() << "[PositionY] cursorRect=" << cursorRect
+                     << " windowHeight=" << height()
+                     << " actualHeight=" << actualHeight
+                     << " topShadow=" << topSW
+                     << " bottomShadow=" << bottomSW
+                     << " dpi=" << dpi_
+                     << " closestScreen="
+                     << (closestScreen ? *closestScreen : Rect())
+                     << " flipped=" << (flipped ? "yes" : "no")
+                     << " finalY=" << y;
+
     return y;
 }
 
 void XCBInputWindow::updatePosition(InputContext *inputContext) {
     if (!visible()) {
+        CLASSICUI_INFO() << "[updatePosition] Window not visible, skip";
         return;
     }
 
@@ -155,6 +179,14 @@ void XCBInputWindow::updatePosition(InputContext *inputContext) {
     wc.x = calculatePositionX(cursorRect, closestScreen);
     wc.y = calculatePositionY(cursorRect, closestScreen);
     wc.stack_mode = XCB_STACK_MODE_ABOVE;
+
+    CLASSICUI_INFO() << "[updatePosition] program=" << inputContext->program()
+                     << " frontend=" << inputContext->frontendName()
+                     << " display=" << inputContext->display()
+                     << " cursorRect=" << cursorRect
+                     << " finalPos=(" << wc.x << "," << wc.y << ")"
+                     << " windowSize=" << width() << "x" << height();
+
     xcb_aux_configure_window(ui_->connection(), wid_,
                              XCB_CONFIG_WINDOW_STACK_MODE |
                                  XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y,
@@ -177,6 +209,19 @@ void XCBInputWindow::update(InputContext *inputContext) {
         updateDPI(inputContext);
     }
     auto [width, height] = InputWindow::update(inputContext);
+
+    CLASSICUI_INFO() << "[Update] program="
+                     << (inputContext ? inputContext->program() : std::string("null"))
+                     << " frontend="
+                     << (inputContext ? inputContext->frontendName() : std::string("null"))
+                     << " display="
+                     << (inputContext ? inputContext->display() : std::string("null"))
+                     << " oldVisible=" << (oldVisible ? "yes" : "no")
+                     << " newVisible=" << (visible() ? "yes" : "no")
+                     << " size=" << width << "x" << height
+                     << " cursorRect="
+                     << (inputContext ? inputContext->cursorRect() : Rect());
+
     if (!visible()) {
         if (oldVisible) {
             xcb_unmap_window(ui_->connection(), wid_);

--- a/src/ui/kimpanel/kimpanel.cpp
+++ b/src/ui/kimpanel/kimpanel.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "kimpanel.h"
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
@@ -93,11 +94,23 @@ public:
         auto msg = bus_->createMethodCall("org.kde.impanel", "/org/kde/impanel",
                                           "org.kde.impanel2", name);
 
+        // Anchor the spot rect at cursor bottom with a margin so
+        // the panel appears below the input field rather than covering it.
+        // 80px was determined empirically to work across Chrome variants
+        // (with/without bookmarks bar) and different web page layouts.
+        static constexpr int32_t kCursorMargin = 80;
         int32_t x = inputContext->cursorRect().left(),
-                y = inputContext->cursorRect().top(),
-                w = inputContext->cursorRect().width(),
-                h = inputContext->cursorRect().height();
+                y = inputContext->cursorRect().bottom() + kCursorMargin,
+                w = std::max(static_cast<int32_t>(inputContext->cursorRect().width()), static_cast<int32_t>(1)),
+                h = std::max(static_cast<int32_t>(inputContext->cursorRect().height()), static_cast<int32_t>(1));
 
+        FCITX_INFO() << "[Kimpanel] D-Bus " << name
+                      << " program=" << inputContext->program()
+                      << " frontend=" << inputContext->frontendName()
+                      << " display=" << inputContext->display()
+                      << " origTop=" << inputContext->cursorRect().top()
+                      << " sent=(" << x << "," << y << " " << w << "x" << h
+                      << ")";
         msg << x << y << w << h;
         if (method == CursorRectMethod::SetRelativeSpotRectV2) {
             msg << inputContext->scaleFactor();
@@ -292,11 +305,18 @@ void Kimpanel::update(UserInterfaceComponent component,
         return;
     }
     if (component == UserInterfaceComponent::InputPanel) {
+        FCITX_INFO() << "[Kimpanel] update InputPanel"
+                      << " program=" << inputContext->program()
+                      << " frontend=" << inputContext->frontendName()
+                      << " display=" << inputContext->display()
+                      << " isKDE=" << isKDE()
+                      << " hasClassicUI=" << (classicui() != nullptr);
         if (classicui() && isKDE() &&
             (inputContext->frontendName().starts_with("wayland") ||
              (xcb() && inputContext->display().starts_with("x11:") &&
               xcb()->call<IXCBModule::isXWayland>(
                   inputContext->display().substr(4))))) {
+            FCITX_INFO() << "[Kimpanel] Delegating to classicui.";
             proxy_->showAux(false);
             proxy_->showPreedit(false);
             proxy_->showLookupTable(false);
@@ -304,6 +324,7 @@ void Kimpanel::update(UserInterfaceComponent component,
                 ->update(component, inputContext);
             lastInputContext_ = inputContext->watch();
         } else {
+            FCITX_INFO() << "[Kimpanel] Handling panel directly (kimpanel).";
             updateInputPanel(inputContext);
         }
     } else if (component == UserInterfaceComponent::StatusArea) {


### PR DESCRIPTION

### Problem

On GNOME Shell/Wayland, the candidate panel rendered by the kimpanel
D-Bus protocol covers the input field instead of appearing below it.
This affects all applications that use `zwp_text_input_v3` (e.g.,
Chrome, GTK 4 apps).
<img width="930" height="218" alt="截图 2026-06-28 19-13-29" src="https://github.com/user-attachments/assets/0fcef8ff-2979-4bec-8817-87046fbe8b43" />


### Maybe Cause

In `KimpanelProxy::updateCursor()`, the `SetSpotRect` D-Bus message
sent to GNOME Shell uses `cursorRect().top()` as the Y coordinate.
GNOME Shell's kimpanel implementation anchors the candidate panel at
the given (x, y) position, so using the cursor's top edge causes the
panel to overlap the input field.

### Fix

**`src/ui/kimpanel/kimpanel.cpp`** — `KimpanelProxy::updateCursor()`:

1. **Y coordinate**: Changed from `cursorRect().top()` to
   `cursorRect().bottom() + 80px`.

2. **Minimum size**: Enforce `w >= 1, h >= 1` because Chrome via
   `zwp_text_input_v3` can send cursor rectangles with 0px width,
   which interferes with GNOME Shell's positioning heuristics.

**Before:**
```cpp
int32_t y = inputContext->cursorRect().top();
```

**After:**
```cpp
static constexpr int32_t kCursorMargin = 80;
int32_t y = inputContext->cursorRect().bottom() + kCursorMargin;
```

### Data Flow

```
Chrome (zwp_text_input_v3) → GNOME Shell → IBus D-Bus
  → fcitx5 ibus frontend → setCursorRect()
  → kimpanel → SetSpotRect D-Bus → GNOME Shell renders panel
```

fcitx5 does not directly position the panel on GNOME Wayland — it
sends coordinates to GNOME Shell via `SetSpotRect`, and GNOME Shell
decides the final placement.

### Why 80px?

The offset was determined through gradient testing across multiple
scenarios. Key observations during testing:

1. **GNOME Shell's SetSpotRect response is non-linear.** Sending +200
   only moves the panel ~40-60px on screen. GNOME Shell applies
   internal clamping to the coordinates.

2. **Spot rect dimensions affect GNOME Shell's positioning.** Reducing
   the spot rect to 1×1 pixel caused the panel to move *upward* rather
   than down, indicating that GNOME Shell uses the rect's height in
   its positioning heuristic.

3. **Chrome's bookmarks bar shifts web content.** When the bookmarks
   bar is visible, page Y coordinates shift but GNOME Shell's cursor
   position calculation does not fully compensate, causing the panel
   to appear higher relative to the input field. The 80px offset
   covers both cases (with/without bookmarks bar).

| Offset | Chrome omnibox | Web inputs (no bookmarks) | Web inputs (with bookmarks) |
|--------|---------------|---------------------------|-----------------------------|
| original (top) | covered | covered | covered |
| bottom()+0 | slightly better | covered | covered |
| bottom()+8 | improved | covered | covered |
| bottom()+16 | — | — | moved *up* (worse) |
| bottom()+50 | — | correct | lower half covered |
| bottom()+200 | too far | too far | — |
| **bottom()+80** | ✅ | ✅ | ✅ |

### Additional: Diagnostic Logging

Added `FCITX_INFO` / `CLASSICUI_INFO` logging at each layer of the
positioning pipeline to aid future debugging:

| File | Location |
|------|----------|
| `src/lib/fcitx/inputcontext.cpp` | `setCursorRect()` |
| `src/ui/kimpanel/kimpanel.cpp` | `updateCursor()`, `update()` |
| `src/ui/classic/classicui.cpp` | `update()` |
| `src/ui/classic/waylandinputwindow.cpp` | `update()` |
| `src/ui/classic/inputwindow.cpp` | `update()` |
| `src/ui/classic/xcbinputwindow.cpp` | position calculation |

### Build Fix

Relaxed `wayland-protocols` required version from 1.46 to 1.45 for
compatibility with Ubuntu 24.04.

### Limitations

This is a **workaround**, not a root-cause fix.

The root cause lies in **GNOME Shell's kimpanel implementation**: it
places the candidate panel at the exact (x, y) coordinates received
via `SetSpotRect`, without checking whether the panel will cover the
input field or overflow the screen bounds.

A proper fix would require GNOME Shell to:
1. Render the panel **below** the cursor, not at the cursor's top
2. Perform **collision detection** — check if there is enough space
   below; if not, flip the panel above the cursor
3. Respect screen boundaries and clamp appropriately

The 80px offset compensates for this on a specific setup (GNOME Shell
default theme on Ubuntu 24.04, 1920×1080 + 2048×1280 monitors). It may
not be optimal for users with different themes, font sizes, or screen
layouts, because fcitx5 has no way to query GNOME Shell's actual
rendered panel height.

### Future Work

- Make the vertical offset configurable via `kimpanel.conf` (e.g.,
  `VerticalOffset` option), so users can tune it for their setup
  without recompiling.
- File an issue upstream against GNOME Shell / Mutter proposing that
  the kimpanel implementation perform cursor-relative positioning with
  automatic collision detection.

### Verified On

- **OS**: Ubuntu 24.04
- **DE**: GNOME Shell (Wayland)
- **Monitors**: Two vertically stacked screens (HDMI-1 1920×1080 above
  eDP-2 2048×1280)
- **Tested scenarios**:
  - Chrome navigation bar (omnibox)
  - Google search input at top of page
  - Web page input fields at various positions
  - Chrome with and without bookmarks bar