### PR TITLE
Preserve current input method when updating input method group

### DIFF
--- a/src/lib/fcitx/inputmethodmanager.cpp
+++ b/src/lib/fcitx/inputmethodmanager.cpp
@@ -352,7 +352,11 @@ void InputMethodManager::setGroup(InputMethodGroup newGroupInfo) {
                                    return !d->entries_.count(item.name());
                                });
     list.erase(iter, list.end());
-    newGroupInfo.setDefaultInputMethod(newGroupInfo.defaultInputMethod());
+    auto defaultInputMethod = newGroupInfo.defaultInputMethod();
+    if (defaultInputMethod.empty()) {
+        defaultInputMethod = group->defaultInputMethod();
+    }
+    newGroupInfo.setDefaultInputMethod(defaultInputMethod);
     *group = std::move(newGroupInfo);
     if (!d->buildingGroup_ && isCurrent) {
         emit<InputMethodManager::CurrentGroupChanged>(d->groupOrder_.front());

--- a/test/testinstance.cpp
+++ b/test/testinstance.cpp
@@ -54,6 +54,38 @@ void testReloadGlobalConfig(Instance &instance) {
     });
 }
 
+void testSetGroupDefaultInputMethod(Instance &instance) {
+    instance.eventDispatcher().schedule([&instance]() {
+        auto &imManager = instance.inputMethodManager();
+        auto group = imManager.currentGroup();
+        group.inputMethodList().clear();
+        group.inputMethodList().emplace_back("keyboard-us");
+        group.inputMethodList().emplace_back("testim");
+        group.setDefaultInputMethod("testim");
+        imManager.setGroup(group);
+        FCITX_ASSERT(imManager.currentGroup().defaultInputMethod() == "testim");
+
+        InputMethodGroup replacement(group.name());
+        replacement.inputMethodList().emplace_back("keyboard-us");
+        replacement.inputMethodList().emplace_back("testim");
+        imManager.setGroup(std::move(replacement));
+        FCITX_ASSERT(imManager.currentGroup().defaultInputMethod() == "testim");
+
+        InputMethodGroup invalidDefault(group.name());
+        invalidDefault.inputMethodList().emplace_back("keyboard-us");
+        invalidDefault.inputMethodList().emplace_back("testim2");
+        imManager.setGroup(std::move(invalidDefault));
+        FCITX_ASSERT(imManager.currentGroup().defaultInputMethod() ==
+                     "testim2");
+
+        InputMethodGroup fallback(group.name());
+        fallback.inputMethodList().emplace_back("keyboard-us");
+        imManager.setGroup(std::move(fallback));
+        FCITX_ASSERT(imManager.currentGroup().defaultInputMethod() ==
+                     "keyboard-us");
+    });
+}
+
 void testModifierOnlyHotkey(Instance &instance) {
     instance.eventDispatcher().schedule([&instance]() {
         auto defaultGroup = instance.inputMethodManager().currentGroup();
@@ -145,6 +177,7 @@ int main() {
                  std::vector<std::string>{});
     testCheckUpdate(instance);
     testReloadGlobalConfig(instance);
+    testSetGroupDefaultInputMethod(instance);
     testModifierOnlyHotkey(instance);
     instance.eventDispatcher().schedule([&instance]() { instance.exit(); });
     instance.exec();


### PR DESCRIPTION
* Keep the current input method when updating the input method group

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the existing default input method when replacing a group without a specified default.
  * Continued using the replacement group’s default when one is provided.
  * Added fallback behavior to select the first available input method when the configured default is unavailable.
  * Improved consistency when updating input method groups and retaining valid user preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->