### PR TITLE
Add HiDPI support to classic UI XCB windows

### DIFF
--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -168,14 +168,10 @@ void XCBInputWindow::updatePosition(InputContext *inputContext) {
 }
 
 void XCBInputWindow::updateDPI(InputContext *inputContext) {
-    dpi_ = ui_->dpiByPosition(inputContext->cursorRect().left(),
-                              inputContext->cursorRect().top());
-
-    // Let Cairo device scale handle HiDPI so Pango keeps logical font sizes.
-    setFontDPI(-1);
+    auto dpi = ui_->dpiByPosition(inputContext->cursorRect().left(),
+                                  inputContext->cursorRect().top());
+    setScale(scaleForDPI(dpi));
 }
-
-double XCBInputWindow::scale() const { return scaleForDPI(dpi_); }
 
 void XCBInputWindow::update(InputContext *inputContext) {
     if (!wid_) {
@@ -249,7 +245,6 @@ void XCBInputWindow::update(InputContext *inputContext) {
 bool XCBInputWindow::filterEvent(xcb_generic_event_t *event) {
     uint8_t response_type = event->response_type & ~0x80;
     switch (response_type) {
-
     case XCB_EXPOSE: {
         auto *expose = reinterpret_cast<xcb_expose_event_t *>(event);
         if (expose->window == wid_) {
@@ -294,6 +289,8 @@ bool XCBInputWindow::filterEvent(xcb_generic_event_t *event) {
         }
         break;
     }
+    default:
+        break;
     }
     return false;
 }

--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -77,11 +77,13 @@ int XCBInputWindow::calculatePositionX(const Rect &cursorRect,
     int x = cursorRect.left();
 
     auto &theme = parent_->theme();
-    int leftSW = theme.inputPanel->shadowMargin->marginLeft.value();
-    int rightSW = theme.inputPanel->shadowMargin->marginRight.value();
+    int leftSW =
+        physicalFromLogical(theme.inputPanel->shadowMargin->marginLeft.value());
+    int rightSW = physicalFromLogical(
+        theme.inputPanel->shadowMargin->marginRight.value());
 
-    int actualWidth = width() - leftSW - rightSW;
-    actualWidth = actualWidth <= 0 ? width() : actualWidth;
+    int actualWidth = physicalWidth_ - leftSW - rightSW;
+    actualWidth = actualWidth <= 0 ? physicalWidth_ : actualWidth;
 
     if (closestScreen != nullptr) {
         int newX = std::max(x, closestScreen->left());
@@ -105,11 +107,13 @@ int XCBInputWindow::calculatePositionY(const Rect &cursorRect,
     int y = cursorRect.top();
 
     auto &theme = parent_->theme();
-    int topSW = theme.inputPanel->shadowMargin->marginTop.value();
-    int bottomSW = theme.inputPanel->shadowMargin->marginBottom.value();
+    int topSW =
+        physicalFromLogical(theme.inputPanel->shadowMargin->marginTop.value());
+    int bottomSW = physicalFromLogical(
+        theme.inputPanel->shadowMargin->marginBottom.value());
 
-    int actualHeight = height() - topSW - bottomSW;
-    actualHeight = actualHeight <= 0 ? height() : actualHeight;
+    int actualHeight = physicalHeight_ - topSW - bottomSW;
+    actualHeight = actualHeight <= 0 ? physicalHeight_ : actualHeight;
 
     if (closestScreen != nullptr) {
         int h = cursorRect.height();
@@ -117,15 +121,17 @@ int XCBInputWindow::calculatePositionY(const Rect &cursorRect,
         if (y < closestScreen->top()) {
             newY = closestScreen->top();
         } else {
-            newY = y + (h ? h : (10 * ((dpi_ < 0 ? 96.0 : dpi_) / 96.0)));
+            newY = y + (h ? h : physicalFromLogical(10));
         }
 
         // Try flip y.
         if (newY + actualHeight > closestScreen->bottom()) {
             if (newY > closestScreen->bottom()) {
-                newY = closestScreen->bottom() - actualHeight - 40;
+                newY = closestScreen->bottom() - actualHeight -
+                       physicalFromLogical(40);
             } else { /* better position the window */
-                newY = newY - actualHeight - ((h == 0) ? 40 : h);
+                newY = newY - actualHeight -
+                       ((h == 0) ? physicalFromLogical(40) : h);
             }
 
             // If after flip, top is out of the screen, we still prefer the top
@@ -165,8 +171,11 @@ void XCBInputWindow::updateDPI(InputContext *inputContext) {
     dpi_ = ui_->dpiByPosition(inputContext->cursorRect().left(),
                               inputContext->cursorRect().top());
 
-    setFontDPI(dpi_);
+    // Let Cairo device scale handle HiDPI so Pango keeps logical font sizes.
+    setFontDPI(-1);
 }
+
+double XCBInputWindow::scale() const { return scaleForDPI(dpi_); }
 
 void XCBInputWindow::update(InputContext *inputContext) {
     if (!wid_) {
@@ -185,15 +194,19 @@ void XCBInputWindow::update(InputContext *inputContext) {
         return;
     }
 
-    if (width != this->width() || height != this->height()) {
-        resize(width, height);
+    auto oldPhysicalWidth = physicalWidth_;
+    auto oldPhysicalHeight = physicalHeight_;
+    resize(width, height);
+    if (physicalWidth_ != oldPhysicalWidth ||
+        physicalHeight_ != oldPhysicalHeight) {
         if (atomBlur_) {
-            Rect rect(0, 0, width, height);
-            shrink(rect, *ui_->parent()->theme().inputPanel->blurMargin);
+            Rect logicalRect(0, 0, width, height);
+            shrink(logicalRect, *ui_->parent()->theme().inputPanel->blurMargin);
             if (!*ui_->parent()->theme().inputPanel->enableBlur ||
-                rect.isEmpty()) {
+                logicalRect.isEmpty()) {
                 xcb_delete_property(ui_->connection(), wid_, atomBlur_);
             } else {
+                auto rect = physicalFromLogical(logicalRect);
                 std::vector<uint32_t> data;
                 if (ui_->parent()->theme().inputPanel->blurMask->empty()) {
                     data.push_back(rect.left());
@@ -208,10 +221,11 @@ void XCBInputWindow::update(InputContext *inputContext) {
                     auto region = parent_->theme().mask(
                         parent_->theme().maskConfig(), width, height);
                     for (const auto &rect : region) {
-                        data.push_back(rect.left());
-                        data.push_back(rect.top());
-                        data.push_back(rect.width());
-                        data.push_back(rect.height());
+                        auto physicalRect = physicalFromLogical(rect);
+                        data.push_back(physicalRect.left());
+                        data.push_back(physicalRect.top());
+                        data.push_back(physicalRect.width());
+                        data.push_back(physicalRect.height());
                     }
                     xcb_change_property(ui_->connection(),
                                         XCB_PROP_MODE_REPLACE, wid_, atomBlur_,
@@ -250,7 +264,8 @@ bool XCBInputWindow::filterEvent(xcb_generic_event_t *event) {
             break;
         }
         if (buttonPress->detail == XCB_BUTTON_INDEX_1) {
-            click(buttonPress->event_x, buttonPress->event_y);
+            click(logicalFromPhysical(buttonPress->event_x),
+                  logicalFromPhysical(buttonPress->event_y));
         } else if (buttonPress->detail == XCB_BUTTON_INDEX_4) {
             wheel(/*up=*/true);
         } else if (buttonPress->detail == XCB_BUTTON_INDEX_5) {
@@ -261,7 +276,8 @@ bool XCBInputWindow::filterEvent(xcb_generic_event_t *event) {
     case XCB_MOTION_NOTIFY: {
         auto *motion = reinterpret_cast<xcb_motion_notify_event_t *>(event);
         if (motion->event == wid_) {
-            if (hover(motion->event_x, motion->event_y)) {
+            if (hover(logicalFromPhysical(motion->event_x),
+                      logicalFromPhysical(motion->event_y))) {
                 repaint();
             }
             return true;

--- a/src/ui/classic/xcbinputwindow.h
+++ b/src/ui/classic/xcbinputwindow.h
@@ -31,6 +31,7 @@ public:
 
 private:
     void repaint();
+    double scale() const override;
     const Rect *getClosestScreen(const Rect &cursorRect) const;
     int calculatePositionX(const Rect &cursorRect,
                            const Rect *closestScreen) const;

--- a/src/ui/classic/xcbinputwindow.h
+++ b/src/ui/classic/xcbinputwindow.h
@@ -31,7 +31,6 @@ public:
 
 private:
     void repaint();
-    double scale() const override;
     const Rect *getClosestScreen(const Rect &cursorRect) const;
     int calculatePositionX(const Rect &cursorRect,
                            const Rect *closestScreen) const;
@@ -39,7 +38,6 @@ private:
                            const Rect *closestScreen) const;
 
     xcb_atom_t atomBlur_;
-    int dpi_ = -1;
 };
 
 } // namespace fcitx::classicui

--- a/src/ui/classic/xcbmenu.cpp
+++ b/src/ui/classic/xcbmenu.cpp
@@ -105,8 +105,9 @@ bool XCBMenu::filterEvent(xcb_generic_event_t *event) {
         }
         if (auto *menu =
                 childByPosition(buttonPress->root_x, buttonPress->root_y)) {
-            menu->handleButtonPress(buttonPress->root_x - menu->x_,
-                                    buttonPress->root_y - menu->y_);
+            menu->handleButtonPress(
+                menu->logicalFromPhysical(buttonPress->root_x - menu->x_),
+                menu->logicalFromPhysical(buttonPress->root_y - menu->y_));
         } else {
             hideAll();
             return true;
@@ -120,8 +121,9 @@ bool XCBMenu::filterEvent(xcb_generic_event_t *event) {
         }
 
         if (auto *menu = childByPosition(motion->root_x, motion->root_y)) {
-            menu->handleMotionNotify(motion->root_x - menu->x_,
-                                     motion->root_y - menu->y_);
+            menu->handleMotionNotify(
+                menu->logicalFromPhysical(motion->root_x - menu->x_),
+                menu->logicalFromPhysical(motion->root_y - menu->y_));
         }
         return true;
     }
@@ -279,7 +281,7 @@ XCBMenu *XCBMenu::childByPosition(int rootX, int rootY) {
     while (result) {
         Rect rect;
         rect.setPosition(result->x_, result->y_)
-            .setSize(result->width_, result->height_);
+            .setSize(result->physicalWidth_, result->physicalHeight_);
         if (rect.contains(rootX, rootY)) {
             break;
         }
@@ -353,7 +355,8 @@ void XCBMenu::setHoveredIndex(int idx) {
                             // FCITX_INFO() << this << " in timer show submenu "
                             // << newMenu;
                             newMenu->show(
-                                item.first->region_.translated(x_, y_),
+                                physicalFromLogical(item.first->region_)
+                                    .translated(x_, y_),
                                 ConstrainAdjustment::Slide);
                         }
                     } else {
@@ -385,17 +388,13 @@ std::pair<MenuItem *, Action *> XCBMenu::actionAt(size_t index) {
 void XCBMenu::updateDPI(int x, int y) {
     dpi_ = ui_->dpiByPosition(x, y);
 
-    // Unlike pango cairo context, Cairo font map does not accept negative dpi.
-    // Restore to default value instead.
-    if (dpi_ < 0) {
-        pango_cairo_font_map_set_resolution(
-            PANGO_CAIRO_FONT_MAP(fontMap_.get()), fontMapDefaultDPI_);
-    } else {
-        pango_cairo_font_map_set_resolution(
-            PANGO_CAIRO_FONT_MAP(fontMap_.get()), dpi_);
-    }
-    pango_cairo_context_set_resolution(context_.get(), dpi_);
+    // Let Cairo device scale handle HiDPI so Pango keeps logical font sizes.
+    pango_cairo_font_map_set_resolution(PANGO_CAIRO_FONT_MAP(fontMap_.get()),
+                                        fontMapDefaultDPI_);
+    pango_cairo_context_set_resolution(context_.get(), -1);
 }
+
+double XCBMenu::scale() const { return scaleForDPI(dpi_); }
 
 void XCBMenu::update() {
     auto *ic = lastRelevantIc();
@@ -501,7 +500,7 @@ void XCBMenu::update() {
             .setSize(maxItemWidth + *highlightMargin.marginLeft +
                          *highlightMargin.marginRight,
                      maxItemHeight + *highlightMargin.marginTop +
-                         *highlightMargin.marginTop);
+                         *highlightMargin.marginBottom);
         item.layoutX_ = width + *textMargin.marginLeft +
                         (hasCheckable ? checkBox.width() : 0);
         item.layoutY_ = height + *textMargin.marginTop +
@@ -664,20 +663,19 @@ void XCBMenu::show(Rect rect, ConstrainAdjustment adjustY) {
     x = x + rect.width();
 
     if (closestScreen) {
-
-        if (x + width() > closestScreen->right()) {
-            x = rect.left() - width();
+        if (x + physicalWidth_ > closestScreen->right()) {
+            x = rect.left() - physicalWidth_;
         }
 
         switch (adjustY) {
         case ConstrainAdjustment::Slide:
-            if (y + height() > closestScreen->bottom()) {
-                y = closestScreen->bottom() - height();
+            if (y + physicalHeight_ > closestScreen->bottom()) {
+                y = closestScreen->bottom() - physicalHeight_;
             }
             break;
         case ConstrainAdjustment::Flip:
-            if (y + height() > closestScreen->bottom()) {
-                y = rect.top() - height();
+            if (y + physicalHeight_ > closestScreen->bottom()) {
+                y = rect.top() - physicalHeight_;
             }
             break;
         };

--- a/src/ui/classic/xcbmenu.cpp
+++ b/src/ui/classic/xcbmenu.cpp
@@ -44,8 +44,6 @@ namespace fcitx::classicui {
 XCBMenu::XCBMenu(XCBUI *ui, MenuPool *pool, Menu *menu)
     : XCBWindow(ui), pool_(pool), menu_(menu) {
     fontMap_.reset(pango_cairo_font_map_new());
-    fontMapDefaultDPI_ = pango_cairo_font_map_get_resolution(
-        PANGO_CAIRO_FONT_MAP(fontMap_.get()));
     context_.reset(pango_font_map_create_context(fontMap_.get()));
     if (auto *ic = ui_->parent()->instance()->mostRecentInputContext()) {
         lastRelevantIc_ = ic->watch();
@@ -386,15 +384,8 @@ std::pair<MenuItem *, Action *> XCBMenu::actionAt(size_t index) {
 }
 
 void XCBMenu::updateDPI(int x, int y) {
-    dpi_ = ui_->dpiByPosition(x, y);
-
-    // Let Cairo device scale handle HiDPI so Pango keeps logical font sizes.
-    pango_cairo_font_map_set_resolution(PANGO_CAIRO_FONT_MAP(fontMap_.get()),
-                                        fontMapDefaultDPI_);
-    pango_cairo_context_set_resolution(context_.get(), -1);
+    setScale(scaleForDPI(ui_->dpiByPosition(x, y)));
 }
-
-double XCBMenu::scale() const { return scaleForDPI(dpi_); }
 
 void XCBMenu::update() {
     auto *ic = lastRelevantIc();

--- a/src/ui/classic/xcbmenu.h
+++ b/src/ui/classic/xcbmenu.h
@@ -92,6 +92,7 @@ private:
     void setHoveredIndex(int idx);
     void setChild(XCBMenu *child);
     void updateDPI(int x, int y);
+    double scale() const override;
     std::pair<MenuItem *, Action *> actionAt(size_t index);
 
     MenuPool *pool_;

--- a/src/ui/classic/xcbmenu.h
+++ b/src/ui/classic/xcbmenu.h
@@ -92,7 +92,6 @@ private:
     void setHoveredIndex(int idx);
     void setChild(XCBMenu *child);
     void updateDPI(int x, int y);
-    double scale() const override;
     std::pair<MenuItem *, Action *> actionAt(size_t index);
 
     MenuPool *pool_;
@@ -106,8 +105,6 @@ private:
     Menu *menu_;
     TrackableObjectReference<XCBMenu> parent_;
     TrackableObjectReference<XCBMenu> child_;
-    int dpi_ = -1;
-    double fontMapDefaultDPI_ = 96.0;
     int x_ = 0;
     int y_ = 0;
     bool hasMouse_ = false;

--- a/src/ui/classic/xcbwindow.cpp
+++ b/src/ui/classic/xcbwindow.cpp
@@ -16,6 +16,7 @@
 #include <xcb/xcb_aux.h>
 #include <xcb/xproto.h>
 #include "fcitx-utils/misc.h"
+#include "fcitx-utils/rect.h"
 #include "common.h"
 #include "window.h"
 #include "xcb_public.h"
@@ -112,8 +113,7 @@ void XCBWindow::createWindow(xcb_visualid_t vid, bool overrideRedirect) {
             : xcb_aux_find_visual_by_id(screen, screen->root_visual),
         physicalWidth_, physicalHeight_));
     if (surface_) {
-        auto s = scale();
-        cairo_surface_set_device_scale(surface_.get(), s, s);
+        cairo_surface_set_device_scale(surface_.get(), scale_, scale_);
         ui_->setCairoDevice(cairo_surface_get_device(surface_.get()));
     }
     contentSurface_.reset();
@@ -138,8 +138,14 @@ void XCBWindow::destroyWindow() {
     }
 }
 
+void XCBWindow::setScale(double scale) {
+    if (scale_ != scale && scale > 0) {
+        scale_ = scale;
+        cairo_surface_set_device_scale(surface_.get(), scale_, scale_);
+    }
+}
+
 void XCBWindow::resize(unsigned int width, unsigned int height) {
-    auto s = scale();
     auto newPhysicalWidth = physicalSizeFromLogical(width);
     auto newPhysicalHeight = physicalSizeFromLogical(height);
     if (newPhysicalWidth != physicalWidth_ ||
@@ -154,10 +160,9 @@ void XCBWindow::resize(unsigned int width, unsigned int height) {
         physicalWidth_ = newPhysicalWidth;
         physicalHeight_ = newPhysicalHeight;
     }
-    cairo_surface_set_device_scale(surface_.get(), s, s);
     Window::resize(width, height);
-    CLASSICUI_DEBUG() << "Resize: " << width << " " << height << " scale " << s
-                      << " physical " << physicalWidth_ << " "
+    CLASSICUI_DEBUG() << "Resize: " << width << " " << height << " scale "
+                      << scale_ << " physical " << physicalWidth_ << " "
                       << physicalHeight_;
 }
 
@@ -169,8 +174,7 @@ cairo_surface_t *XCBWindow::prerender() {
     contentSurface_.reset(cairo_image_surface_create(
         CAIRO_FORMAT_ARGB32, physicalWidth_, physicalHeight_));
 #endif
-    auto s = scale();
-    cairo_surface_set_device_scale(contentSurface_.get(), s, s);
+    cairo_surface_set_device_scale(contentSurface_.get(), scale_, scale_);
     return contentSurface_.get();
 }
 
@@ -183,16 +187,16 @@ void XCBWindow::render() {
     CLASSICUI_DEBUG() << "Render";
 }
 
-int XCBWindow::logicalFromPhysical(int value) const {
-    return static_cast<int>(std::floor(value / scale()));
+double XCBWindow::logicalFromPhysical(double value) const {
+    return std::floor(value / scale_);
 }
 
-int XCBWindow::physicalFromLogical(int value) const {
-    return static_cast<int>(std::lround(value * scale()));
+double XCBWindow::physicalFromLogical(double value) const {
+    return std::round(value * scale_);
 }
 
-int XCBWindow::physicalSizeFromLogical(int size) const {
-    return std::max(1, physicalFromLogical(size));
+int XCBWindow::physicalSizeFromLogical(double size) const {
+    return std::max(1.0, physicalFromLogical(size));
 }
 
 Rect XCBWindow::physicalFromLogical(const Rect &rect) const {

--- a/src/ui/classic/xcbwindow.cpp
+++ b/src/ui/classic/xcbwindow.cpp
@@ -6,6 +6,8 @@
  */
 
 #include "xcbwindow.h"
+#include <algorithm>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <cairo-xcb.h>
@@ -77,9 +79,12 @@ void XCBWindow::createWindow(xcb_visualid_t vid, bool overrideRedirect) {
     params.colormap = colorMap;
     vid_ = vid;
 
+    physicalWidth_ = physicalSizeFromLogical(width_);
+    physicalHeight_ = physicalSizeFromLogical(height_);
+
     auto cookie = xcb_aux_create_window_checked(
-        conn, depth, wid_, screen->root, 0, 0, width_, height_, 0,
-        XCB_WINDOW_CLASS_INPUT_OUTPUT, vid, valueMask, &params);
+        conn, depth, wid_, screen->root, 0, 0, physicalWidth_, physicalHeight_,
+        0, XCB_WINDOW_CLASS_INPUT_OUTPUT, vid, valueMask, &params);
     if (auto error = makeUniqueCPtr(xcb_request_check(conn, cookie))) {
         CLASSICUI_DEBUG() << "Create window failed: "
                           << static_cast<int>(error->error_code) << " " << vid
@@ -105,8 +110,10 @@ void XCBWindow::createWindow(xcb_visualid_t vid, bool overrideRedirect) {
         conn, wid_,
         vid ? xcb_aux_find_visual_by_id(screen, vid)
             : xcb_aux_find_visual_by_id(screen, screen->root_visual),
-        width_, height_));
+        physicalWidth_, physicalHeight_));
     if (surface_) {
+        auto s = scale();
+        cairo_surface_set_device_scale(surface_.get(), s, s);
         ui_->setCairoDevice(cairo_surface_get_device(surface_.get()));
     }
     contentSurface_.reset();
@@ -132,23 +139,38 @@ void XCBWindow::destroyWindow() {
 }
 
 void XCBWindow::resize(unsigned int width, unsigned int height) {
-    const uint32_t vals[2] = {width, height};
-    xcb_configure_window(ui_->connection(), wid_,
-                         XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
-                         vals);
-    cairo_xcb_surface_set_size(surface_.get(), width, height);
+    auto s = scale();
+    auto newPhysicalWidth = physicalSizeFromLogical(width);
+    auto newPhysicalHeight = physicalSizeFromLogical(height);
+    if (newPhysicalWidth != physicalWidth_ ||
+        newPhysicalHeight != physicalHeight_) {
+        const uint32_t vals[2] = {static_cast<uint32_t>(newPhysicalWidth),
+                                  static_cast<uint32_t>(newPhysicalHeight)};
+        xcb_configure_window(ui_->connection(), wid_,
+                             XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT,
+                             vals);
+        cairo_xcb_surface_set_size(surface_.get(), newPhysicalWidth,
+                                   newPhysicalHeight);
+        physicalWidth_ = newPhysicalWidth;
+        physicalHeight_ = newPhysicalHeight;
+    }
+    cairo_surface_set_device_scale(surface_.get(), s, s);
     Window::resize(width, height);
-    CLASSICUI_DEBUG() << "Resize: " << width << " " << height;
+    CLASSICUI_DEBUG() << "Resize: " << width << " " << height << " scale " << s
+                      << " physical " << physicalWidth_ << " "
+                      << physicalHeight_;
 }
 
 cairo_surface_t *XCBWindow::prerender() {
 #if 1
     contentSurface_.reset(cairo_surface_create_similar_image(
-        surface_.get(), CAIRO_FORMAT_ARGB32, width(), height()));
+        surface_.get(), CAIRO_FORMAT_ARGB32, physicalWidth_, physicalHeight_));
 #else
-    contentSurface_.reset(
-        cairo_image_surface_create(CAIRO_FORMAT_ARGB32, width(), height()));
+    contentSurface_.reset(cairo_image_surface_create(
+        CAIRO_FORMAT_ARGB32, physicalWidth_, physicalHeight_));
 #endif
+    auto s = scale();
+    cairo_surface_set_device_scale(contentSurface_.get(), s, s);
     return contentSurface_.get();
 }
 
@@ -160,4 +182,32 @@ void XCBWindow::render() {
     cairo_destroy(cr);
     CLASSICUI_DEBUG() << "Render";
 }
+
+int XCBWindow::logicalFromPhysical(int value) const {
+    return static_cast<int>(std::floor(value / scale()));
+}
+
+int XCBWindow::physicalFromLogical(int value) const {
+    return static_cast<int>(std::lround(value * scale()));
+}
+
+int XCBWindow::physicalSizeFromLogical(int size) const {
+    return std::max(1, physicalFromLogical(size));
+}
+
+Rect XCBWindow::physicalFromLogical(const Rect &rect) const {
+    return Rect()
+        .setLeft(physicalFromLogical(rect.left()))
+        .setTop(physicalFromLogical(rect.top()))
+        .setRight(physicalFromLogical(rect.right()))
+        .setBottom(physicalFromLogical(rect.bottom()));
+}
+
+double XCBWindow::scaleForDPI(int dpi) {
+    if (dpi <= 0) {
+        return 1.0;
+    }
+    return static_cast<double>(dpi) / 96.0;
+}
+
 } // namespace fcitx::classicui

--- a/src/ui/classic/xcbwindow.h
+++ b/src/ui/classic/xcbwindow.h
@@ -13,6 +13,7 @@
 #include <xcb/xproto.h>
 #include "fcitx-utils/handlertable.h"
 #include "fcitx-utils/misc.h"
+#include "fcitx-utils/rect.h"
 #include "window.h"
 #include "xcb_public.h"
 #include "xcbui.h"
@@ -37,6 +38,14 @@ public:
     xcb_window_t wid() const { return wid_; }
 
 protected:
+    virtual double scale() const { return 1.0; }
+    int logicalFromPhysical(int value) const;
+    int physicalFromLogical(int value) const;
+    // X11 window dimensions must be at least one pixel.
+    int physicalSizeFromLogical(int size) const;
+    Rect physicalFromLogical(const Rect &rect) const;
+    static double scaleForDPI(int dpi);
+
     XCBUI *ui_;
     xcb_window_t wid_ = 0;
     xcb_colormap_t colorMapNeedFree_ = 0;
@@ -44,6 +53,8 @@ protected:
     std::unique_ptr<HandlerTableEntry<XCBEventFilter>> eventFilter_;
     UniqueCPtr<cairo_surface_t, cairo_surface_destroy> surface_;
     UniqueCPtr<cairo_surface_t, cairo_surface_destroy> contentSurface_;
+    int physicalWidth_ = 1;
+    int physicalHeight_ = 1;
 };
 
 } // namespace fcitx::classicui

--- a/src/ui/classic/xcbwindow.h
+++ b/src/ui/classic/xcbwindow.h
@@ -36,13 +36,13 @@ public:
     virtual bool filterEvent(xcb_generic_event_t *event) = 0;
 
     xcb_window_t wid() const { return wid_; }
+    void setScale(double scale);
 
 protected:
-    virtual double scale() const { return 1.0; }
-    int logicalFromPhysical(int value) const;
-    int physicalFromLogical(int value) const;
+    double logicalFromPhysical(double value) const;
+    double physicalFromLogical(double value) const;
     // X11 window dimensions must be at least one pixel.
-    int physicalSizeFromLogical(int size) const;
+    int physicalSizeFromLogical(double size) const;
     Rect physicalFromLogical(const Rect &rect) const;
     static double scaleForDPI(int dpi);
 
@@ -55,6 +55,7 @@ protected:
     UniqueCPtr<cairo_surface_t, cairo_surface_destroy> contentSurface_;
     int physicalWidth_ = 1;
     int physicalHeight_ = 1;
+    double scale_ = 1.0;
 };
 
 } // namespace fcitx::classicui


### PR DESCRIPTION
This improves HiDPI support in the classic UI XCB path.

Theme margins, overlays, action images, input window layout metrics, menu spacing, menu icons, separators, click regions, blur regions, and masks are now scaled with the current DPI.

This keeps the input window and XCB menu visually consistent on high-DPI displays instead of mixing scaled text with unscaled theme metrics.

Comparison on my KDE Wayland 175% scale setting, with Xft.dpi: 168 for Xwayland:
Wayland:
<img width="973" height="138" alt="图片" src="https://github.com/user-attachments/assets/4279719c-7414-4f22-8afa-41da558240f1" />

Xwayland, before this fix:
<img width="831" height="117" alt="图片" src="https://github.com/user-attachments/assets/c41350a5-6dc7-46d5-9298-ae706dec0bd2" />

Xwayland, after this fix:
<img width="973" height="138" alt="图片" src="https://github.com/user-attachments/assets/e9db2d0b-b8b1-4187-a2db-1ade47b22dd3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HiDPI support across classic menus and windows.
  * Corrected window sizing, rendering, shadows, blur effects, and popup placement on scaled displays.
  * Improved pointer hit testing and submenu interactions when display scaling is enabled.
  * Updated text and theme element scaling for clearer, more consistent appearance across different DPI settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->