### PR TITLE
Add wl_fixes.ack_global_remove support

### DIFF
--- a/src/lib/fcitx-wayland/core/CMakeLists.txt
+++ b/src/lib/fcitx-wayland/core/CMakeLists.txt
@@ -24,6 +24,10 @@ set(FCITX_WAYLAND_CORE_SOURCES
     wl_touch.cpp
 )
 
+if (Wayland_VERSION VERSION_GREATER_EQUAL 1.26)
+    list(APPEND FCITX_WAYLAND_CORE_SOURCES wl_fixes.cpp)
+endif()
+
 add_library(Fcitx5WaylandCore STATIC ${FCITX_WAYLAND_CORE_SOURCES})
 set_target_properties(Fcitx5WaylandCore PROPERTIES
   POSITION_INDEPENDENT_CODE ON

--- a/src/lib/fcitx-wayland/core/display.cpp
+++ b/src/lib/fcitx-wayland/core/display.cpp
@@ -49,7 +49,7 @@ Display::Display(wl_display *display) : display_(display) {
         });
     reg->globalRemove().connect([this](uint32_t name) {
 #if defined(WL_FIXES_ACK_GLOBAL_REMOVE)
-        auto fixes = this->getGlobal<wayland::WlFixes>();
+        std::shared_ptr<WlFixes> fixes = this->getGlobal<wayland::WlFixes>();
 #endif
         auto iter = globals_.find(name);
         if (iter != globals_.end()) {
@@ -64,13 +64,13 @@ Display::Display(wl_display *display) : display_(display) {
             if (localGlobalIter != requestedGlobals_.end()) {
                 localGlobalIter->second->erase(name);
             }
-            globals_.erase(iter);
 #if defined(WL_FIXES_ACK_GLOBAL_REMOVE)
             if (fixes && fixes->actualVersion() >=
                              WL_FIXES_ACK_GLOBAL_REMOVE_SINCE_VERSION) {
                 fixes->ackGlobalRemove(registry(), name);
             }
 #endif
+            globals_.erase(iter);
         }
     });
 

--- a/src/lib/fcitx-wayland/core/display.cpp
+++ b/src/lib/fcitx-wayland/core/display.cpp
@@ -14,6 +14,10 @@
 #include "wl_output.h"
 #include "wl_registry.h"
 
+#if defined(WL_FIXES_ACK_GLOBAL_REMOVE)
+#include "wl_fixes.h"
+#endif
+
 namespace fcitx::wayland {
 
 void Display::createGlobalHelper(
@@ -44,6 +48,9 @@ Display::Display(wl_display *display) : display_(display) {
             }
         });
     reg->globalRemove().connect([this](uint32_t name) {
+#if defined(WL_FIXES_ACK_GLOBAL_REMOVE)
+        auto fixes = this->getGlobal<wayland::WlFixes>();
+#endif
         auto iter = globals_.find(name);
         if (iter != globals_.end()) {
             const auto &globalObject =
@@ -58,6 +65,12 @@ Display::Display(wl_display *display) : display_(display) {
                 localGlobalIter->second->erase(name);
             }
             globals_.erase(iter);
+#if defined(WL_FIXES_ACK_GLOBAL_REMOVE)
+            if (fixes && fixes->actualVersion() >=
+                             WL_FIXES_ACK_GLOBAL_REMOVE_SINCE_VERSION) {
+                fixes->ackGlobalRemove(registry(), name);
+            }
+#endif
         }
     });
 
@@ -78,6 +91,9 @@ Display::Display(wl_display *display) : display_(display) {
         auto *output = static_cast<wayland::WlOutput *>(data.get());
         removeOutput(output);
     });
+#ifdef WL_FIXES_ACK_GLOBAL_REMOVE
+    requestGlobalsWithMinimalVersion<wayland::WlFixes>(2);
+#endif
 }
 
 Display::~Display() {}

--- a/src/lib/fcitx-wayland/core/wl_buffer.cpp
+++ b/src/lib/fcitx-wayland/core/wl_buffer.cpp
@@ -3,6 +3,7 @@
 
 namespace fcitx::wayland {
 const struct wl_buffer_listener WlBuffer::listener = {
+#if defined(WL_BUFFER_RELEASE_SINCE_VERSION)
     .release =
         [](void *data, wl_buffer *wldata) {
             auto *obj = static_cast<WlBuffer *>(data);
@@ -11,6 +12,7 @@ const struct wl_buffer_listener WlBuffer::listener = {
                 obj->release()();
             }
         },
+#endif
 };
 
 WlBuffer::WlBuffer(wl_buffer *data)

--- a/src/lib/fcitx-wayland/core/wl_callback.cpp
+++ b/src/lib/fcitx-wayland/core/wl_callback.cpp
@@ -3,6 +3,7 @@
 
 namespace fcitx::wayland {
 const struct wl_callback_listener WlCallback::listener = {
+#if defined(WL_CALLBACK_DONE_SINCE_VERSION)
     .done =
         [](void *data, wl_callback *wldata, uint32_t callbackData) {
             auto *obj = static_cast<WlCallback *>(data);
@@ -11,6 +12,7 @@ const struct wl_callback_listener WlCallback::listener = {
                 obj->done()(callbackData);
             }
         },
+#endif
 };
 
 WlCallback::WlCallback(wl_callback *data)

--- a/src/lib/fcitx-wayland/core/wl_compositor.cpp
+++ b/src/lib/fcitx-wayland/core/wl_compositor.cpp
@@ -10,6 +10,13 @@ WlCompositor::WlCompositor(wl_compositor *data)
 }
 
 void WlCompositor::destructor(wl_compositor *data) {
+    const auto version = wl_compositor_get_version(data);
+#if defined(WL_COMPOSITOR_RELEASE_SINCE_VERSION)
+    if (version >= 7) {
+        wl_compositor_release(data);
+        return;
+    }
+#endif
     wl_compositor_destroy(data);
 }
 WlSurface *WlCompositor::createSurface() {

--- a/src/lib/fcitx-wayland/core/wl_compositor.cpp
+++ b/src/lib/fcitx-wayland/core/wl_compositor.cpp
@@ -19,11 +19,15 @@ void WlCompositor::destructor(wl_compositor *data) {
 #endif
     wl_compositor_destroy(data);
 }
+#if defined(WL_COMPOSITOR_CREATE_SURFACE_SINCE_VERSION)
 WlSurface *WlCompositor::createSurface() {
     return new WlSurface(wl_compositor_create_surface(*this));
 }
+#endif
+#if defined(WL_COMPOSITOR_CREATE_REGION_SINCE_VERSION)
 WlRegion *WlCompositor::createRegion() {
     return new WlRegion(wl_compositor_create_region(*this));
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_compositor.h
+++ b/src/lib/fcitx-wayland/core/wl_compositor.h
@@ -14,7 +14,7 @@ public:
     static constexpr const char *interface = "wl_compositor";
     static constexpr const wl_interface *const wlInterface =
         &wl_compositor_interface;
-    static constexpr const uint32_t version = 6;
+    static constexpr const uint32_t version = 7;
     using wlType = wl_compositor;
     operator wl_compositor *() { return data_.get(); }
     WlCompositor(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_compositor.h
+++ b/src/lib/fcitx-wayland/core/wl_compositor.h
@@ -23,8 +23,12 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_COMPOSITOR_CREATE_SURFACE_SINCE_VERSION)
     WlSurface *createSurface();
+#endif
+#if defined(WL_COMPOSITOR_CREATE_REGION_SINCE_VERSION)
     WlRegion *createRegion();
+#endif
 
 private:
     static void destructor(wl_compositor *);

--- a/src/lib/fcitx-wayland/core/wl_data_device.cpp
+++ b/src/lib/fcitx-wayland/core/wl_data_device.cpp
@@ -6,6 +6,7 @@
 
 namespace fcitx::wayland {
 const struct wl_data_device_listener WlDataDevice::listener = {
+#if defined(WL_DATA_DEVICE_DATA_OFFER_SINCE_VERSION)
     .data_offer =
         [](void *data, wl_data_device *wldata, wl_data_offer *id) {
             auto *obj = static_cast<WlDataDevice *>(data);
@@ -15,6 +16,8 @@ const struct wl_data_device_listener WlDataDevice::listener = {
                 obj->dataOffer()(id_);
             }
         },
+#endif
+#if defined(WL_DATA_DEVICE_ENTER_SINCE_VERSION)
     .enter =
         [](void *data, wl_data_device *wldata, uint32_t serial,
            wl_surface *surface, wl_fixed_t x, wl_fixed_t y, wl_data_offer *id) {
@@ -32,6 +35,8 @@ const struct wl_data_device_listener WlDataDevice::listener = {
                 obj->enter()(serial, surface_, x, y, id_);
             }
         },
+#endif
+#if defined(WL_DATA_DEVICE_LEAVE_SINCE_VERSION)
     .leave =
         [](void *data, wl_data_device *wldata) {
             auto *obj = static_cast<WlDataDevice *>(data);
@@ -40,6 +45,8 @@ const struct wl_data_device_listener WlDataDevice::listener = {
                 obj->leave()();
             }
         },
+#endif
+#if defined(WL_DATA_DEVICE_MOTION_SINCE_VERSION)
     .motion =
         [](void *data, wl_data_device *wldata, uint32_t time, wl_fixed_t x,
            wl_fixed_t y) {
@@ -49,6 +56,8 @@ const struct wl_data_device_listener WlDataDevice::listener = {
                 obj->motion()(time, x, y);
             }
         },
+#endif
+#if defined(WL_DATA_DEVICE_DROP_SINCE_VERSION)
     .drop =
         [](void *data, wl_data_device *wldata) {
             auto *obj = static_cast<WlDataDevice *>(data);
@@ -57,6 +66,8 @@ const struct wl_data_device_listener WlDataDevice::listener = {
                 obj->drop()();
             }
         },
+#endif
+#if defined(WL_DATA_DEVICE_SELECTION_SINCE_VERSION)
     .selection =
         [](void *data, wl_data_device *wldata, wl_data_offer *id) {
             auto *obj = static_cast<WlDataDevice *>(data);
@@ -68,6 +79,7 @@ const struct wl_data_device_listener WlDataDevice::listener = {
                 obj->selection()(id_);
             }
         },
+#endif
 };
 
 WlDataDevice::WlDataDevice(wl_data_device *data)
@@ -86,13 +98,17 @@ void WlDataDevice::destructor(wl_data_device *data) {
 #endif
     wl_data_device_destroy(data);
 }
+#if defined(WL_DATA_DEVICE_START_DRAG_SINCE_VERSION)
 void WlDataDevice::startDrag(WlDataSource *source, WlSurface *origin,
                              WlSurface *icon, uint32_t serial) {
     wl_data_device_start_drag(*this, rawPointer(source), rawPointer(origin),
                               rawPointer(icon), serial);
 }
+#endif
+#if defined(WL_DATA_DEVICE_SET_SELECTION_SINCE_VERSION)
 void WlDataDevice::setSelection(WlDataSource *source, uint32_t serial) {
     wl_data_device_set_selection(*this, rawPointer(source), serial);
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_data_device.h
+++ b/src/lib/fcitx-wayland/core/wl_data_device.h
@@ -16,7 +16,7 @@ public:
     static constexpr const char *interface = "wl_data_device";
     static constexpr const wl_interface *const wlInterface =
         &wl_data_device_interface;
-    static constexpr const uint32_t version = 3;
+    static constexpr const uint32_t version = 4;
     using wlType = wl_data_device;
     operator wl_data_device *() { return data_.get(); }
     WlDataDevice(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_data_device.h
+++ b/src/lib/fcitx-wayland/core/wl_data_device.h
@@ -25,9 +25,13 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_DATA_DEVICE_START_DRAG_SINCE_VERSION)
     void startDrag(WlDataSource *source, WlSurface *origin, WlSurface *icon,
                    uint32_t serial);
+#endif
+#if defined(WL_DATA_DEVICE_SET_SELECTION_SINCE_VERSION)
     void setSelection(WlDataSource *source, uint32_t serial);
+#endif
 
     auto &dataOffer() { return dataOfferSignal_; }
     auto &enter() { return enterSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_data_device_manager.cpp
+++ b/src/lib/fcitx-wayland/core/wl_data_device_manager.cpp
@@ -20,12 +20,16 @@ void WlDataDeviceManager::destructor(wl_data_device_manager *data) {
 #endif
     wl_data_device_manager_destroy(data);
 }
+#if defined(WL_DATA_DEVICE_MANAGER_CREATE_DATA_SOURCE_SINCE_VERSION)
 WlDataSource *WlDataDeviceManager::createDataSource() {
     return new WlDataSource(wl_data_device_manager_create_data_source(*this));
 }
+#endif
+#if defined(WL_DATA_DEVICE_MANAGER_GET_DATA_DEVICE_SINCE_VERSION)
 WlDataDevice *WlDataDeviceManager::getDataDevice(WlSeat *seat) {
     return new WlDataDevice(
         wl_data_device_manager_get_data_device(*this, rawPointer(seat)));
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_data_device_manager.cpp
+++ b/src/lib/fcitx-wayland/core/wl_data_device_manager.cpp
@@ -11,6 +11,13 @@ WlDataDeviceManager::WlDataDeviceManager(wl_data_device_manager *data)
 }
 
 void WlDataDeviceManager::destructor(wl_data_device_manager *data) {
+    const auto version = wl_data_device_manager_get_version(data);
+#if defined(WL_DATA_DEVICE_MANAGER_RELEASE_SINCE_VERSION)
+    if (version >= 4) {
+        wl_data_device_manager_release(data);
+        return;
+    }
+#endif
     wl_data_device_manager_destroy(data);
 }
 WlDataSource *WlDataDeviceManager::createDataSource() {

--- a/src/lib/fcitx-wayland/core/wl_data_device_manager.h
+++ b/src/lib/fcitx-wayland/core/wl_data_device_manager.h
@@ -15,7 +15,7 @@ public:
     static constexpr const char *interface = "wl_data_device_manager";
     static constexpr const wl_interface *const wlInterface =
         &wl_data_device_manager_interface;
-    static constexpr const uint32_t version = 3;
+    static constexpr const uint32_t version = 4;
     using wlType = wl_data_device_manager;
     operator wl_data_device_manager *() { return data_.get(); }
     WlDataDeviceManager(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_data_device_manager.h
+++ b/src/lib/fcitx-wayland/core/wl_data_device_manager.h
@@ -25,8 +25,12 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_DATA_DEVICE_MANAGER_CREATE_DATA_SOURCE_SINCE_VERSION)
     WlDataSource *createDataSource();
+#endif
+#if defined(WL_DATA_DEVICE_MANAGER_GET_DATA_DEVICE_SINCE_VERSION)
     WlDataDevice *getDataDevice(WlSeat *seat);
+#endif
 
 private:
     static void destructor(wl_data_device_manager *);

--- a/src/lib/fcitx-wayland/core/wl_data_offer.cpp
+++ b/src/lib/fcitx-wayland/core/wl_data_offer.cpp
@@ -3,6 +3,7 @@
 
 namespace fcitx::wayland {
 const struct wl_data_offer_listener WlDataOffer::listener = {
+#if defined(WL_DATA_OFFER_OFFER_SINCE_VERSION)
     .offer =
         [](void *data, wl_data_offer *wldata, const char *mimeType) {
             auto *obj = static_cast<WlDataOffer *>(data);
@@ -11,6 +12,8 @@ const struct wl_data_offer_listener WlDataOffer::listener = {
                 obj->offer()(mimeType);
             }
         },
+#endif
+#if defined(WL_DATA_OFFER_SOURCE_ACTIONS_SINCE_VERSION)
     .source_actions =
         [](void *data, wl_data_offer *wldata, uint32_t sourceActions) {
             auto *obj = static_cast<WlDataOffer *>(data);
@@ -19,6 +22,8 @@ const struct wl_data_offer_listener WlDataOffer::listener = {
                 obj->sourceActions()(sourceActions);
             }
         },
+#endif
+#if defined(WL_DATA_OFFER_ACTION_SINCE_VERSION)
     .action =
         [](void *data, wl_data_offer *wldata, uint32_t dndAction) {
             auto *obj = static_cast<WlDataOffer *>(data);
@@ -27,6 +32,7 @@ const struct wl_data_offer_listener WlDataOffer::listener = {
                 obj->action()(dndAction);
             }
         },
+#endif
 };
 
 WlDataOffer::WlDataOffer(wl_data_offer *data)
@@ -38,15 +44,23 @@ WlDataOffer::WlDataOffer(wl_data_offer *data)
 void WlDataOffer::destructor(wl_data_offer *data) {
     wl_data_offer_destroy(data);
 }
+#if defined(WL_DATA_OFFER_ACCEPT_SINCE_VERSION)
 void WlDataOffer::accept(uint32_t serial, const char *mimeType) {
     wl_data_offer_accept(*this, serial, mimeType);
 }
+#endif
+#if defined(WL_DATA_OFFER_RECEIVE_SINCE_VERSION)
 void WlDataOffer::receive(const char *mimeType, int32_t fd) {
     wl_data_offer_receive(*this, mimeType, fd);
 }
+#endif
+#if defined(WL_DATA_OFFER_FINISH_SINCE_VERSION)
 void WlDataOffer::finish() { wl_data_offer_finish(*this); }
+#endif
+#if defined(WL_DATA_OFFER_SET_ACTIONS_SINCE_VERSION)
 void WlDataOffer::setActions(uint32_t dndActions, uint32_t preferredAction) {
     wl_data_offer_set_actions(*this, dndActions, preferredAction);
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_data_offer.h
+++ b/src/lib/fcitx-wayland/core/wl_data_offer.h
@@ -21,10 +21,18 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_DATA_OFFER_ACCEPT_SINCE_VERSION)
     void accept(uint32_t serial, const char *mimeType);
+#endif
+#if defined(WL_DATA_OFFER_RECEIVE_SINCE_VERSION)
     void receive(const char *mimeType, int32_t fd);
+#endif
+#if defined(WL_DATA_OFFER_FINISH_SINCE_VERSION)
     void finish();
+#endif
+#if defined(WL_DATA_OFFER_SET_ACTIONS_SINCE_VERSION)
     void setActions(uint32_t dndActions, uint32_t preferredAction);
+#endif
 
     auto &offer() { return offerSignal_; }
     auto &sourceActions() { return sourceActionsSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_data_offer.h
+++ b/src/lib/fcitx-wayland/core/wl_data_offer.h
@@ -12,7 +12,7 @@ public:
     static constexpr const char *interface = "wl_data_offer";
     static constexpr const wl_interface *const wlInterface =
         &wl_data_offer_interface;
-    static constexpr const uint32_t version = 3;
+    static constexpr const uint32_t version = 4;
     using wlType = wl_data_offer;
     operator wl_data_offer *() { return data_.get(); }
     WlDataOffer(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_data_source.cpp
+++ b/src/lib/fcitx-wayland/core/wl_data_source.cpp
@@ -3,6 +3,7 @@
 
 namespace fcitx::wayland {
 const struct wl_data_source_listener WlDataSource::listener = {
+#if defined(WL_DATA_SOURCE_TARGET_SINCE_VERSION)
     .target =
         [](void *data, wl_data_source *wldata, const char *mimeType) {
             auto *obj = static_cast<WlDataSource *>(data);
@@ -11,6 +12,8 @@ const struct wl_data_source_listener WlDataSource::listener = {
                 obj->target()(mimeType);
             }
         },
+#endif
+#if defined(WL_DATA_SOURCE_SEND_SINCE_VERSION)
     .send =
         [](void *data, wl_data_source *wldata, const char *mimeType,
            int32_t fd) {
@@ -20,6 +23,8 @@ const struct wl_data_source_listener WlDataSource::listener = {
                 obj->send()(mimeType, fd);
             }
         },
+#endif
+#if defined(WL_DATA_SOURCE_CANCELLED_SINCE_VERSION)
     .cancelled =
         [](void *data, wl_data_source *wldata) {
             auto *obj = static_cast<WlDataSource *>(data);
@@ -28,6 +33,8 @@ const struct wl_data_source_listener WlDataSource::listener = {
                 obj->cancelled()();
             }
         },
+#endif
+#if defined(WL_DATA_SOURCE_DND_DROP_PERFORMED_SINCE_VERSION)
     .dnd_drop_performed =
         [](void *data, wl_data_source *wldata) {
             auto *obj = static_cast<WlDataSource *>(data);
@@ -36,6 +43,8 @@ const struct wl_data_source_listener WlDataSource::listener = {
                 obj->dndDropPerformed()();
             }
         },
+#endif
+#if defined(WL_DATA_SOURCE_DND_FINISHED_SINCE_VERSION)
     .dnd_finished =
         [](void *data, wl_data_source *wldata) {
             auto *obj = static_cast<WlDataSource *>(data);
@@ -44,6 +53,8 @@ const struct wl_data_source_listener WlDataSource::listener = {
                 obj->dndFinished()();
             }
         },
+#endif
+#if defined(WL_DATA_SOURCE_ACTION_SINCE_VERSION)
     .action =
         [](void *data, wl_data_source *wldata, uint32_t dndAction) {
             auto *obj = static_cast<WlDataSource *>(data);
@@ -52,6 +63,7 @@ const struct wl_data_source_listener WlDataSource::listener = {
                 obj->action()(dndAction);
             }
         },
+#endif
 };
 
 WlDataSource::WlDataSource(wl_data_source *data)
@@ -63,11 +75,15 @@ WlDataSource::WlDataSource(wl_data_source *data)
 void WlDataSource::destructor(wl_data_source *data) {
     wl_data_source_destroy(data);
 }
+#if defined(WL_DATA_SOURCE_OFFER_SINCE_VERSION)
 void WlDataSource::offer(const char *mimeType) {
     wl_data_source_offer(*this, mimeType);
 }
+#endif
+#if defined(WL_DATA_SOURCE_SET_ACTIONS_SINCE_VERSION)
 void WlDataSource::setActions(uint32_t dndActions) {
     wl_data_source_set_actions(*this, dndActions);
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_data_source.h
+++ b/src/lib/fcitx-wayland/core/wl_data_source.h
@@ -21,8 +21,12 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_DATA_SOURCE_OFFER_SINCE_VERSION)
     void offer(const char *mimeType);
+#endif
+#if defined(WL_DATA_SOURCE_SET_ACTIONS_SINCE_VERSION)
     void setActions(uint32_t dndActions);
+#endif
 
     auto &target() { return targetSignal_; }
     auto &send() { return sendSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_data_source.h
+++ b/src/lib/fcitx-wayland/core/wl_data_source.h
@@ -12,7 +12,7 @@ public:
     static constexpr const char *interface = "wl_data_source";
     static constexpr const wl_interface *const wlInterface =
         &wl_data_source_interface;
-    static constexpr const uint32_t version = 3;
+    static constexpr const uint32_t version = 4;
     using wlType = wl_data_source;
     operator wl_data_source *() { return data_.get(); }
     WlDataSource(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_fixes.cpp
+++ b/src/lib/fcitx-wayland/core/wl_fixes.cpp
@@ -1,0 +1,19 @@
+#include "wl_fixes.h"
+#include "wl_registry.h"
+
+namespace fcitx::wayland {
+
+WlFixes::WlFixes(wl_fixes *data)
+    : version_(wl_fixes_get_version(data)), data_(data) {
+    wl_fixes_set_user_data(*this, this);
+}
+
+void WlFixes::destructor(wl_fixes *data) { wl_fixes_destroy(data); }
+void WlFixes::destroyRegistry(WlRegistry *registry) {
+    wl_fixes_destroy_registry(*this, rawPointer(registry));
+}
+void WlFixes::ackGlobalRemove(WlRegistry *registry, uint32_t name) {
+    wl_fixes_ack_global_remove(*this, rawPointer(registry), name);
+}
+
+} // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_fixes.cpp
+++ b/src/lib/fcitx-wayland/core/wl_fixes.cpp
@@ -9,11 +9,15 @@ WlFixes::WlFixes(wl_fixes *data)
 }
 
 void WlFixes::destructor(wl_fixes *data) { wl_fixes_destroy(data); }
+#if defined(WL_FIXES_DESTROY_REGISTRY_SINCE_VERSION)
 void WlFixes::destroyRegistry(WlRegistry *registry) {
     wl_fixes_destroy_registry(*this, rawPointer(registry));
 }
+#endif
+#if defined(WL_FIXES_ACK_GLOBAL_REMOVE_SINCE_VERSION)
 void WlFixes::ackGlobalRemove(WlRegistry *registry, uint32_t name) {
     wl_fixes_ack_global_remove(*this, rawPointer(registry), name);
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_fixes.h
+++ b/src/lib/fcitx-wayland/core/wl_fixes.h
@@ -1,0 +1,41 @@
+#ifndef WL_FIXES_H_
+#define WL_FIXES_H_
+#include <cstdint>
+#include <wayland-client.h>
+#include <wayland-util.h>
+#include "fcitx-utils/misc.h"
+namespace fcitx::wayland {
+
+class WlRegistry;
+
+class WlFixes final {
+public:
+    static constexpr const char *interface = "wl_fixes";
+    static constexpr const wl_interface *const wlInterface =
+        &wl_fixes_interface;
+    static constexpr const uint32_t version = 2;
+    using wlType = wl_fixes;
+    operator wl_fixes *() { return data_.get(); }
+    WlFixes(wlType *data);
+    WlFixes(WlFixes &&other) noexcept = delete;
+    WlFixes &operator=(WlFixes &&other) noexcept = delete;
+    auto actualVersion() const { return version_; }
+    void *userData() const { return userData_; }
+    void setUserData(void *userData) { userData_ = userData; }
+    void destroyRegistry(WlRegistry *registry);
+    void ackGlobalRemove(WlRegistry *registry, uint32_t name);
+
+private:
+    static void destructor(wl_fixes *);
+
+    uint32_t version_;
+    void *userData_ = nullptr;
+    UniqueCPtr<wl_fixes, &destructor> data_;
+};
+static inline wl_fixes *rawPointer(WlFixes *p) {
+    return p ? static_cast<wl_fixes *>(*p) : nullptr;
+}
+
+} // namespace fcitx::wayland
+
+#endif // WL_FIXES_H_

--- a/src/lib/fcitx-wayland/core/wl_fixes.h
+++ b/src/lib/fcitx-wayland/core/wl_fixes.h
@@ -22,8 +22,12 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_FIXES_DESTROY_REGISTRY_SINCE_VERSION)
     void destroyRegistry(WlRegistry *registry);
+#endif
+#if defined(WL_FIXES_ACK_GLOBAL_REMOVE_SINCE_VERSION)
     void ackGlobalRemove(WlRegistry *registry, uint32_t name);
+#endif
 
 private:
     static void destructor(wl_fixes *);

--- a/src/lib/fcitx-wayland/core/wl_keyboard.cpp
+++ b/src/lib/fcitx-wayland/core/wl_keyboard.cpp
@@ -4,6 +4,7 @@
 
 namespace fcitx::wayland {
 const struct wl_keyboard_listener WlKeyboard::listener = {
+#if defined(WL_KEYBOARD_KEYMAP_SINCE_VERSION)
     .keymap =
         [](void *data, wl_keyboard *wldata, uint32_t format, int32_t fd,
            uint32_t size) {
@@ -13,6 +14,8 @@ const struct wl_keyboard_listener WlKeyboard::listener = {
                 obj->keymap()(format, fd, size);
             }
         },
+#endif
+#if defined(WL_KEYBOARD_ENTER_SINCE_VERSION)
     .enter =
         [](void *data, wl_keyboard *wldata, uint32_t serial,
            wl_surface *surface, wl_array *keys) {
@@ -27,6 +30,8 @@ const struct wl_keyboard_listener WlKeyboard::listener = {
                 obj->enter()(serial, surface_, keys);
             }
         },
+#endif
+#if defined(WL_KEYBOARD_LEAVE_SINCE_VERSION)
     .leave =
         [](void *data, wl_keyboard *wldata, uint32_t serial,
            wl_surface *surface) {
@@ -41,6 +46,8 @@ const struct wl_keyboard_listener WlKeyboard::listener = {
                 obj->leave()(serial, surface_);
             }
         },
+#endif
+#if defined(WL_KEYBOARD_KEY_SINCE_VERSION)
     .key =
         [](void *data, wl_keyboard *wldata, uint32_t serial, uint32_t time,
            uint32_t key, uint32_t state) {
@@ -50,6 +57,8 @@ const struct wl_keyboard_listener WlKeyboard::listener = {
                 obj->key()(serial, time, key, state);
             }
         },
+#endif
+#if defined(WL_KEYBOARD_MODIFIERS_SINCE_VERSION)
     .modifiers =
         [](void *data, wl_keyboard *wldata, uint32_t serial,
            uint32_t modsDepressed, uint32_t modsLatched, uint32_t modsLocked,
@@ -61,6 +70,8 @@ const struct wl_keyboard_listener WlKeyboard::listener = {
                                  group);
             }
         },
+#endif
+#if defined(WL_KEYBOARD_REPEAT_INFO_SINCE_VERSION)
     .repeat_info =
         [](void *data, wl_keyboard *wldata, int32_t rate, int32_t delay) {
             auto *obj = static_cast<WlKeyboard *>(data);
@@ -69,6 +80,7 @@ const struct wl_keyboard_listener WlKeyboard::listener = {
                 obj->repeatInfo()(rate, delay);
             }
         },
+#endif
 };
 
 WlKeyboard::WlKeyboard(wl_keyboard *data)

--- a/src/lib/fcitx-wayland/core/wl_keyboard.h
+++ b/src/lib/fcitx-wayland/core/wl_keyboard.h
@@ -14,7 +14,7 @@ public:
     static constexpr const char *interface = "wl_keyboard";
     static constexpr const wl_interface *const wlInterface =
         &wl_keyboard_interface;
-    static constexpr const uint32_t version = 10;
+    static constexpr const uint32_t version = 11;
     using wlType = wl_keyboard;
     operator wl_keyboard *() { return data_.get(); }
     WlKeyboard(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_output.cpp
+++ b/src/lib/fcitx-wayland/core/wl_output.cpp
@@ -3,6 +3,7 @@
 
 namespace fcitx::wayland {
 const struct wl_output_listener WlOutput::listener = {
+#if defined(WL_OUTPUT_GEOMETRY_SINCE_VERSION)
     .geometry =
         [](void *data, wl_output *wldata, int32_t x, int32_t y,
            int32_t physicalWidth, int32_t physicalHeight, int32_t subpixel,
@@ -14,6 +15,8 @@ const struct wl_output_listener WlOutput::listener = {
                                 make, model, transform);
             }
         },
+#endif
+#if defined(WL_OUTPUT_MODE_SINCE_VERSION)
     .mode =
         [](void *data, wl_output *wldata, uint32_t flags, int32_t width,
            int32_t height, int32_t refresh) {
@@ -23,6 +26,8 @@ const struct wl_output_listener WlOutput::listener = {
                 obj->mode()(flags, width, height, refresh);
             }
         },
+#endif
+#if defined(WL_OUTPUT_DONE_SINCE_VERSION)
     .done =
         [](void *data, wl_output *wldata) {
             auto *obj = static_cast<WlOutput *>(data);
@@ -31,6 +36,8 @@ const struct wl_output_listener WlOutput::listener = {
                 obj->done()();
             }
         },
+#endif
+#if defined(WL_OUTPUT_SCALE_SINCE_VERSION)
     .scale =
         [](void *data, wl_output *wldata, int32_t factor) {
             auto *obj = static_cast<WlOutput *>(data);
@@ -39,6 +46,8 @@ const struct wl_output_listener WlOutput::listener = {
                 obj->scale()(factor);
             }
         },
+#endif
+#if defined(WL_OUTPUT_NAME_SINCE_VERSION)
     .name =
         [](void *data, wl_output *wldata, const char *name) {
             auto *obj = static_cast<WlOutput *>(data);
@@ -47,6 +56,8 @@ const struct wl_output_listener WlOutput::listener = {
                 obj->name()(name);
             }
         },
+#endif
+#if defined(WL_OUTPUT_DESCRIPTION_SINCE_VERSION)
     .description =
         [](void *data, wl_output *wldata, const char *description) {
             auto *obj = static_cast<WlOutput *>(data);
@@ -55,6 +66,7 @@ const struct wl_output_listener WlOutput::listener = {
                 obj->description()(description);
             }
         },
+#endif
 };
 
 WlOutput::WlOutput(wl_output *data)

--- a/src/lib/fcitx-wayland/core/wl_pointer.cpp
+++ b/src/lib/fcitx-wayland/core/wl_pointer.cpp
@@ -107,6 +107,15 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->axisRelativeDirection()(axis, direction);
             }
         },
+    .warp =
+        [](void *data, wl_pointer *wldata, wl_fixed_t surfaceX,
+           wl_fixed_t surfaceY) {
+            auto *obj = static_cast<WlPointer *>(data);
+            assert(*obj == wldata);
+            {
+                obj->warp()(surfaceX, surfaceY);
+            }
+        },
 };
 
 WlPointer::WlPointer(wl_pointer *data)

--- a/src/lib/fcitx-wayland/core/wl_pointer.cpp
+++ b/src/lib/fcitx-wayland/core/wl_pointer.cpp
@@ -4,6 +4,7 @@
 
 namespace fcitx::wayland {
 const struct wl_pointer_listener WlPointer::listener = {
+#if defined(WL_POINTER_ENTER_SINCE_VERSION)
     .enter =
         [](void *data, wl_pointer *wldata, uint32_t serial, wl_surface *surface,
            wl_fixed_t surfaceX, wl_fixed_t surfaceY) {
@@ -18,6 +19,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->enter()(serial, surface_, surfaceX, surfaceY);
             }
         },
+#endif
+#if defined(WL_POINTER_LEAVE_SINCE_VERSION)
     .leave =
         [](void *data, wl_pointer *wldata, uint32_t serial,
            wl_surface *surface) {
@@ -32,6 +35,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->leave()(serial, surface_);
             }
         },
+#endif
+#if defined(WL_POINTER_MOTION_SINCE_VERSION)
     .motion =
         [](void *data, wl_pointer *wldata, uint32_t time, wl_fixed_t surfaceX,
            wl_fixed_t surfaceY) {
@@ -41,6 +46,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->motion()(time, surfaceX, surfaceY);
             }
         },
+#endif
+#if defined(WL_POINTER_BUTTON_SINCE_VERSION)
     .button =
         [](void *data, wl_pointer *wldata, uint32_t serial, uint32_t time,
            uint32_t button, uint32_t state) {
@@ -50,6 +57,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->button()(serial, time, button, state);
             }
         },
+#endif
+#if defined(WL_POINTER_AXIS_SINCE_VERSION)
     .axis =
         [](void *data, wl_pointer *wldata, uint32_t time, uint32_t axis,
            wl_fixed_t value) {
@@ -59,6 +68,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->axis()(time, axis, value);
             }
         },
+#endif
+#if defined(WL_POINTER_FRAME_SINCE_VERSION)
     .frame =
         [](void *data, wl_pointer *wldata) {
             auto *obj = static_cast<WlPointer *>(data);
@@ -67,6 +78,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->frame()();
             }
         },
+#endif
+#if defined(WL_POINTER_AXIS_SOURCE_SINCE_VERSION)
     .axis_source =
         [](void *data, wl_pointer *wldata, uint32_t axisSource) {
             auto *obj = static_cast<WlPointer *>(data);
@@ -75,6 +88,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->axisSource()(axisSource);
             }
         },
+#endif
+#if defined(WL_POINTER_AXIS_STOP_SINCE_VERSION)
     .axis_stop =
         [](void *data, wl_pointer *wldata, uint32_t time, uint32_t axis) {
             auto *obj = static_cast<WlPointer *>(data);
@@ -83,6 +98,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->axisStop()(time, axis);
             }
         },
+#endif
+#if defined(WL_POINTER_AXIS_DISCRETE_SINCE_VERSION)
     .axis_discrete =
         [](void *data, wl_pointer *wldata, uint32_t axis, int32_t discrete) {
             auto *obj = static_cast<WlPointer *>(data);
@@ -91,6 +108,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->axisDiscrete()(axis, discrete);
             }
         },
+#endif
+#if defined(WL_POINTER_AXIS_VALUE120_SINCE_VERSION)
     .axis_value120 =
         [](void *data, wl_pointer *wldata, uint32_t axis, int32_t value120) {
             auto *obj = static_cast<WlPointer *>(data);
@@ -99,6 +118,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->axisValue120()(axis, value120);
             }
         },
+#endif
+#if defined(WL_POINTER_AXIS_RELATIVE_DIRECTION_SINCE_VERSION)
     .axis_relative_direction =
         [](void *data, wl_pointer *wldata, uint32_t axis, uint32_t direction) {
             auto *obj = static_cast<WlPointer *>(data);
@@ -107,6 +128,8 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->axisRelativeDirection()(axis, direction);
             }
         },
+#endif
+#if defined(WL_POINTER_WARP_SINCE_VERSION)
     .warp =
         [](void *data, wl_pointer *wldata, wl_fixed_t surfaceX,
            wl_fixed_t surfaceY) {
@@ -116,6 +139,7 @@ const struct wl_pointer_listener WlPointer::listener = {
                 obj->warp()(surfaceX, surfaceY);
             }
         },
+#endif
 };
 
 WlPointer::WlPointer(wl_pointer *data)
@@ -134,10 +158,12 @@ void WlPointer::destructor(wl_pointer *data) {
 #endif
     wl_pointer_destroy(data);
 }
+#if defined(WL_POINTER_SET_CURSOR_SINCE_VERSION)
 void WlPointer::setCursor(uint32_t serial, WlSurface *surface, int32_t hotspotX,
                           int32_t hotspotY) {
     wl_pointer_set_cursor(*this, serial, rawPointer(surface), hotspotX,
                           hotspotY);
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_pointer.h
+++ b/src/lib/fcitx-wayland/core/wl_pointer.h
@@ -14,7 +14,7 @@ public:
     static constexpr const char *interface = "wl_pointer";
     static constexpr const wl_interface *const wlInterface =
         &wl_pointer_interface;
-    static constexpr const uint32_t version = 10;
+    static constexpr const uint32_t version = 11;
     using wlType = wl_pointer;
     operator wl_pointer *() { return data_.get(); }
     WlPointer(wlType *data);
@@ -37,6 +37,7 @@ public:
     auto &axisDiscrete() { return axisDiscreteSignal_; }
     auto &axisValue120() { return axisValue120Signal_; }
     auto &axisRelativeDirection() { return axisRelativeDirectionSignal_; }
+    auto &warp() { return warpSignal_; }
 
 private:
     static void destructor(wl_pointer *);
@@ -53,6 +54,7 @@ private:
     fcitx::Signal<void(uint32_t, int32_t)> axisDiscreteSignal_;
     fcitx::Signal<void(uint32_t, int32_t)> axisValue120Signal_;
     fcitx::Signal<void(uint32_t, uint32_t)> axisRelativeDirectionSignal_;
+    fcitx::Signal<void(wl_fixed_t, wl_fixed_t)> warpSignal_;
 
     uint32_t version_;
     void *userData_ = nullptr;

--- a/src/lib/fcitx-wayland/core/wl_pointer.h
+++ b/src/lib/fcitx-wayland/core/wl_pointer.h
@@ -23,8 +23,10 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_POINTER_SET_CURSOR_SINCE_VERSION)
     void setCursor(uint32_t serial, WlSurface *surface, int32_t hotspotX,
                    int32_t hotspotY);
+#endif
 
     auto &enter() { return enterSignal_; }
     auto &leave() { return leaveSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_region.cpp
+++ b/src/lib/fcitx-wayland/core/wl_region.cpp
@@ -8,11 +8,15 @@ WlRegion::WlRegion(wl_region *data)
 }
 
 void WlRegion::destructor(wl_region *data) { wl_region_destroy(data); }
+#if defined(WL_REGION_ADD_SINCE_VERSION)
 void WlRegion::add(int32_t x, int32_t y, int32_t width, int32_t height) {
     wl_region_add(*this, x, y, width, height);
 }
+#endif
+#if defined(WL_REGION_SUBTRACT_SINCE_VERSION)
 void WlRegion::subtract(int32_t x, int32_t y, int32_t width, int32_t height) {
     wl_region_subtract(*this, x, y, width, height);
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_region.h
+++ b/src/lib/fcitx-wayland/core/wl_region.h
@@ -11,7 +11,7 @@ public:
     static constexpr const char *interface = "wl_region";
     static constexpr const wl_interface *const wlInterface =
         &wl_region_interface;
-    static constexpr const uint32_t version = 1;
+    static constexpr const uint32_t version = 7;
     using wlType = wl_region;
     operator wl_region *() { return data_.get(); }
     WlRegion(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_region.h
+++ b/src/lib/fcitx-wayland/core/wl_region.h
@@ -20,8 +20,12 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_REGION_ADD_SINCE_VERSION)
     void add(int32_t x, int32_t y, int32_t width, int32_t height);
+#endif
+#if defined(WL_REGION_SUBTRACT_SINCE_VERSION)
     void subtract(int32_t x, int32_t y, int32_t width, int32_t height);
+#endif
 
 private:
     static void destructor(wl_region *);

--- a/src/lib/fcitx-wayland/core/wl_registry.cpp
+++ b/src/lib/fcitx-wayland/core/wl_registry.cpp
@@ -3,6 +3,7 @@
 
 namespace fcitx::wayland {
 const struct wl_registry_listener WlRegistry::listener = {
+#if defined(WL_REGISTRY_GLOBAL_SINCE_VERSION)
     .global =
         [](void *data, wl_registry *wldata, uint32_t name,
            const char *interface, uint32_t version) {
@@ -12,6 +13,8 @@ const struct wl_registry_listener WlRegistry::listener = {
                 obj->global()(name, interface, version);
             }
         },
+#endif
+#if defined(WL_REGISTRY_GLOBAL_REMOVE_SINCE_VERSION)
     .global_remove =
         [](void *data, wl_registry *wldata, uint32_t name) {
             auto *obj = static_cast<WlRegistry *>(data);
@@ -20,6 +23,7 @@ const struct wl_registry_listener WlRegistry::listener = {
                 obj->globalRemove()(name);
             }
         },
+#endif
 };
 
 WlRegistry::WlRegistry(wl_registry *data)

--- a/src/lib/fcitx-wayland/core/wl_registry.h
+++ b/src/lib/fcitx-wayland/core/wl_registry.h
@@ -21,12 +21,14 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_REGISTRY_BIND_SINCE_VERSION)
 
     template <typename T>
     T *bind(uint32_t name, uint32_t requested_version) {
         return new T(static_cast<typename T::wlType *>(
             wl_registry_bind(*this, name, T::wlInterface, requested_version)));
     }
+#endif
 
     auto &global() { return globalSignal_; }
     auto &globalRemove() { return globalRemoveSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_seat.cpp
+++ b/src/lib/fcitx-wayland/core/wl_seat.cpp
@@ -6,6 +6,7 @@
 
 namespace fcitx::wayland {
 const struct wl_seat_listener WlSeat::listener = {
+#if defined(WL_SEAT_CAPABILITIES_SINCE_VERSION)
     .capabilities =
         [](void *data, wl_seat *wldata, uint32_t capabilities) {
             auto *obj = static_cast<WlSeat *>(data);
@@ -14,6 +15,8 @@ const struct wl_seat_listener WlSeat::listener = {
                 obj->capabilities()(capabilities);
             }
         },
+#endif
+#if defined(WL_SEAT_NAME_SINCE_VERSION)
     .name =
         [](void *data, wl_seat *wldata, const char *name) {
             auto *obj = static_cast<WlSeat *>(data);
@@ -22,6 +25,7 @@ const struct wl_seat_listener WlSeat::listener = {
                 obj->name()(name);
             }
         },
+#endif
 };
 
 WlSeat::WlSeat(wl_seat *data)
@@ -40,12 +44,18 @@ void WlSeat::destructor(wl_seat *data) {
 #endif
     wl_seat_destroy(data);
 }
+#if defined(WL_SEAT_GET_POINTER_SINCE_VERSION)
 WlPointer *WlSeat::getPointer() {
     return new WlPointer(wl_seat_get_pointer(*this));
 }
+#endif
+#if defined(WL_SEAT_GET_KEYBOARD_SINCE_VERSION)
 WlKeyboard *WlSeat::getKeyboard() {
     return new WlKeyboard(wl_seat_get_keyboard(*this));
 }
+#endif
+#if defined(WL_SEAT_GET_TOUCH_SINCE_VERSION)
 WlTouch *WlSeat::getTouch() { return new WlTouch(wl_seat_get_touch(*this)); }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_seat.h
+++ b/src/lib/fcitx-wayland/core/wl_seat.h
@@ -24,9 +24,15 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_SEAT_GET_POINTER_SINCE_VERSION)
     WlPointer *getPointer();
+#endif
+#if defined(WL_SEAT_GET_KEYBOARD_SINCE_VERSION)
     WlKeyboard *getKeyboard();
+#endif
+#if defined(WL_SEAT_GET_TOUCH_SINCE_VERSION)
     WlTouch *getTouch();
+#endif
 
     auto &capabilities() { return capabilitiesSignal_; }
     auto &name() { return nameSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_seat.h
+++ b/src/lib/fcitx-wayland/core/wl_seat.h
@@ -15,7 +15,7 @@ class WlSeat final {
 public:
     static constexpr const char *interface = "wl_seat";
     static constexpr const wl_interface *const wlInterface = &wl_seat_interface;
-    static constexpr const uint32_t version = 10;
+    static constexpr const uint32_t version = 11;
     using wlType = wl_seat;
     operator wl_seat *() { return data_.get(); }
     WlSeat(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_shell.cpp
+++ b/src/lib/fcitx-wayland/core/wl_shell.cpp
@@ -10,9 +10,11 @@ WlShell::WlShell(wl_shell *data)
 }
 
 void WlShell::destructor(wl_shell *data) { wl_shell_destroy(data); }
+#if defined(WL_SHELL_GET_SHELL_SURFACE_SINCE_VERSION)
 WlShellSurface *WlShell::getShellSurface(WlSurface *surface) {
     return new WlShellSurface(
         wl_shell_get_shell_surface(*this, rawPointer(surface)));
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_shell.h
+++ b/src/lib/fcitx-wayland/core/wl_shell.h
@@ -23,7 +23,9 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_SHELL_GET_SHELL_SURFACE_SINCE_VERSION)
     WlShellSurface *getShellSurface(WlSurface *surface);
+#endif
 
 private:
     static void destructor(wl_shell *);

--- a/src/lib/fcitx-wayland/core/wl_shell_surface.cpp
+++ b/src/lib/fcitx-wayland/core/wl_shell_surface.cpp
@@ -6,6 +6,7 @@
 
 namespace fcitx::wayland {
 const struct wl_shell_surface_listener WlShellSurface::listener = {
+#if defined(WL_SHELL_SURFACE_PING_SINCE_VERSION)
     .ping =
         [](void *data, wl_shell_surface *wldata, uint32_t serial) {
             auto *obj = static_cast<WlShellSurface *>(data);
@@ -14,6 +15,8 @@ const struct wl_shell_surface_listener WlShellSurface::listener = {
                 obj->ping()(serial);
             }
         },
+#endif
+#if defined(WL_SHELL_SURFACE_CONFIGURE_SINCE_VERSION)
     .configure =
         [](void *data, wl_shell_surface *wldata, uint32_t edges, int32_t width,
            int32_t height) {
@@ -23,6 +26,8 @@ const struct wl_shell_surface_listener WlShellSurface::listener = {
                 obj->configure()(edges, width, height);
             }
         },
+#endif
+#if defined(WL_SHELL_SURFACE_POPUP_DONE_SINCE_VERSION)
     .popup_done =
         [](void *data, wl_shell_surface *wldata) {
             auto *obj = static_cast<WlShellSurface *>(data);
@@ -31,6 +36,7 @@ const struct wl_shell_surface_listener WlShellSurface::listener = {
                 obj->popupDone()();
             }
         },
+#endif
 };
 
 WlShellSurface::WlShellSurface(wl_shell_surface *data)
@@ -42,38 +48,58 @@ WlShellSurface::WlShellSurface(wl_shell_surface *data)
 void WlShellSurface::destructor(wl_shell_surface *data) {
     wl_shell_surface_destroy(data);
 }
+#if defined(WL_SHELL_SURFACE_PONG_SINCE_VERSION)
 void WlShellSurface::pong(uint32_t serial) {
     wl_shell_surface_pong(*this, serial);
 }
+#endif
+#if defined(WL_SHELL_SURFACE_MOVE_SINCE_VERSION)
 void WlShellSurface::move(WlSeat *seat, uint32_t serial) {
     wl_shell_surface_move(*this, rawPointer(seat), serial);
 }
+#endif
+#if defined(WL_SHELL_SURFACE_RESIZE_SINCE_VERSION)
 void WlShellSurface::resize(WlSeat *seat, uint32_t serial, uint32_t edges) {
     wl_shell_surface_resize(*this, rawPointer(seat), serial, edges);
 }
+#endif
+#if defined(WL_SHELL_SURFACE_SET_TOPLEVEL_SINCE_VERSION)
 void WlShellSurface::setToplevel() { wl_shell_surface_set_toplevel(*this); }
+#endif
+#if defined(WL_SHELL_SURFACE_SET_TRANSIENT_SINCE_VERSION)
 void WlShellSurface::setTransient(WlSurface *parent, int32_t x, int32_t y,
                                   uint32_t flags) {
     wl_shell_surface_set_transient(*this, rawPointer(parent), x, y, flags);
 }
+#endif
+#if defined(WL_SHELL_SURFACE_SET_FULLSCREEN_SINCE_VERSION)
 void WlShellSurface::setFullscreen(uint32_t method, uint32_t framerate,
                                    WlOutput *output) {
     wl_shell_surface_set_fullscreen(*this, method, framerate,
                                     rawPointer(output));
 }
+#endif
+#if defined(WL_SHELL_SURFACE_SET_POPUP_SINCE_VERSION)
 void WlShellSurface::setPopup(WlSeat *seat, uint32_t serial, WlSurface *parent,
                               int32_t x, int32_t y, uint32_t flags) {
     wl_shell_surface_set_popup(*this, rawPointer(seat), serial,
                                rawPointer(parent), x, y, flags);
 }
+#endif
+#if defined(WL_SHELL_SURFACE_SET_MAXIMIZED_SINCE_VERSION)
 void WlShellSurface::setMaximized(WlOutput *output) {
     wl_shell_surface_set_maximized(*this, rawPointer(output));
 }
+#endif
+#if defined(WL_SHELL_SURFACE_SET_TITLE_SINCE_VERSION)
 void WlShellSurface::setTitle(const char *title) {
     wl_shell_surface_set_title(*this, title);
 }
+#endif
+#if defined(WL_SHELL_SURFACE_SET_CLASS_SINCE_VERSION)
 void WlShellSurface::setClass(const char *class_) {
     wl_shell_surface_set_class(*this, class_);
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_shell_surface.h
+++ b/src/lib/fcitx-wayland/core/wl_shell_surface.h
@@ -25,17 +25,37 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_SHELL_SURFACE_PONG_SINCE_VERSION)
     void pong(uint32_t serial);
+#endif
+#if defined(WL_SHELL_SURFACE_MOVE_SINCE_VERSION)
     void move(WlSeat *seat, uint32_t serial);
+#endif
+#if defined(WL_SHELL_SURFACE_RESIZE_SINCE_VERSION)
     void resize(WlSeat *seat, uint32_t serial, uint32_t edges);
+#endif
+#if defined(WL_SHELL_SURFACE_SET_TOPLEVEL_SINCE_VERSION)
     void setToplevel();
+#endif
+#if defined(WL_SHELL_SURFACE_SET_TRANSIENT_SINCE_VERSION)
     void setTransient(WlSurface *parent, int32_t x, int32_t y, uint32_t flags);
+#endif
+#if defined(WL_SHELL_SURFACE_SET_FULLSCREEN_SINCE_VERSION)
     void setFullscreen(uint32_t method, uint32_t framerate, WlOutput *output);
+#endif
+#if defined(WL_SHELL_SURFACE_SET_POPUP_SINCE_VERSION)
     void setPopup(WlSeat *seat, uint32_t serial, WlSurface *parent, int32_t x,
                   int32_t y, uint32_t flags);
+#endif
+#if defined(WL_SHELL_SURFACE_SET_MAXIMIZED_SINCE_VERSION)
     void setMaximized(WlOutput *output);
+#endif
+#if defined(WL_SHELL_SURFACE_SET_TITLE_SINCE_VERSION)
     void setTitle(const char *title);
+#endif
+#if defined(WL_SHELL_SURFACE_SET_CLASS_SINCE_VERSION)
     void setClass(const char *class_);
+#endif
 
     auto &ping() { return pingSignal_; }
     auto &configure() { return configureSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_shm.cpp
+++ b/src/lib/fcitx-wayland/core/wl_shm.cpp
@@ -4,6 +4,7 @@
 
 namespace fcitx::wayland {
 const struct wl_shm_listener WlShm::listener = {
+#if defined(WL_SHM_FORMAT_SINCE_VERSION)
     .format =
         [](void *data, wl_shm *wldata, uint32_t format) {
             auto *obj = static_cast<WlShm *>(data);
@@ -12,6 +13,7 @@ const struct wl_shm_listener WlShm::listener = {
                 obj->format()(format);
             }
         },
+#endif
 };
 
 WlShm::WlShm(wl_shm *data) : version_(wl_shm_get_version(data)), data_(data) {
@@ -29,8 +31,10 @@ void WlShm::destructor(wl_shm *data) {
 #endif
     wl_shm_destroy(data);
 }
+#if defined(WL_SHM_CREATE_POOL_SINCE_VERSION)
 WlShmPool *WlShm::createPool(int32_t fd, int32_t size) {
     return new WlShmPool(wl_shm_create_pool(*this, fd, size));
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_shm.h
+++ b/src/lib/fcitx-wayland/core/wl_shm.h
@@ -22,7 +22,9 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_SHM_CREATE_POOL_SINCE_VERSION)
     WlShmPool *createPool(int32_t fd, int32_t size);
+#endif
 
     auto &format() { return formatSignal_; }
 

--- a/src/lib/fcitx-wayland/core/wl_shm.h
+++ b/src/lib/fcitx-wayland/core/wl_shm.h
@@ -13,7 +13,7 @@ class WlShm final {
 public:
     static constexpr const char *interface = "wl_shm";
     static constexpr const wl_interface *const wlInterface = &wl_shm_interface;
-    static constexpr const uint32_t version = 2;
+    static constexpr const uint32_t version = 3;
     using wlType = wl_shm;
     operator wl_shm *() { return data_.get(); }
     WlShm(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_shm_pool.cpp
+++ b/src/lib/fcitx-wayland/core/wl_shm_pool.cpp
@@ -9,11 +9,15 @@ WlShmPool::WlShmPool(wl_shm_pool *data)
 }
 
 void WlShmPool::destructor(wl_shm_pool *data) { wl_shm_pool_destroy(data); }
+#if defined(WL_SHM_POOL_CREATE_BUFFER_SINCE_VERSION)
 WlBuffer *WlShmPool::createBuffer(int32_t offset, int32_t width, int32_t height,
                                   int32_t stride, uint32_t format) {
     return new WlBuffer(wl_shm_pool_create_buffer(*this, offset, width, height,
                                                   stride, format));
 }
+#endif
+#if defined(WL_SHM_POOL_RESIZE_SINCE_VERSION)
 void WlShmPool::resize(int32_t size) { wl_shm_pool_resize(*this, size); }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_shm_pool.h
+++ b/src/lib/fcitx-wayland/core/wl_shm_pool.h
@@ -13,7 +13,7 @@ public:
     static constexpr const char *interface = "wl_shm_pool";
     static constexpr const wl_interface *const wlInterface =
         &wl_shm_pool_interface;
-    static constexpr const uint32_t version = 2;
+    static constexpr const uint32_t version = 3;
     using wlType = wl_shm_pool;
     operator wl_shm_pool *() { return data_.get(); }
     WlShmPool(wlType *data);

--- a/src/lib/fcitx-wayland/core/wl_shm_pool.h
+++ b/src/lib/fcitx-wayland/core/wl_shm_pool.h
@@ -22,9 +22,13 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_SHM_POOL_CREATE_BUFFER_SINCE_VERSION)
     WlBuffer *createBuffer(int32_t offset, int32_t width, int32_t height,
                            int32_t stride, uint32_t format);
+#endif
+#if defined(WL_SHM_POOL_RESIZE_SINCE_VERSION)
     void resize(int32_t size);
+#endif
 
 private:
     static void destructor(wl_shm_pool *);

--- a/src/lib/fcitx-wayland/core/wl_subcompositor.cpp
+++ b/src/lib/fcitx-wayland/core/wl_subcompositor.cpp
@@ -12,10 +12,12 @@ WlSubcompositor::WlSubcompositor(wl_subcompositor *data)
 void WlSubcompositor::destructor(wl_subcompositor *data) {
     wl_subcompositor_destroy(data);
 }
+#if defined(WL_SUBCOMPOSITOR_GET_SUBSURFACE_SINCE_VERSION)
 WlSubsurface *WlSubcompositor::getSubsurface(WlSurface *surface,
                                              WlSurface *parent) {
     return new WlSubsurface(wl_subcompositor_get_subsurface(
         *this, rawPointer(surface), rawPointer(parent)));
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_subcompositor.h
+++ b/src/lib/fcitx-wayland/core/wl_subcompositor.h
@@ -23,7 +23,9 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_SUBCOMPOSITOR_GET_SUBSURFACE_SINCE_VERSION)
     WlSubsurface *getSubsurface(WlSurface *surface, WlSurface *parent);
+#endif
 
 private:
     static void destructor(wl_subcompositor *);

--- a/src/lib/fcitx-wayland/core/wl_subsurface.cpp
+++ b/src/lib/fcitx-wayland/core/wl_subsurface.cpp
@@ -11,16 +11,26 @@ WlSubsurface::WlSubsurface(wl_subsurface *data)
 void WlSubsurface::destructor(wl_subsurface *data) {
     wl_subsurface_destroy(data);
 }
+#if defined(WL_SUBSURFACE_SET_POSITION_SINCE_VERSION)
 void WlSubsurface::setPosition(int32_t x, int32_t y) {
     wl_subsurface_set_position(*this, x, y);
 }
+#endif
+#if defined(WL_SUBSURFACE_PLACE_ABOVE_SINCE_VERSION)
 void WlSubsurface::placeAbove(WlSurface *sibling) {
     wl_subsurface_place_above(*this, rawPointer(sibling));
 }
+#endif
+#if defined(WL_SUBSURFACE_PLACE_BELOW_SINCE_VERSION)
 void WlSubsurface::placeBelow(WlSurface *sibling) {
     wl_subsurface_place_below(*this, rawPointer(sibling));
 }
+#endif
+#if defined(WL_SUBSURFACE_SET_SYNC_SINCE_VERSION)
 void WlSubsurface::setSync() { wl_subsurface_set_sync(*this); }
+#endif
+#if defined(WL_SUBSURFACE_SET_DESYNC_SINCE_VERSION)
 void WlSubsurface::setDesync() { wl_subsurface_set_desync(*this); }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_subsurface.h
+++ b/src/lib/fcitx-wayland/core/wl_subsurface.h
@@ -22,11 +22,21 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_SUBSURFACE_SET_POSITION_SINCE_VERSION)
     void setPosition(int32_t x, int32_t y);
+#endif
+#if defined(WL_SUBSURFACE_PLACE_ABOVE_SINCE_VERSION)
     void placeAbove(WlSurface *sibling);
+#endif
+#if defined(WL_SUBSURFACE_PLACE_BELOW_SINCE_VERSION)
     void placeBelow(WlSurface *sibling);
+#endif
+#if defined(WL_SUBSURFACE_SET_SYNC_SINCE_VERSION)
     void setSync();
+#endif
+#if defined(WL_SUBSURFACE_SET_DESYNC_SINCE_VERSION)
     void setDesync();
+#endif
 
 private:
     static void destructor(wl_subsurface *);

--- a/src/lib/fcitx-wayland/core/wl_surface.cpp
+++ b/src/lib/fcitx-wayland/core/wl_surface.cpp
@@ -85,5 +85,8 @@ void WlSurface::damageBuffer(int32_t x, int32_t y, int32_t width,
     wl_surface_damage_buffer(*this, x, y, width, height);
 }
 void WlSurface::offset(int32_t x, int32_t y) { wl_surface_offset(*this, x, y); }
+WlCallback *WlSurface::getRelease() {
+    return new WlCallback(wl_surface_get_release(*this));
+}
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_surface.cpp
+++ b/src/lib/fcitx-wayland/core/wl_surface.cpp
@@ -7,6 +7,7 @@
 
 namespace fcitx::wayland {
 const struct wl_surface_listener WlSurface::listener = {
+#if defined(WL_SURFACE_ENTER_SINCE_VERSION)
     .enter =
         [](void *data, wl_surface *wldata, wl_output *output) {
             auto *obj = static_cast<WlSurface *>(data);
@@ -20,6 +21,8 @@ const struct wl_surface_listener WlSurface::listener = {
                 obj->enter()(output_);
             }
         },
+#endif
+#if defined(WL_SURFACE_LEAVE_SINCE_VERSION)
     .leave =
         [](void *data, wl_surface *wldata, wl_output *output) {
             auto *obj = static_cast<WlSurface *>(data);
@@ -33,6 +36,8 @@ const struct wl_surface_listener WlSurface::listener = {
                 obj->leave()(output_);
             }
         },
+#endif
+#if defined(WL_SURFACE_PREFERRED_BUFFER_SCALE_SINCE_VERSION)
     .preferred_buffer_scale =
         [](void *data, wl_surface *wldata, int32_t factor) {
             auto *obj = static_cast<WlSurface *>(data);
@@ -41,6 +46,8 @@ const struct wl_surface_listener WlSurface::listener = {
                 obj->preferredBufferScale()(factor);
             }
         },
+#endif
+#if defined(WL_SURFACE_PREFERRED_BUFFER_TRANSFORM_SINCE_VERSION)
     .preferred_buffer_transform =
         [](void *data, wl_surface *wldata, uint32_t transform) {
             auto *obj = static_cast<WlSurface *>(data);
@@ -49,6 +56,7 @@ const struct wl_surface_listener WlSurface::listener = {
                 obj->preferredBufferTransform()(transform);
             }
         },
+#endif
 };
 
 WlSurface::WlSurface(wl_surface *data)
@@ -58,35 +66,57 @@ WlSurface::WlSurface(wl_surface *data)
 }
 
 void WlSurface::destructor(wl_surface *data) { wl_surface_destroy(data); }
+#if defined(WL_SURFACE_ATTACH_SINCE_VERSION)
 void WlSurface::attach(WlBuffer *buffer, int32_t x, int32_t y) {
     wl_surface_attach(*this, rawPointer(buffer), x, y);
 }
+#endif
+#if defined(WL_SURFACE_DAMAGE_SINCE_VERSION)
 void WlSurface::damage(int32_t x, int32_t y, int32_t width, int32_t height) {
     wl_surface_damage(*this, x, y, width, height);
 }
+#endif
+#if defined(WL_SURFACE_FRAME_SINCE_VERSION)
 WlCallback *WlSurface::frame() {
     return new WlCallback(wl_surface_frame(*this));
 }
+#endif
+#if defined(WL_SURFACE_SET_OPAQUE_REGION_SINCE_VERSION)
 void WlSurface::setOpaqueRegion(WlRegion *region) {
     wl_surface_set_opaque_region(*this, rawPointer(region));
 }
+#endif
+#if defined(WL_SURFACE_SET_INPUT_REGION_SINCE_VERSION)
 void WlSurface::setInputRegion(WlRegion *region) {
     wl_surface_set_input_region(*this, rawPointer(region));
 }
+#endif
+#if defined(WL_SURFACE_COMMIT_SINCE_VERSION)
 void WlSurface::commit() { wl_surface_commit(*this); }
+#endif
+#if defined(WL_SURFACE_SET_BUFFER_TRANSFORM_SINCE_VERSION)
 void WlSurface::setBufferTransform(int32_t transform) {
     wl_surface_set_buffer_transform(*this, transform);
 }
+#endif
+#if defined(WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION)
 void WlSurface::setBufferScale(int32_t scale) {
     wl_surface_set_buffer_scale(*this, scale);
 }
+#endif
+#if defined(WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION)
 void WlSurface::damageBuffer(int32_t x, int32_t y, int32_t width,
                              int32_t height) {
     wl_surface_damage_buffer(*this, x, y, width, height);
 }
+#endif
+#if defined(WL_SURFACE_OFFSET_SINCE_VERSION)
 void WlSurface::offset(int32_t x, int32_t y) { wl_surface_offset(*this, x, y); }
+#endif
+#if defined(WL_SURFACE_GET_RELEASE_SINCE_VERSION)
 WlCallback *WlSurface::getRelease() {
     return new WlCallback(wl_surface_get_release(*this));
 }
+#endif
 
 } // namespace fcitx::wayland

--- a/src/lib/fcitx-wayland/core/wl_surface.h
+++ b/src/lib/fcitx-wayland/core/wl_surface.h
@@ -26,17 +26,39 @@ public:
     auto actualVersion() const { return version_; }
     void *userData() const { return userData_; }
     void setUserData(void *userData) { userData_ = userData; }
+#if defined(WL_SURFACE_ATTACH_SINCE_VERSION)
     void attach(WlBuffer *buffer, int32_t x, int32_t y);
+#endif
+#if defined(WL_SURFACE_DAMAGE_SINCE_VERSION)
     void damage(int32_t x, int32_t y, int32_t width, int32_t height);
+#endif
+#if defined(WL_SURFACE_FRAME_SINCE_VERSION)
     WlCallback *frame();
+#endif
+#if defined(WL_SURFACE_SET_OPAQUE_REGION_SINCE_VERSION)
     void setOpaqueRegion(WlRegion *region);
+#endif
+#if defined(WL_SURFACE_SET_INPUT_REGION_SINCE_VERSION)
     void setInputRegion(WlRegion *region);
+#endif
+#if defined(WL_SURFACE_COMMIT_SINCE_VERSION)
     void commit();
+#endif
+#if defined(WL_SURFACE_SET_BUFFER_TRANSFORM_SINCE_VERSION)
     void setBufferTransform(int32_t transform);
+#endif
+#if defined(WL_SURFACE_SET_BUFFER_SCALE_SINCE_VERSION)
     void setBufferScale(int32_t scale);
+#endif
+#if defined(WL_SURFACE_DAMAGE_BUFFER_SINCE_VERSION)
     void damageBuffer(int32_t x, int32_t y, int32_t width, int32_t height);
+#endif
+#if defined(WL_SURFACE_OFFSET_SINCE_VERSION)
     void offset(int32_t x, int32_t y);
+#endif
+#if defined(WL_SURFACE_GET_RELEASE_SINCE_VERSION)
     WlCallback *getRelease();
+#endif
 
     auto &enter() { return enterSignal_; }
     auto &leave() { return leaveSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_surface.h
+++ b/src/lib/fcitx-wayland/core/wl_surface.h
@@ -17,7 +17,7 @@ public:
     static constexpr const char *interface = "wl_surface";
     static constexpr const wl_interface *const wlInterface =
         &wl_surface_interface;
-    static constexpr const uint32_t version = 6;
+    static constexpr const uint32_t version = 7;
     using wlType = wl_surface;
     operator wl_surface *() { return data_.get(); }
     WlSurface(wlType *data);
@@ -36,6 +36,7 @@ public:
     void setBufferScale(int32_t scale);
     void damageBuffer(int32_t x, int32_t y, int32_t width, int32_t height);
     void offset(int32_t x, int32_t y);
+    WlCallback *getRelease();
 
     auto &enter() { return enterSignal_; }
     auto &leave() { return leaveSignal_; }

--- a/src/lib/fcitx-wayland/core/wl_touch.cpp
+++ b/src/lib/fcitx-wayland/core/wl_touch.cpp
@@ -4,6 +4,7 @@
 
 namespace fcitx::wayland {
 const struct wl_touch_listener WlTouch::listener = {
+#if defined(WL_TOUCH_DOWN_SINCE_VERSION)
     .down =
         [](void *data, wl_touch *wldata, uint32_t serial, uint32_t time,
            wl_surface *surface, int32_t id, wl_fixed_t x, wl_fixed_t y) {
@@ -18,6 +19,8 @@ const struct wl_touch_listener WlTouch::listener = {
                 obj->down()(serial, time, surface_, id, x, y);
             }
         },
+#endif
+#if defined(WL_TOUCH_UP_SINCE_VERSION)
     .up =
         [](void *data, wl_touch *wldata, uint32_t serial, uint32_t time,
            int32_t id) {
@@ -27,6 +30,8 @@ const struct wl_touch_listener WlTouch::listener = {
                 obj->up()(serial, time, id);
             }
         },
+#endif
+#if defined(WL_TOUCH_MOTION_SINCE_VERSION)
     .motion =
         [](void *data, wl_touch *wldata, uint32_t time, int32_t id,
            wl_fixed_t x, wl_fixed_t y) {
@@ -36,6 +41,8 @@ const struct wl_touch_listener WlTouch::listener = {
                 obj->motion()(time, id, x, y);
             }
         },
+#endif
+#if defined(WL_TOUCH_FRAME_SINCE_VERSION)
     .frame =
         [](void *data, wl_touch *wldata) {
             auto *obj = static_cast<WlTouch *>(data);
@@ -44,6 +51,8 @@ const struct wl_touch_listener WlTouch::listener = {
                 obj->frame()();
             }
         },
+#endif
+#if defined(WL_TOUCH_CANCEL_SINCE_VERSION)
     .cancel =
         [](void *data, wl_touch *wldata) {
             auto *obj = static_cast<WlTouch *>(data);
@@ -52,6 +61,8 @@ const struct wl_touch_listener WlTouch::listener = {
                 obj->cancel()();
             }
         },
+#endif
+#if defined(WL_TOUCH_SHAPE_SINCE_VERSION)
     .shape =
         [](void *data, wl_touch *wldata, int32_t id, wl_fixed_t major,
            wl_fixed_t minor) {
@@ -61,6 +72,8 @@ const struct wl_touch_listener WlTouch::listener = {
                 obj->shape()(id, major, minor);
             }
         },
+#endif
+#if defined(WL_TOUCH_ORIENTATION_SINCE_VERSION)
     .orientation =
         [](void *data, wl_touch *wldata, int32_t id, wl_fixed_t orientation) {
             auto *obj = static_cast<WlTouch *>(data);
@@ -69,6 +82,7 @@ const struct wl_touch_listener WlTouch::listener = {
                 obj->orientation()(id, orientation);
             }
         },
+#endif
 };
 
 WlTouch::WlTouch(wl_touch *data)

--- a/src/lib/fcitx-wayland/core/wl_touch.h
+++ b/src/lib/fcitx-wayland/core/wl_touch.h
@@ -14,7 +14,7 @@ public:
     static constexpr const char *interface = "wl_touch";
     static constexpr const wl_interface *const wlInterface =
         &wl_touch_interface;
-    static constexpr const uint32_t version = 10;
+    static constexpr const uint32_t version = 11;
     using wlType = wl_touch;
     operator wl_touch *() { return data_.get(); }
     WlTouch(wlType *data);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added handling for pointer warp events and surface release notifications.
  * Improved global removal robustness by integrating protocol-based acknowledgements when supported.
* **Bug Fixes**
  * Expanded Wayland protocol compatibility by updating supported versions and conditionally enabling newer requests/events across inputs, surfaces, compositor, shared memory, regions, seats, and data-transfer.
  * Improved “release” behavior for compositor and related objects when the newer protocol mechanisms are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->