### PR TITLE
fix(latex.mb): typo in quickphrase latex

### DIFF
--- a/src/modules/quickphrase/quickphrase.d/latex.mb
+++ b/src/modules/quickphrase/quickphrase.d/latex.mb
@@ -92,7 +92,6 @@
 \Re ℜ
 \mathbb ℝ
 \mathbb ℤ
-\Omega Ω
 \mho ℧
 \mathfrak ℨ
 \mathfrak ℭ
@@ -123,7 +122,7 @@
 \nwarrow ↖
 \nearrow ↗
 \searrow ↘
-\searrow ↙
+\swarrow ↙
 \nleftarrow ↚
 \nrightarrow ↛
 \leadsto ↝


### PR DESCRIPTION
I notice that `\Omega Ω` is duplicated. Also, `\searrow` maps to both `↘` and `↙` now. The latter should be `\swarrow`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the shortcut for the southwest diagonal arrow symbol.
  - Removed the incorrect `\Omega` symbol mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->