### PR TITLE
feat: block the diagnostic prompt messages in the Deepin desktop envi…

### DIFF
--- a/src/modules/wayland/waylandmodule.cpp
+++ b/src/modules/wayland/waylandmodule.cpp
@@ -726,6 +726,8 @@ void WaylandModule::selfDiagnose() {
                   "see "
                   "https://fcitx-im.org/wiki/Using_Fcitx_5_on_Wayland#GNOME"));
         }
+    } else if (desktop == DesktopType::DEEPIN) {
+        // Per Deepin upstream request, do not show this message for them.
     } else if (desktop == DesktopType::UKUI) {
         // Per UkUI upstream request, do not show this message for them.
     } else {


### PR DESCRIPTION
In the Deepin desktop environment, the Wayland diagnostic prompt will no longer be displayed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wayland self-diagnosis messaging by excluding Deepin from the generic diagnostic notice, consistent with existing desktop environment handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->