### PR TITLE
Make HandlerTableView to work with std::ranges

### DIFF
--- a/src/lib/fcitx-utils/handlertable_details.h
+++ b/src/lib/fcitx-utils/handlertable_details.h
@@ -117,6 +117,8 @@ public:
         using reference = value_type &;
         using pointer = value_type *;
 
+        iterator() = default;
+
         iterator(typename container_type::const_iterator iter,
                  typename container_type::const_iterator end)
             : parentIter_(iter), endIter_(end) {
@@ -150,9 +152,9 @@ public:
             return {old, endIter_};
         }
 
-        reference operator*() { return ***parentIter_; }
+        reference operator*() const { return ***parentIter_; }
 
-        pointer operator->() { return (**parentIter_).get(); }
+        pointer operator->() const { return (**parentIter_).get(); }
 
     private:
         typename container_type::const_iterator parentIter_;

--- a/test/testhandlertable.cpp
+++ b/test/testhandlertable.cpp
@@ -5,6 +5,7 @@
  *
  */
 
+#include <algorithm>
 #include <memory>
 #include <unordered_set>
 #include "fcitx-utils/handlertable.h"
@@ -41,6 +42,13 @@ int main() {
         };
 
         auto table2 = std::move(table);
+
+        {
+            FCITX_ASSERT(table2.size() == 6);
+            FCITX_ASSERT(std::ranges::all_of(table2.view(), [](auto &handler) {
+                return handler != nullptr;
+            }));
+        }
 
         {
             FCITX_ASSERT(table2.size() == 6);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handler table iteration compatibility, including support for default-constructed iterators and const-qualified access.
  * Updated validation to confirm moved handler tables retain all entries and valid handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->