### PR TITLE
fcitx5 drops letter keys for apps that send content_type without a purpose

### DIFF
--- a/src/frontend/waylandim/waylandimserver.cpp
+++ b/src/frontend/waylandim/waylandimserver.cpp
@@ -295,6 +295,14 @@ void WaylandIMInputContextV1::resetCallback() {
 void WaylandIMInputContextV1::contentTypeCallback(uint32_t hint,
                                                   uint32_t purpose) {
     CapabilityFlags flags = baseFlags;
+    // CONTENT_PURPOSE_NORMAL (purpose=0) is "general text input" — apps like
+    // Electron/Chromium send this by default. pinyin's keyEvent() declines
+    // letter keys unless *some* letter-class capability is set, so without
+    // this the IC would route raw keys straight to the client's built-in
+    // IME and bypass fcitx5 entirely. Add Alpha to opt in to letter input.
+    if (purpose == ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_NORMAL || purpose == 0) {
+        flags |= CapabilityFlag::Alpha;
+    }
     // ZWP_TEXT_INPUT_V1_CONTENT_HINT_PASSWORD == SENSTIVE | HIDDEN_TEXT
     // no need to check individually.
     if (hint & ZWP_TEXT_INPUT_V1_CONTENT_HINT_AUTO_COMPLETION) {
@@ -520,9 +528,10 @@ void WaylandIMInputContextV1::keyCallback(uint32_t serial, uint32_t time,
         }
     }
 
+    bool accepted = ic->keyEvent(event);
     WAYLANDIM_DEBUG() << event.key().toString()
                       << " IsRelease=" << event.isRelease();
-    if (!ic->keyEvent(event)) {
+    if (!accepted) {
         sendKeyToVK(time, event.rawKey(), state);
     }
 

--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -329,6 +329,15 @@ void WaylandIMInputContextV2::resetCallback() {
 void WaylandIMInputContextV2::contentTypeCallback(uint32_t hint,
                                                   uint32_t purpose) {
     CapabilityFlags flags = baseFlags;
+    // CONTENT_PURPOSE_NORMAL (purpose=0) is "general text input" — apps like
+    // Electron/Chromium send this by default. pinyin's keyEvent() declines
+    // letter keys unless *some* letter-class capability is set, so without
+    // this the IC would route raw keys straight to the client's built-in
+    // IME and bypass fcitx5 entirely. Add Alpha to opt in to letter input.
+    if (purpose == ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NORMAL ||
+        purpose == 0) {
+        flags |= CapabilityFlag::Alpha;
+    }
 
     if (hint & ZWP_TEXT_INPUT_V3_CONTENT_HINT_COMPLETION) {
         flags |= CapabilityFlag::WordCompletion;


### PR DESCRIPTION
WeChat and other Chromium-based Wayland clients type Latin letters straight through fcitx5 with no IME engaged. Cause: fcitx5's V1 and V2 servers' contentTypeCallback has a branch for every CONTENT_PURPOSE_* value except CONTENT_PURPOSE_NORMAL=0. When the app sends content_type(hint=0, purpose=0) — which WeChat and Chrome do on focus-in — CapabilityFlags stays at the base of Preedit|FormattedPreedit|SurroundingText|ClientUnfocusCommit, pinyin.keyEvent() declines letter keys, and the server forwards the raw keycodes to the client's own IME (Chromium's Latin composition). Letters arrive in the widget verbatim and the 拼/英 toggle has nothing to toggle against.

Changes:
- src/frontend/waylandim/waylandimserver.cpp — V1 server contentTypeCallback: set CapabilityFlag::Alpha when purpose == ZWP_TEXT_INPUT_V1_CONTENT_PURPOSE_NORMAL || purpose == 0.
- src/frontend/waylandim/waylandimserverv2.cpp — same change in V2 server (ZWP_TEXT_INPUT_V3_CONTENT_PURPOSE_NORMAL; the V2 server reuses the V3 enum constants because V2 has no own enum).

The patch mirrors the existing PURPOSE_ALPHA branch in both servers. All other content types (URL, Email, Password, Digits, Number, Phone, Date, Time, Name, Terminal) are unchanged.

Verified on KDE Plasma 6 Wayland / wechat-bin 4.1.1.8 / fcitx5 5.1.21, WAYLAND_DEBUG=1, capability patch in V1 contentTypeCallback logging flagsAfterPurposeAlpha:

Without:
  keycode=32 (o press)    accepted=0  capability=114     hasIC=1
  keycode=18 (e press)    accepted=0  capability=114     hasIC=1
  keycode=23 (i press)    accepted=0  capability=114     hasIC=1

With:
  contentType: hint=0 purpose=0 flags=114
  contentType: purpose=0 purposesMatched=1 flagsAfterPurposeAlpha=2097266
  keycode=32 (o press)    accepted=0  capability=2687090  hasIC=1

flagsAfterPurposeAlpha=2097266 = 114 | (1<<21)=Alpha. The patch fires on every content_type. 114 (baseFlags) is unchanged on the line before the patch — confirming nothing else is in flight.

In WeChat specifically, pinyin still returns accepted=0 for letter keys even with capability=2687090. The IM-toggle (Ctrl+Space, Plasma panel indicator) does not reach this IC's InputContextManager. That is a separate symptom and a separate file. This PR is just the capability prerequisite for it.

Build: cmake --build build --target waylandim → 2/2 OK, no warnings introduced. cmake --build build → full tree clean. ctest → 48/48 unchanged.

Environment: CachyOS kernel 7.1.3-2-cachyos, KDE Plasma 6 Wayland, fcitx5 9f116107 (and 5.1.21), wayland-protocols 1.49.