### PR TITLE
fcitx-utils/eventloopinterface.h: add missing <ctime> for clockid_t

### DIFF
--- a/src/lib/fcitx-utils/eventloopinterface.h
+++ b/src/lib/fcitx-utils/eventloopinterface.h
@@ -8,6 +8,7 @@
 #define _FCITX_UTILS_EVENTLOOPINTERFACE_H_
 
 #include <cstdint>
+#include <ctime>
 #include <functional>
 #include <memory>
 #include <stdexcept>


### PR DESCRIPTION
Fixes missing `clockid_t` when building with `clang++ -D_LIBCPP_REMOVE_TRANSITIVE_INCLUDES`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a compilation issue by ensuring the required time-related type is available to event-loop interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->