### PR TITLE
Remove triggerKeys from simple temp mode.

### DIFF
--- a/src/lib/fcitx/tempmode.h
+++ b/src/lib/fcitx/tempmode.h
@@ -138,19 +138,6 @@ protected:
         return false;
     }
 
-    bool triggerTempMode(const KeyEvent &keyEvent) override {
-        if (keyEvent.isRelease()) {
-            return false;
-        }
-        if (keyEvent.key().checkKeyList(triggerKeys())) {
-            if (auto *prop = property(keyEvent.inputContext())) {
-                prop->setActive(true);
-            }
-            return true;
-        }
-        return false;
-    }
-
     void reset(InputContext *inputContext) override {
         if (auto *prop = property(inputContext)) {
             prop->setActive(false);
@@ -161,11 +148,6 @@ protected:
         FCITX_UNUSED(inputContext);
         return new PropertyType;
     }
-
-    /**
-     * Return the hotkeys that can activate this temp mode.
-     */
-    virtual const KeyList &triggerKeys() const = 0;
 };
 
 } // namespace fcitx

--- a/src/modules/clipboard/clipboardtempmode.cpp
+++ b/src/modules/clipboard/clipboardtempmode.cpp
@@ -29,7 +29,12 @@ ClipboardTempMode::ClipboardTempMode(Clipboard *clipboard)
     : clipboard_(clipboard) {}
 
 bool ClipboardTempMode::triggerTempMode(const KeyEvent &keyEvent) {
-    if (Base::triggerTempMode(keyEvent)) {
+    if (keyEvent.isRelease()) {
+        return false;
+    }
+
+    if (keyEvent.key().checkKeyList(*clipboard_->config().triggerKey)) {
+        property(keyEvent.inputContext())->setActive(true);
         clipboard_->updateUI(keyEvent.inputContext());
         return true;
     }
@@ -129,9 +134,5 @@ void ClipboardTempMode::reset(InputContext *inputContext) {
 }
 
 std::string_view ClipboardTempMode::name() const { return "clipboardState"; }
-
-const KeyList &ClipboardTempMode::triggerKeys() const {
-    return clipboard_->config().triggerKey.value();
-}
 
 } // namespace fcitx

--- a/src/modules/clipboard/clipboardtempmode.h
+++ b/src/modules/clipboard/clipboardtempmode.h
@@ -33,9 +33,6 @@ public:
     void reset(InputContext *inputContext) override;
     std::string_view name() const override;
 
-protected:
-    const KeyList &triggerKeys() const override;
-
 private:
     Clipboard *clipboard_;
 };

--- a/src/modules/imselector/imselectortempmode.cpp
+++ b/src/modules/imselector/imselectortempmode.cpp
@@ -211,6 +211,4 @@ void IMSelectorTempMode::reset(InputContext *inputContext) {
 
 std::string_view IMSelectorTempMode::name() const { return "imselector"; }
 
-const KeyList &IMSelectorTempMode::triggerKeys() const { return emptyKeyList; }
-
 } // namespace fcitx

--- a/src/modules/imselector/imselectortempmode.h
+++ b/src/modules/imselector/imselectortempmode.h
@@ -8,6 +8,8 @@
 #ifndef _FCITX5_MODULES_IMSELECTOR_IMSELECTORTEMPMODE_H_
 #define _FCITX5_MODULES_IMSELECTOR_IMSELECTORTEMPMODE_H_
 
+#include <string_view>
+#include "fcitx/event.h"
 #include "fcitx/tempmode.h"
 
 namespace fcitx {
@@ -29,9 +31,6 @@ public:
     bool keyEvent(const KeyEvent &keyEvent) override;
     void reset(InputContext *inputContext) override;
     std::string_view name() const override;
-
-protected:
-    const KeyList &triggerKeys() const override;
 
 private:
     bool trigger(InputContext *inputContext, bool local);

--- a/src/modules/quickphrase/quickphrasetempmode.cpp
+++ b/src/modules/quickphrase/quickphrasetempmode.cpp
@@ -427,10 +427,6 @@ void QuickPhraseTempMode::updateUI(InputContext *inputContext) {
     inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
 }
 
-const KeyList &QuickPhraseTempMode::triggerKeys() const {
-    return quickPhrase_->config().triggerKey.value();
-}
-
 void QuickPhraseTempMode::setSelectionKeys(QuickPhraseAction action) {
     std::array<KeySym, 10> syms;
     switch (action) {

--- a/src/modules/quickphrase/quickphrasetempmode.h
+++ b/src/modules/quickphrase/quickphrasetempmode.h
@@ -60,9 +60,6 @@ public:
                                       QuickPhraseRestoreCallback callback);
     void updateUI(InputContext *inputContext);
 
-protected:
-    const KeyList &triggerKeys() const override;
-
 private:
     void setSelectionKeys(QuickPhraseAction action);
 

--- a/src/modules/unicode/unicodetempmode.cpp
+++ b/src/modules/unicode/unicodetempmode.cpp
@@ -140,10 +140,6 @@ void UnicodeTempMode::reset(InputContext *inputContext) {
 
 std::string_view UnicodeTempMode::name() const { return "unicodeState"; }
 
-const KeyList &UnicodeTempMode::triggerKeys() const {
-    return unicode_->config().triggerKey.value();
-}
-
 bool UnicodeTempMode::trigger(InputContext *inputContext, UnicodeMode mode) {
     if (!unicode_->data().load()) {
         return false;

--- a/src/modules/unicode/unicodetempmode.h
+++ b/src/modules/unicode/unicodetempmode.h
@@ -48,9 +48,6 @@ public:
 
     void updateUI(InputContext *inputContext, bool trigger = false);
 
-protected:
-    const KeyList &triggerKeys() const override;
-
 private:
     bool trigger(InputContext *inputContext, UnicodeMode mode);
     bool handleSearch(const KeyEvent &keyEvent);

--- a/test/testtempmode.cpp
+++ b/test/testtempmode.cpp
@@ -42,8 +42,12 @@ public:
     using Base::isActive;
 
     bool triggerTempMode(const KeyEvent &keyEvent) override {
-        if (Base::triggerTempMode(keyEvent)) {
+        if (keyEvent.isRelease()) {
+            return false;
+        }
+        if (keyEvent.key().checkKeyList(triggerKeys_)) {
             triggerCount_++;
+            property(keyEvent.inputContext())->setActive(true);
             return true;
         }
         return false;
@@ -67,8 +71,6 @@ public:
     const std::vector<std::string> &handledKeys() const { return handledKeys_; }
 
 private:
-    const KeyList &triggerKeys() const override { return triggerKeys_; }
-
     KeyList triggerKeys_;
     int triggerCount_ = 0;
     int invokeActionCount_ = 0;


### PR DESCRIPTION
Based on current 4 usages, it renders that it is not very useful.
1. all module override triggerTempMode.
2. two of the module has two set of trigger key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Behavior Changes**
  * Temporary input modes now only trigger on key press (not key release), with activation handled directly by each mode’s temp-mode logic.
  * Clipboard, Quick Phrase, Unicode, and IM Selector continue to respond to their configured activation keys.
* **Bug Fixes**
  * Prevented temporary modes from activating when an activation key is released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->