### PR TITLE
Add option to consume redundant Activate/Deactivate key press

### DIFF
--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -72,6 +72,19 @@ FCITX_CONFIGURATION(
         {Key("Hangul_Romaja")},
         KeyListConstrain({KeyConstrainFlag::AllowModifierLess,
                           KeyConstrainFlag::AllowModifierOnly})};
+    OptionWithAnnotation<bool, ToolTipAnnotation>
+        consumeRedundantActivateKeys{{
+            .parent = this,
+            .path{"ConsumeRedundantActivateKeys"},
+            .description{_("Consume redundant Activate/Deactivate key")},
+            .defaultValue = false,
+            .annotation{
+                _("When the input method is already in the state the key "
+                  "requests, pressing an Activate/Deactivate key changes "
+                  "nothing; consume the key event in that case instead of "
+                  "forwarding it to the application. Modifier only keys are "
+                  "never consumed.")},
+        }};
     KeyListOptionWithAnnotation<ToolTipAnnotation> altTriggerKeys{
         {.parent = this,
          .path{"AltTriggerKeys"},
@@ -296,6 +309,11 @@ const KeyList &GlobalConfig::activateKeys() const {
 const KeyList &GlobalConfig::deactivateKeys() const {
     FCITX_D();
     return d->hotkey->deactivateKeys.value();
+}
+
+bool GlobalConfig::consumeRedundantActivateKeys() const {
+    FCITX_D();
+    return *d->hotkey->consumeRedundantActivateKeys;
 }
 
 const KeyList &GlobalConfig::enumerateForwardKeys() const {

--- a/src/lib/fcitx/globalconfig.cpp
+++ b/src/lib/fcitx/globalconfig.cpp
@@ -72,19 +72,18 @@ FCITX_CONFIGURATION(
         {Key("Hangul_Romaja")},
         KeyListConstrain({KeyConstrainFlag::AllowModifierLess,
                           KeyConstrainFlag::AllowModifierOnly})};
-    OptionWithAnnotation<bool, ToolTipAnnotation>
-        consumeRedundantActivateKeys{{
-            .parent = this,
-            .path{"ConsumeRedundantActivateKeys"},
-            .description{_("Consume redundant Activate/Deactivate key")},
-            .defaultValue = false,
-            .annotation{
-                _("When the input method is already in the state the key "
-                  "requests, pressing an Activate/Deactivate key changes "
-                  "nothing; consume the key event in that case instead of "
-                  "forwarding it to the application. Modifier only keys are "
-                  "never consumed.")},
-        }};
+    OptionWithAnnotation<bool, ToolTipAnnotation> consumeRedundantActivateKeys{{
+        .parent = this,
+        .path{"ConsumeRedundantActivateKeys"},
+        .description{_("Consume redundant Activate/Deactivate key")},
+        .defaultValue = false,
+        .annotation{
+            _("When the input method is already in the state the key "
+              "requests, pressing an Activate/Deactivate key changes "
+              "nothing; consume the key event in that case instead of "
+              "forwarding it to the application. Modifier only keys are "
+              "never consumed.")},
+    }};
     KeyListOptionWithAnnotation<ToolTipAnnotation> altTriggerKeys{
         {.parent = this,
          .path{"AltTriggerKeys"},

--- a/src/lib/fcitx/globalconfig.h
+++ b/src/lib/fcitx/globalconfig.h
@@ -31,6 +31,19 @@ public:
     const KeyList &altTriggerKeys() const;
     const KeyList &activateKeys() const;
     const KeyList &deactivateKeys() const;
+
+    /**
+     * Consume Activate/Deactivate keys even when the state does not change.
+     *
+     * When enabled, pressing an activate key while the input method is
+     * already active (or a deactivate key while inactive) is consumed by
+     * fcitx instead of being forwarded to the application. Modifier only
+     * keys are not affected.
+     *
+     * @return whether to consume redundant activate/deactivate keys
+     * @since 5.1.22
+     */
+    bool consumeRedundantActivateKeys() const;
     const KeyList &enumerateForwardKeys() const;
     const KeyList &enumerateBackwardKeys() const;
     bool enumerateSkipFirst() const;

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -873,6 +873,19 @@ Instance::Instance(int argc, char **argv) {
                     }
                     idx++;
                 }
+                if (d->globalConfig_.consumeRedundantActivateKeys() &&
+                    !isModifier && canTrigger() &&
+                    (origKey.keyListIndex(d->globalConfig_.activateKeys()) >=
+                         0 ||
+                     origKey.keyListIndex(d->globalConfig_.deactivateKeys()) >=
+                         0)) {
+                    // Activate/Deactivate keys act as modeless switches: when
+                    // the state already matches, the state-gated handlers
+                    // above do not claim the key. Consume it instead of
+                    // leaking it to the client.
+                    keyEvent.filterAndAccept();
+                    return;
+                }
             }
         }));
     d->eventWatchers_.emplace_back(watchEvent(

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -458,7 +458,7 @@ bool InstancePrivate::canActivate(InputContext *ic) {
     }
     auto *inputState = ic->propertyFor(&inputStateFactory_);
     return (!inputState->isActive()) ||
-        globalConfig_.consumeRedundantActivateKeys();
+           globalConfig_.consumeRedundantActivateKeys();
 }
 
 bool InstancePrivate::canDeactivate(InputContext *ic) {
@@ -468,7 +468,7 @@ bool InstancePrivate::canDeactivate(InputContext *ic) {
     }
     auto *inputState = ic->propertyFor(&inputStateFactory_);
     return inputState->isActive() ||
-        globalConfig_.consumeRedundantActivateKeys();
+           globalConfig_.consumeRedundantActivateKeys();
 }
 
 void InstancePrivate::navigateGroup(InputContext *ic, const Key &key,

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -457,7 +457,8 @@ bool InstancePrivate::canActivate(InputContext *ic) {
         return false;
     }
     auto *inputState = ic->propertyFor(&inputStateFactory_);
-    return !inputState->isActive();
+    return (!inputState->isActive()) ||
+        globalConfig_.consumeRedundantActivateKeys();
 }
 
 bool InstancePrivate::canDeactivate(InputContext *ic) {
@@ -466,7 +467,8 @@ bool InstancePrivate::canDeactivate(InputContext *ic) {
         return false;
     }
     auto *inputState = ic->propertyFor(&inputStateFactory_);
-    return inputState->isActive();
+    return inputState->isActive() ||
+        globalConfig_.consumeRedundantActivateKeys();
 }
 
 void InstancePrivate::navigateGroup(InputContext *ic, const Key &key,
@@ -872,19 +874,6 @@ Instance::Instance(int argc, char **argv) {
                         return;
                     }
                     idx++;
-                }
-                if (d->globalConfig_.consumeRedundantActivateKeys() &&
-                    !isModifier && canTrigger() &&
-                    (origKey.keyListIndex(d->globalConfig_.activateKeys()) >=
-                         0 ||
-                     origKey.keyListIndex(d->globalConfig_.deactivateKeys()) >=
-                         0)) {
-                    // Activate/Deactivate keys act as modeless switches: when
-                    // the state already matches, the state-gated handlers
-                    // above do not claim the key. Consume it instead of
-                    // leaking it to the client.
-                    keyEvent.filterAndAccept();
-                    return;
                 }
             }
         }));


### PR DESCRIPTION
The current behavior — an Activate/Deactivate key press that doesn't
change state falls through to the application — is clearly intentional
and fine for most setups (as discussed in #845), so this PR changes no
defaults.

My use case is a modeless switch: dedicated `ActivateKeys=Super+N` /
`DeactivateKeys=Super+S`, picked to be idempotent — a redundant press
should be a no-op. Instead it leaks into the client and types a letter:
with the IM already active, Super+N inserts "n" (easy to reproduce with
two input methods in a group).

This adds an opt-in Hotkey option "Consume redundant Activate/Deactivate
key" (`ConsumeRedundantActivateKeys`, default false). When enabled, a
non-modifier press of an activate/deactivate key that no state-gated
handler claimed is consumed after the handler loop instead of being
forwarded. Modifier-only keys are never consumed (a bare modifier press
still reaches the client), and a key present in both lists (toggle
setup) matches a handler earlier and is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to consume redundant Activate/Deactivate key events when the input method is already in the requested state.
  * The setting is disabled by default and does not affect modifier-only keys.

* **Bug Fixes**
  * Prevented redundant activation or deactivation keystrokes from being passed to applications when the option is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->