### PR TITLE
implicit

### DIFF
--- a/src/lib/fcitx-config/configuration.cpp
+++ b/src/lib/fcitx-config/configuration.cpp
@@ -129,6 +129,9 @@ void Configuration::save(RawConfig &config) const {
         auto subConfigPtr = config.get(path, true);
         iter->second->marshall(*subConfigPtr);
         subConfigPtr->setComment(iter->second->description());
+        if (iter->second->isDefault()) {
+            subConfigPtr->setImplicit(true);
+        }
     }
 }
 

--- a/src/lib/fcitx-config/configuration.cpp
+++ b/src/lib/fcitx-config/configuration.cpp
@@ -129,9 +129,7 @@ void Configuration::save(RawConfig &config) const {
         auto subConfigPtr = config.get(path, true);
         iter->second->marshall(*subConfigPtr);
         subConfigPtr->setComment(iter->second->description());
-        if (iter->second->isDefault()) {
-            subConfigPtr->setImplicit(true);
-        }
+        subConfigPtr->setImplicit(iter->second->isDefault());
     }
 }
 

--- a/src/lib/fcitx-config/iniparser.cpp
+++ b/src/lib/fcitx-config/iniparser.cpp
@@ -124,6 +124,9 @@ bool writeAsIni(const RawConfig &config, std::ostream &out) {
                         values += "\n";
                     }
 
+                    if (config.isImplicit()) {
+                        values += "# ";
+                    }
                     values += config.name();
                     values += "=";
                     values += stringutils::escapeForValue(config.value());
@@ -133,7 +136,11 @@ bool writeAsIni(const RawConfig &config, std::ostream &out) {
                 "", false, path);
             if (!values.empty()) {
                 if (!path.empty()) {
-                    out << "[" << path << "]\n";
+                    if (config.isImplicit()) {
+                        out << "# [" << path << "]\n";
+                    } else {
+                        out << "[" << path << "]\n";
+                    }
                     FCITX_RETURN_IF(!out, false);
                 }
                 out << values << "\n";

--- a/src/lib/fcitx-config/rawconfig.cpp
+++ b/src/lib/fcitx-config/rawconfig.cpp
@@ -20,21 +20,23 @@ namespace fcitx {
 class RawConfigPrivate : public QPtrHolder<RawConfig> {
 public:
     RawConfigPrivate(RawConfig *q, std::string _name)
-        : QPtrHolder(q), name_(std::move(_name)), lineNumber_(0) {}
+        : QPtrHolder(q), name_(std::move(_name)), lineNumber_(0),
+          implicit_(false) {}
     RawConfigPrivate(RawConfig *q, const RawConfigPrivate &other)
         : QPtrHolder(q), value_(other.value_), comment_(other.comment_),
-          lineNumber_(other.lineNumber_) {}
+          lineNumber_(other.lineNumber_), implicit_(other.implicit_) {}
 
     RawConfigPrivate &operator=(const RawConfigPrivate &other) {
         if (&other == this) {
             return *this;
         }
         // There is no need to copy "name_", because name refers to its parent.
-        // Make a copy of value, comment, and lineNumber, because this "other"
-        // might be our parent.
+        // Make a copy of value, comment, lineNumber, and implicit_, because
+        // this "other" might be our parent.
         auto value = other.value_;
         auto comment = other.comment_;
         auto lineNumber = other.lineNumber_;
+        auto implicit = other.implicit_;
         OrderedMap<std::string, std::shared_ptr<RawConfig>> newSubItems;
         for (const auto &item : other.subItems_) {
             auto result = newSubItems[item.first] =
@@ -44,6 +46,7 @@ public:
         value_ = std::move(value);
         comment_ = std::move(comment);
         lineNumber_ = lineNumber;
+        implicit_ = implicit;
         detachSubItems();
         subItems_ = std::move(newSubItems);
         return *this;
@@ -123,6 +126,7 @@ public:
     std::string comment_;
     OrderedMap<std::string, std::shared_ptr<RawConfig>> subItems_;
     unsigned int lineNumber_;
+    bool implicit_;
 };
 
 RawConfig::RawConfig() : RawConfig("") {}
@@ -195,6 +199,11 @@ void RawConfig::setLineNumber(unsigned int lineNumber) {
     d->lineNumber_ = lineNumber;
 }
 
+void RawConfig::setImplicit(bool implicit) {
+    FCITX_D();
+    d->implicit_ = implicit;
+}
+
 const std::string &RawConfig::name() const {
     FCITX_D();
     return d->name_;
@@ -213,6 +222,22 @@ const std::string &RawConfig::value() const {
 unsigned int RawConfig::lineNumber() const {
     FCITX_D();
     return d->lineNumber_;
+}
+
+bool RawConfig::isImplicitSelf() const {
+    FCITX_D();
+    return d->implicit_;
+}
+
+bool RawConfig::isImplicit() const {
+    const RawConfig *node = this;
+    while (node) {
+        if (node->isImplicitSelf()) {
+            return true;
+        }
+        node = node->parent();
+    }
+    return false;
 }
 
 bool RawConfig::hasSubItems() const {

--- a/src/lib/fcitx-config/rawconfig.h
+++ b/src/lib/fcitx-config/rawconfig.h
@@ -37,10 +37,13 @@ public:
     void setValue(std::string value);
     void setComment(std::string comment);
     void setLineNumber(unsigned int lineNumber);
+    void setImplicit(bool implicit);
     const std::string &name() const;
     const std::string &comment() const;
     const std::string &value() const;
     unsigned int lineNumber() const;
+    bool isImplicitSelf() const;
+    bool isImplicit() const;
     bool hasSubItems() const;
     size_t subItemsSize() const;
     std::vector<std::string> subItems() const;

--- a/src/lib/fcitx-config/rawconfig.h
+++ b/src/lib/fcitx-config/rawconfig.h
@@ -21,47 +21,177 @@ namespace fcitx {
 
 class RawConfig;
 
+/** Shared pointer type for RawConfig. */
 using RawConfigPtr = std::shared_ptr<RawConfig>;
 
 class RawConfigPrivate;
+/**
+ * A raw configuration tree that stores key-value pairs in a hierarchical
+ * structure.
+ *
+ * RawConfig represents a configuration as a tree of nodes, where each node
+ * can have a value and sub-items. For example, It supports reading from and
+ * writing to INI format, and can represent configuration with implicit
+ * (default) values.
+ */
 class FCITXCONFIG_EXPORT RawConfig {
 public:
+    /** Construct a RawConfig with an empty name. */
     RawConfig();
     FCITX_DECLARE_VIRTUAL_DTOR_COPY(RawConfig)
 
+    /**
+     * Get a sub-item by path.
+     *
+     * @param path path to the sub-item, using '/' as separator
+     * @param create if true, create intermediate nodes if they don't exist
+     * @return shared pointer to the sub-item, or nullptr if not found and
+     *         create is false
+     */
     std::shared_ptr<RawConfig> get(const std::string &path,
                                    bool create = false);
+    /** @overload */
     std::shared_ptr<const RawConfig> get(const std::string &path) const;
+
+    /**
+     * Remove a sub-item by path.
+     *
+     * @param path path to the item to remove
+     * @return true if the item was removed, false if not found or invalid path
+     */
     bool remove(const std::string &path);
+
+    /** Remove all sub-items. */
     void removeAll();
+
+    /**
+     * Set the value of this node.
+     *
+     * @param value the value to set
+     */
     void setValue(std::string value);
+
+    /**
+     * Set the comment for this node.
+     *
+     * @param comment the comment to set
+     */
     void setComment(std::string comment);
+
+    /**
+     * Set the line number where this node was parsed from.
+     *
+     * @param lineNumber the line number
+     */
     void setLineNumber(unsigned int lineNumber);
+
+    /**
+     * Mark this config node as implicit (default value that won't be written
+     * to INI).
+     *
+     * @param implicit true to mark as implicit, false otherwise
+     *
+     * @since 5.1.22
+     */
     void setImplicit(bool implicit);
+
+    /** Get the name of this node. */
     const std::string &name() const;
+
+    /** Get the comment for this node. */
     const std::string &comment() const;
+
+    /** Get the value of this node. */
     const std::string &value() const;
+
+    /** Get the line number where this node was parsed from. */
     unsigned int lineNumber() const;
+
+    /**
+     * Check if this node itself is marked as implicit.
+     *
+     * @return true if this node is marked as implicit
+     *
+     * @since 5.1.22
+     */
     bool isImplicitSelf() const;
+
+    /**
+     * Check if this node or any of its ancestors is marked as implicit.
+     *
+     * @return true if this node or any ancestor is marked as implicit
+     *
+     * @since 5.1.22
+     */
     bool isImplicit() const;
+
+    /**
+     * Check if this node has any sub-items.
+     *
+     * @return true if this node has sub-items
+     */
     bool hasSubItems() const;
+
+    /**
+     * Get the number of sub-items.
+     *
+     * @return number of sub-items
+     */
     size_t subItemsSize() const;
+
+    /**
+     * Get a list of sub-item names.
+     *
+     * @return list of sub-item names
+     */
     std::vector<std::string> subItems() const;
+
+    /**
+     * Set a value by path, creating intermediate nodes if needed.
+     *
+     * @param path path to the value, using '/' as separator
+     * @param value the value to set
+     */
     void setValueByPath(const std::string &path, std::string value) {
         (*this)[path] = std::move(value);
     }
 
+    /**
+     * Get a value by path.
+     *
+     * @param path path to the value, using '/' as separator
+     * @return pointer to the value, or nullptr if not found
+     */
     const std::string *valueByPath(const std::string &path) const {
         auto config = get(path);
         return config ? &config->value() : nullptr;
     }
 
+    /**
+     * Get or create a sub-item by path.
+     *
+     * @param path path to the sub-item, using '/' as separator
+     * @return reference to the sub-item
+     */
     RawConfig &operator[](const std::string &path) { return *get(path, true); }
+
+    /**
+     * Assign a string value to this node.
+     *
+     * @param value the value to assign
+     * @return reference to this node
+     */
     RawConfig &operator=(std::string value) {
         setValue(std::move(value));
         return *this;
     }
 
+    /**
+     * Check if two RawConfig trees are equal.
+     *
+     * @param other the other RawConfig to compare with
+     * @return true if the trees are equal
+     */
     bool operator==(const RawConfig &other) const {
         if (this == &other) {
             return true;
@@ -79,25 +209,61 @@ public:
             });
     }
 
+    /**
+     * Check if two RawConfig trees are not equal.
+     *
+     * @param config the other RawConfig to compare with
+     * @return true if the trees are not equal
+     */
     bool operator!=(const RawConfig &config) const {
         return !(*this == config);
     }
 
+    /**
+     * Get the parent node.
+     *
+     * @return pointer to the parent node, or nullptr if this is the root
+     */
     RawConfig *parent() const;
+
+    /**
+     * Detach this node from its parent.
+     *
+     * @return shared pointer to the detached node, or empty if already root
+     */
     std::shared_ptr<RawConfig> detach();
 
+    /**
+     * Visit all sub-items.
+     *
+     * @param callback function to call for each sub-item, return false to stop
+     * @param path path to start visiting from, empty for root
+     * @param recursive if true, visit sub-items recursively
+     * @param pathPrefix prefix to prepend to paths in callback
+     * @return true if all items were visited, false if stopped early
+     */
     bool visitSubItems(
         std::function<bool(RawConfig &, const std::string &path)> callback,
         const std::string &path = "", bool recursive = false,
         const std::string &pathPrefix = "");
+    /** @overload */
     bool visitSubItems(
         std::function<bool(const RawConfig &, const std::string &path)>
             callback,
         const std::string &path = "", bool recursive = false,
         const std::string &pathPrefix = "") const;
+
+    /**
+     * Visit all items on a path.
+     *
+     * @param callback function to call for each item on the path
+     * @param path the path to visit
+     */
     void visitItemsOnPath(
         std::function<void(RawConfig &, const std::string &path)> callback,
         const std::string &path);
+
+    /** @overload */
     void visitItemsOnPath(
         std::function<void(const RawConfig &, const std::string &path)>
             callback,
@@ -111,6 +277,13 @@ private:
     std::unique_ptr<RawConfigPrivate> d_ptr;
 };
 
+/**
+ * Output a RawConfig to a log message.
+ *
+ * @param log the log message builder
+ * @param config the RawConfig to output
+ * @return reference to the log message builder
+ */
 FCITXCONFIG_EXPORT LogMessageBuilder &operator<<(LogMessageBuilder &log,
                                                  const RawConfig &config);
 } // namespace fcitx

--- a/test/testconfig.cpp
+++ b/test/testconfig.cpp
@@ -51,8 +51,11 @@ void testBasics() {
     RawConfig another;
     readFromIni(another, ss);
 
+    // Default values are marked as implicit and not written to INI,
+    // so they won't be read back.
     FCITX_ASSERT(*rawConfig.valueByPath("IntOption") == "0");
-    FCITX_ASSERT(*another.valueByPath("IntOption") == "0") << another;
+    FCITX_ASSERT(!another.valueByPath("IntOption"))
+        << "Default value should not be written to INI";
 
     config.intValue.setValue(5);
     FCITX_ASSERT(config.intValue.value() == 5);

--- a/test/testconfig.cpp
+++ b/test/testconfig.cpp
@@ -235,6 +235,87 @@ void testOptional() {
     FCITX_ASSERT(!*config2.optionalIntVectorValue);
 }
 
+void testImplicit() {
+    // Test isImplicitSelf and isImplicit on a simple node
+    {
+        RawConfig config;
+        config["A"].setValue("1");
+
+        FCITX_ASSERT(!config["A"].isImplicitSelf());
+        FCITX_ASSERT(!config["A"].isImplicit());
+
+        config["A"].setImplicit(true);
+        FCITX_ASSERT(config["A"].isImplicitSelf());
+        FCITX_ASSERT(config["A"].isImplicit());
+    }
+
+    // Test isImplicit with parent inheritance
+    {
+        RawConfig config;
+        config["A"]["B"].setValue("1");
+        config["A"]["C"].setValue("2");
+
+        // Initially, no implicit flags
+        FCITX_ASSERT(!config["A"].isImplicit());
+        FCITX_ASSERT(!config["A"]["B"].isImplicit());
+        FCITX_ASSERT(!config["A"]["C"].isImplicit());
+
+        // Set implicit on parent
+        config["A"].setImplicit(true);
+        FCITX_ASSERT(config["A"].isImplicitSelf());
+        FCITX_ASSERT(config["A"].isImplicit());
+
+        // Children inherit implicit from parent
+        FCITX_ASSERT(!config["A"]["B"].isImplicitSelf());
+        FCITX_ASSERT(config["A"]["B"].isImplicit());
+        FCITX_ASSERT(!config["A"]["C"].isImplicitSelf());
+        FCITX_ASSERT(config["A"]["C"].isImplicit());
+    }
+
+    // Test writeAsIni with implicit
+    {
+        RawConfig config;
+        config["A"]["B"].setValue("1");
+        config["A"]["C"].setValue("2");
+        config["D"]["E"].setValue("3");
+
+        // Set implicit on section A
+        config["A"].setImplicit(true);
+
+        std::stringstream ss;
+        writeAsIni(config, ss);
+        std::string output = ss.str();
+
+        // Section A should be commented out
+        FCITX_ASSERT(output.find("# [A]") != std::string::npos)
+            << "Section header should be commented: " << output;
+        FCITX_ASSERT(output.find("# B=1") != std::string::npos)
+            << "Value should be commented: " << output;
+        FCITX_ASSERT(output.find("# C=2") != std::string::npos)
+            << "Value should be commented: " << output;
+
+        // Section D should not be commented
+        FCITX_ASSERT(output.find("[D]") != std::string::npos)
+            << "Section header should not be commented: " << output;
+        FCITX_ASSERT(output.find("E=3") != std::string::npos)
+            << "Value should not be commented: " << output;
+    }
+
+    // Test copy preserves implicit flag
+    {
+        RawConfig config;
+        config["A"].setValue("1");
+        config["A"].setImplicit(true);
+
+        RawConfig copy(config);
+        FCITX_ASSERT(copy["A"].isImplicitSelf());
+
+        RawConfig assign;
+        assign = config;
+        FCITX_ASSERT(assign["A"].isImplicitSelf());
+    }
+}
+
 int main() {
     testBasics();
     testMove();
@@ -244,5 +325,6 @@ int main() {
     testExtend();
     testCopyConfiguration();
     testOptional();
+    testImplicit();
     return 0;
 }


### PR DESCRIPTION
- **Add isImplicit to allow comment the value when output**
- **If value is default, mark is as implicit**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “implicit” marking for configuration nodes, including new `RawConfig` APIs to set/query implicit state.
  * INI output now treats implicit entries as commented-out sections/values and prefixes inline comments accordingly.
* **Bug Fixes**
  * Default-valued sub-configurations are now correctly marked implicit when saving, rather than treated as active overrides.
* **Tests**
  * Updated INI round-trip expectations for defaulted options.
  * Added tests covering implicit behavior, parent inheritance, INI serialization output, and copy/paste preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->