### PR TITLE
Fix clockid include

### DIFF
--- a/src/lib/fcitx-utils/event.cpp
+++ b/src/lib/fcitx-utils/event.cpp
@@ -16,6 +16,10 @@
 #include "eventloopinterface.h"
 #include "macros.h"
 
+#if defined(_WIN32)
+#include <pthread.h>
+#endif
+
 namespace fcitx {
 
 class EventLoopPrivate {

--- a/src/lib/fcitx-utils/event.cpp
+++ b/src/lib/fcitx-utils/event.cpp
@@ -7,9 +7,8 @@
  */
 
 #include "event.h"
+#include <sys/types.h>
 #include <cstdint>
-#include <cstring>
-#include <ctime>
 #include <memory>
 #include <stdexcept>
 #include <utility>
@@ -69,7 +68,7 @@ bool EventLoop::exec() {
 
 void EventLoop::exit() {
     FCITX_D();
-    return d->impl_->exit();
+    d->impl_->exit();
 }
 
 std::unique_ptr<EventSourceIO> EventLoop::addIOEvent(int fd, IOEventFlags flags,

--- a/src/lib/fcitx-utils/event.h
+++ b/src/lib/fcitx-utils/event.h
@@ -16,6 +16,10 @@
 #include <fcitx-utils/flags.h>
 #include <fcitx-utils/macros.h>
 
+#if defined(_WIN32)
+#include <pthread.h>
+#endif
+
 namespace fcitx {
 
 using EventLoopFactory = std::function<std::unique_ptr<EventLoopInterface>()>;

--- a/src/lib/fcitx-utils/event.h
+++ b/src/lib/fcitx-utils/event.h
@@ -7,6 +7,7 @@
 #ifndef _FCITX_UTILS_EVENT_H_
 #define _FCITX_UTILS_EVENT_H_
 
+#include <sys/types.h>
 #include <cstdint>
 #include <functional>
 #include <memory>

--- a/src/lib/fcitx-utils/event_libuv.cpp
+++ b/src/lib/fcitx-utils/event_libuv.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "event_libuv.h"
+#include <sys/types.h>
 #include <cstdint>
 #include <cstdlib>
 #include <ctime>
@@ -25,13 +26,17 @@
 
 namespace fcitx {
 
+namespace {
+
+FCITX_DEFINE_LOG_CATEGORY(libuv_logcategory, "libuv");
+
+}
+
 std::unique_ptr<EventLoopInterface> createDefaultEventLoop() {
     return std::make_unique<EventLoopLibUV>();
 }
 
 const char *defaultEventLoopImplementation() { return "libuv"; }
-
-FCITX_DEFINE_LOG_CATEGORY(libuv_logcategory, "libuv");
 
 static int IOEventFlagsToLibUVFlags(IOEventFlags flags) {
     int result = 0;

--- a/src/lib/fcitx-utils/event_libuv.cpp
+++ b/src/lib/fcitx-utils/event_libuv.cpp
@@ -22,6 +22,10 @@
 #include "log.h"
 #include "trackableobject.h"
 
+#if defined(_WIN32)
+#include <pthread.h>
+#endif
+
 #define FCITX_LIBUV_DEBUG() FCITX_LOGC(::fcitx::libuv_logcategory, Debug)
 
 namespace fcitx {

--- a/src/lib/fcitx-utils/event_libuv.h
+++ b/src/lib/fcitx-utils/event_libuv.h
@@ -19,6 +19,10 @@
 #include <fcitx-utils/trackableobject.h>
 #include <uv.h>
 
+#if defined(_WIN32)
+#include <pthread.h>
+#endif
+
 namespace fcitx {
 
 struct UVLoop {

--- a/src/lib/fcitx-utils/event_libuv.h
+++ b/src/lib/fcitx-utils/event_libuv.h
@@ -7,6 +7,7 @@
 #ifndef _FCITX_UTILS_EVENT_LIBUV_H_
 #define _FCITX_UTILS_EVENT_LIBUV_H_
 
+#include <sys/types.h>
 #include <cstdint>
 #include <cstdlib>
 #include <memory>
@@ -95,9 +96,7 @@ public:
         return state_ == LibUVSourceEnableState::Oneshot;
     }
 
-    inline HandleType *handle() {
-        return reinterpret_cast<HandleType *>(handle_);
-    }
+    HandleType *handle() { return reinterpret_cast<HandleType *>(handle_); }
 
     void init(uv_loop_t *loop) override {
         handle_ = static_cast<uv_handle_t *>(calloc(1, sizeof(HandleType)));

--- a/src/lib/fcitx-utils/event_sdevent.cpp
+++ b/src/lib/fcitx-utils/event_sdevent.cpp
@@ -5,6 +5,7 @@
  *
  */
 
+#include <sys/types.h>
 #include <cstdint>
 #include <cstdlib>
 #include <exception>
@@ -15,6 +16,7 @@
 #include <utility>
 #include <sys/epoll.h>
 #include "eventloopinterface.h"
+#include "fs.h"
 #include "log.h"
 #include "macros.h"
 #include "misc_p.h"

--- a/src/lib/fcitx-utils/eventloopinterface.cpp
+++ b/src/lib/fcitx-utils/eventloopinterface.cpp
@@ -9,6 +9,7 @@
 #include <cstring>
 #include <ctime>
 #include <stdexcept>
+#include <string>
 #include <format>
 
 namespace fcitx {
@@ -39,8 +40,8 @@ uint64_t timespec_load(const struct timespec *ts) {
         return USEC_INFINITY;
     }
 
-    return (uint64_t)ts->tv_sec * USEC_PER_SEC +
-           (uint64_t)ts->tv_nsec / NSEC_PER_USEC;
+    return ((uint64_t)ts->tv_sec * USEC_PER_SEC) +
+           ((uint64_t)ts->tv_nsec / NSEC_PER_USEC);
 }
 
 uint64_t now(clockid_t clock_id) {

--- a/src/lib/fcitx-utils/eventloopinterface.h
+++ b/src/lib/fcitx-utils/eventloopinterface.h
@@ -7,6 +7,7 @@
 #ifndef _FCITX_UTILS_EVENTLOOPINTERFACE_H_
 #define _FCITX_UTILS_EVENTLOOPINTERFACE_H_
 
+#include <sys/types.h>
 #include <cstdint>
 #include <functional>
 #include <memory>

--- a/src/lib/fcitx-utils/eventloopinterface.h
+++ b/src/lib/fcitx-utils/eventloopinterface.h
@@ -16,6 +16,10 @@
 #include <fcitx-utils/flags.h>
 #include <fcitx-utils/macros.h>
 
+#if defined(_WIN32)
+#include <pthread.h>
+#endif
+
 namespace fcitx {
 
 enum class IOEventFlag {

--- a/test/testcustomeventloop.cpp
+++ b/test/testcustomeventloop.cpp
@@ -27,6 +27,10 @@
 #include "fcitx-utils/unixfd.h"
 #include "eventlooptests.h"
 
+#if defined(_WIN32)
+#include <pthread.h>
+#endif
+
 using namespace fcitx;
 
 // Following is also an example of poll() based event loop

--- a/test/testcustomeventloop.cpp
+++ b/test/testcustomeventloop.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <poll.h>
+#include <sys/types.h>
 #include <unistd.h>
 #include <algorithm>
 #include <cassert>
@@ -18,6 +19,7 @@
 #include "fcitx-utils/event.h"
 #include "fcitx-utils/eventdispatcher.h"
 #include "fcitx-utils/eventloopinterface.h"
+#include "fcitx-utils/fs.h"
 #include "fcitx-utils/intrusivelist.h"
 #include "fcitx-utils/macros.h"
 #include "fcitx-utils/misc_p.h"


### PR DESCRIPTION
- **Fix headers Include sys/types for clockid_t**
- **Add header for clockid_t on windows**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event-loop portability and build compatibility across platforms, including Windows.
  * Preserved event-loop timing calculations while improving type handling and header compatibility.

* **Tests**
  * Updated event-loop test coverage to compile consistently across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->