### PR TITLE
Migrate to std::ranges and fix clang-tidy issues

### DIFF
--- a/src/frontend/waylandim/waylandimserver.cpp
+++ b/src/frontend/waylandim/waylandimserver.cpp
@@ -265,7 +265,7 @@ void WaylandIMInputContextV1::repeat() {
 void WaylandIMInputContextV1::surroundingTextCallback(const char *text,
                                                       uint32_t cursor,
                                                       uint32_t anchor) {
-    std::string str(text);
+    std::string_view str(text);
     surroundingText().invalidate();
     do {
         auto length = utf8::lengthValidated(str);
@@ -275,13 +275,11 @@ void WaylandIMInputContextV1::surroundingTextCallback(const char *text,
         if (cursor > str.size() || anchor > str.size()) {
             break;
         }
-        size_t cursorByChar =
-            utf8::lengthValidated(str.begin(), str.begin() + cursor);
+        size_t cursorByChar = utf8::lengthValidated(str.substr(0, cursor));
         if (cursorByChar == utf8::INVALID_LENGTH) {
             break;
         }
-        size_t anchorByChar =
-            utf8::lengthValidated(str.begin(), str.begin() + anchor);
+        size_t anchorByChar = utf8::lengthValidated(str.substr(0, anchor));
         if (anchorByChar == utf8::INVALID_LENGTH) {
             break;
         }

--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -95,10 +95,10 @@ InputContextManager &WaylandIMServerV2::inputContextManager() {
 Instance *WaylandIMServerV2::instance() { return parent_->instance(); }
 
 bool WaylandIMServerV2::hasKeyboardGrab() const {
-    return std::any_of(icMap_.begin(), icMap_.end(),
-                       [](const decltype(icMap_)::value_type &ic) {
-                           return ic.second && ic.second->hasKeyboardGrab();
-                       });
+    return std::ranges::any_of(
+        icMap_, [](const decltype(icMap_)::value_type &ic) {
+            return ic.second && ic.second->hasKeyboardGrab();
+        });
 }
 
 void WaylandIMServerV2::init() {

--- a/src/lib/fcitx-config/configuration.cpp
+++ b/src/lib/fcitx-config/configuration.cpp
@@ -11,8 +11,15 @@
 #include <list>
 #include <memory>
 #include <stdexcept>
+#include <string>
+#include <tuple>
 #include <unordered_map>
+#include <utility>
+#include <vector>
+#include "fcitx-utils/macros.h"
 #include "fcitx-utils/stringutils.h"
+#include "option.h"
+#include "rawconfig.h"
 
 namespace fcitx {
 class ConfigurationPrivate {
@@ -27,7 +34,7 @@ Configuration::Configuration()
 Configuration::~Configuration() = default;
 
 void Configuration::dumpDescription(RawConfig &config) const {
-    return dumpDescriptionImpl(config, {});
+    dumpDescriptionImpl(config, {});
 }
 
 void Configuration::dumpDescriptionImpl(
@@ -78,15 +85,13 @@ void Configuration::dumpDescriptionImpl(
 
 bool Configuration::compareHelper(const Configuration &other) const {
     FCITX_D();
-    return std::all_of(
-        d->optionsOrder_.begin(), d->optionsOrder_.end(),
-        [d, &other](const auto &path) {
-            auto optionIter = d->options_.find(path);
-            assert(optionIter != d->options_.end());
-            auto otherOptionIter = other.d_func()->options_.find(path);
-            assert(otherOptionIter != other.d_func()->options_.end());
-            return *optionIter->second == *otherOptionIter->second;
-        });
+    return std::ranges::all_of(d->optionsOrder_, [d, &other](const auto &path) {
+        auto optionIter = d->options_.find(path);
+        assert(optionIter != d->options_.end());
+        auto otherOptionIter = other.d_func()->options_.find(path);
+        assert(otherOptionIter != other.d_func()->options_.end());
+        return *optionIter->second == *otherOptionIter->second;
+    });
     return true;
 }
 
@@ -135,7 +140,7 @@ void Configuration::save(RawConfig &config) const {
 
 void Configuration::addOption(OptionBase *option) {
     FCITX_D();
-    if (d->options_.count(option->path())) {
+    if (d->options_.contains(option->path())) {
         throw std::logic_error("Duplicate option path");
     }
 

--- a/src/lib/fcitx-config/option.h
+++ b/src/lib/fcitx-config/option.h
@@ -7,6 +7,7 @@
 #ifndef _FCITX_CONFIG_OPTION_H_
 #define _FCITX_CONFIG_OPTION_H_
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -157,9 +158,8 @@ struct ListConstrain {
     using ElementType = typename SubConstrain::Type;
     using Type = std::vector<ElementType>;
     bool check(const Type &value) {
-        return std::all_of(
-            value.begin(), value.end(),
-            [this](const ElementType &ele) { return sub_.check(ele); });
+        return std::ranges::all_of(
+            value, [this](const ElementType &ele) { return sub_.check(ele); });
     }
 
     void dumpDescription(RawConfig &config) const {

--- a/src/lib/fcitx-utils/fs.cpp
+++ b/src/lib/fcitx-utils/fs.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <ranges>
 #include "misc.h"
 #include "unixfd.h"
 #include "utf8.h" // IWYU pragma: keep
@@ -198,7 +199,7 @@ std::string dirName(const std::string &path) {
         return result;
     }
 
-    auto iter = std::find(result.rbegin(), result.rend(), '/');
+    auto iter = std::ranges::find(std::ranges::reverse_view(result), '/');
     if (iter != result.rend()) {
         result.erase(iter.base(), result.end());
         // remove trailing slash
@@ -220,7 +221,7 @@ std::string baseName(std::string_view path) {
         return std::string{path};
     }
 
-    auto iter = std::find(path.rbegin(), path.rend(), '/');
+    auto iter = std::ranges::find(std::ranges::reverse_view(path), '/');
     if (iter != path.rend()) {
         path.remove_prefix(std::distance(path.begin(), iter.base()));
     }

--- a/src/lib/fcitx-utils/intrusivelist.h
+++ b/src/lib/fcitx-utils/intrusivelist.h
@@ -214,9 +214,9 @@ public:
         return {old, *nodeGetter};
     }
 
-    reference operator*() { return nodeGetter->toValue(*node); }
+    reference operator*() const { return nodeGetter->toValue(*node); }
 
-    pointer operator->() { return &nodeGetter->toValue(*node); }
+    pointer operator->() const { return &nodeGetter->toValue(*node); }
 
     node_ptr pointed_node() const { return node; }
 

--- a/src/lib/fcitx-utils/key.h
+++ b/src/lib/fcitx-utils/key.h
@@ -22,6 +22,7 @@
 #include <fcitx-utils/flags.h>
 #include <fcitx-utils/keysym.h>
 #include <fcitx-utils/macros.h>
+#include <ranges>
 
 namespace fcitx {
 class Key;
@@ -220,9 +221,9 @@ public:
     /// \see fcitx::Key::check
     template <typename Container>
     bool checkKeyList(const Container &c) const {
-        return std::find_if(c.begin(), c.end(), [this](const Key &toCheck) {
+        return std::ranges::find_if(c, [this](const Key &toCheck) {
                    return check(toCheck);
-               }) != c.end();
+               }) != std::ranges::end(c);
     }
 
     /// Check the current key against a key list and get the matched key index.

--- a/src/lib/fcitx-utils/keydata.cpp
+++ b/src/lib/fcitx-utils/keydata.cpp
@@ -15,9 +15,8 @@ const UnicodeToKeySymTab &unicode_to_keysym_tab() {
         for (size_t i = 0; i < tab.size(); i++) {
             tab[i] = keysym_to_unicode_tab[i];
         }
-        std::stable_sort(tab.begin(), tab.end(), [](auto &lhs, auto &rhs) {
-            return lhs.ucs < rhs.ucs;
-        });
+        std::ranges::stable_sort(
+            tab, [](auto &lhs, auto &rhs) { return lhs.ucs < rhs.ucs; });
         return tab;
     }();
 

--- a/src/lib/fcitx-utils/misc_p.h
+++ b/src/lib/fcitx-utils/misc_p.h
@@ -23,6 +23,7 @@
 #include <fcitx-utils/endian_p.h>
 #include <fcitx-utils/environ.h>
 #include <fcitx-utils/macros.h>
+#include <ranges>
 #include "config.h" // IWYU pragma: keep
 
 #ifdef _WIN32
@@ -44,8 +45,7 @@ decltype(&std::declval<M>().begin()->second) findValue(M &&m, K &&key) {
 
 template <typename C, typename V>
 bool containerContains(C &&container, V &&value) {
-    return std::find(std::begin(container), std::end(container), value) !=
-           std::end(container);
+    return std::ranges::find(container, value) != std::ranges::end(container);
 }
 
 template <typename T>

--- a/src/lib/fcitx-utils/semver.cpp
+++ b/src/lib/fcitx-utils/semver.cpp
@@ -34,7 +34,7 @@ bool isIdChar(char c) {
 
 std::optional<uint32_t> consumeNumericIdentifier(std::string_view &str) {
     std::string_view::iterator endOfNum =
-        std::find_if_not(str.begin(), str.end(), charutils::isdigit);
+        std::ranges::find_if_not(str, charutils::isdigit);
     auto length = std::distance(str.begin(), endOfNum);
     if (length == 0) {
         return std::nullopt;
@@ -58,7 +58,7 @@ std::optional<std::vector<PreReleaseId>>
 consumePrereleaseIds(std::string_view &data) {
     std::vector<PreReleaseId> preReleaseIds;
     std::string_view::const_iterator endOfVersion =
-        std::find_if_not(data.begin(), data.end(), isIdChar);
+        std::ranges::find_if_not(data, isIdChar);
     auto length = std::distance(data.begin(), endOfVersion);
     auto idString = data.substr(0, length);
     auto ids = stringutils::split(idString, ".",
@@ -69,7 +69,7 @@ consumePrereleaseIds(std::string_view &data) {
         }
         // If it's numeric, it need to be a valid numeric.
         // Otherwise it can be anything.
-        if (std::all_of(id.begin(), id.end(), charutils::isdigit)) {
+        if (std::ranges::all_of(id, charutils::isdigit)) {
             std::string_view idView(id);
             auto result = consumeNumericIdentifier(idView);
             if (result && idView.empty()) {
@@ -86,11 +86,11 @@ consumePrereleaseIds(std::string_view &data) {
 }
 
 std::optional<std::vector<std::string>> consumeBuild(std::string_view &data) {
-    if (std::all_of(data.begin(), data.end(), isIdChar)) {
+    if (std::ranges::all_of(data, isIdChar)) {
         auto ids = stringutils::split(data, ".",
                                       stringutils::SplitBehavior::KeepEmpty);
-        if (std::any_of(ids.begin(), ids.end(),
-                        [](const auto &id) { return id.empty(); })) {
+        if (std::ranges::any_of(ids,
+                                [](const auto &id) { return id.empty(); })) {
             return std::nullopt;
         }
         data.remove_prefix(data.size());

--- a/src/lib/fcitx-utils/standardpath.cpp
+++ b/src/lib/fcitx-utils/standardpath.cpp
@@ -294,8 +294,7 @@ private:
                 builtInPath = StandardPath::fcitxPath(builtInPathType);
             }
             std::string path = fs::cleanPath(builtInPath);
-            if (!path.empty() &&
-                std::find(dirs.begin(), dirs.end(), path) == dirs.end()) {
+            if (!path.empty() && std::ranges::find(dirs, path) == dirs.end()) {
                 dirs.push_back(path);
             }
         }

--- a/src/lib/fcitx/inputmethodgroup.cpp
+++ b/src/lib/fcitx/inputmethodgroup.cpp
@@ -7,6 +7,12 @@
 
 #include "inputmethodgroup.h"
 #include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include "fcitx-utils/log.h"
+#include "fcitx-utils/macros.h"
 
 namespace fcitx {
 
@@ -16,7 +22,7 @@ const std::string emptyString;
 
 class InputMethodGroupItemPrivate {
 public:
-    InputMethodGroupItemPrivate(const std::string &name) : name_(name) {}
+    InputMethodGroupItemPrivate(std::string name) : name_(std::move(name)) {}
     FCITX_INLINE_DEFINE_DEFAULT_DTOR_COPY_AND_MOVE_WITHOUT_SPEC(
         InputMethodGroupItemPrivate);
 
@@ -26,7 +32,7 @@ public:
 
 class InputMethodGroupPrivate {
 public:
-    InputMethodGroupPrivate(const std::string &name) : name_(name) {}
+    InputMethodGroupPrivate(std::string name) : name_(std::move(name)) {}
 
     std::string name_;
     std::vector<InputMethodGroupItem> inputMethodList_;
@@ -86,10 +92,10 @@ InputMethodGroup::inputMethodList() const {
 
 void InputMethodGroup::setDefaultInputMethod(const std::string &im) {
     FCITX_D();
-    if (std::any_of(d->inputMethodList_.begin(), d->inputMethodList_.end(),
-                    [&im](const InputMethodGroupItem &item) {
-                        return item.name() == im;
-                    })) {
+    if (std::ranges::any_of(d->inputMethodList_,
+                            [&im](const InputMethodGroupItem &item) {
+                                return item.name() == im;
+                            })) {
         if (d->inputMethodList_.size() > 1 &&
             d->inputMethodList_[0].name() == im) {
             d->defaultInputMethod_ = d->inputMethodList_[1].name();
@@ -109,8 +115,8 @@ void InputMethodGroup::setDefaultInputMethod(const std::string &im) {
 
 const std::string &InputMethodGroup::layoutFor(const std::string &im) const {
     FCITX_D();
-    auto iter = std::find_if(
-        d->inputMethodList_.begin(), d->inputMethodList_.end(),
+    auto iter = std::ranges::find_if(
+        d->inputMethodList_,
         [&im](const InputMethodGroupItem &item) { return item.name() == im; });
     if (iter != d->inputMethodList_.end()) {
         return iter->layout();

--- a/src/lib/fcitx/inputmethodmanager.cpp
+++ b/src/lib/fcitx/inputmethodmanager.cpp
@@ -39,6 +39,15 @@
 
 namespace fcitx {
 
+namespace {
+
+bool checkEntry(const InputMethodEntry &entry,
+                const std::unordered_set<std::string> &inputMethods) {
+    return !entry.name().empty() && !entry.uniqueName().empty() &&
+           !entry.addon().empty() && inputMethods.contains(entry.addon());
+}
+} // namespace
+
 class InputMethodManagerPrivate : QPtrHolder<InputMethodManager> {
 public:
     InputMethodManagerPrivate(AddonManager *addonManager_,
@@ -71,12 +80,6 @@ public:
     int64_t timestamp_ = 0;
 };
 
-bool checkEntry(const InputMethodEntry &entry,
-                const std::unordered_set<std::string> &inputMethods) {
-    return !(entry.name().empty() || entry.uniqueName().empty() ||
-             entry.addon().empty() || inputMethods.count(entry.addon()) == 0);
-}
-
 void InputMethodManagerPrivate::loadConfig(
     const std::function<void(InputMethodManager &)>
         &buildDefaultGroupCallback) {
@@ -107,7 +110,7 @@ void InputMethodManagerPrivate::loadConfig(
             group.setDefaultLayout(groupConfig.defaultLayout.value());
             const auto &items = groupConfig.items.value();
             for (const auto &item : items) {
-                if (!entries_.count(item.name.value())) {
+                if (!entries_.contains(item.name.value())) {
                     FCITX_WARN() << "Group Item " << item.name.value()
                                  << " in group " << groupConfig.name.value()
                                  << " is not valid. Removed.";
@@ -172,7 +175,7 @@ void InputMethodManagerPrivate::loadStaticEntries(
     for (const auto &[fileName, fullName] : filesMap) {
         const auto u8name = fileName.stem().u8string();
         std::string name(u8name.begin(), u8name.end());
-        if (entries_.count(name) != 0) {
+        if (entries_.contains(name)) {
             continue;
         }
         RawConfig config;
@@ -213,7 +216,7 @@ void InputMethodManagerPrivate::loadDynamicEntries(
             // ok we can't let you register something weird.
             if (checkEntry(newEntry, addonNames) &&
                 newEntry.addon() == addonName &&
-                entries_.count(newEntry.uniqueName()) == 0) {
+                !entries_.contains(newEntry.uniqueName())) {
                 entries_.emplace(std::string(newEntry.uniqueName()),
                                  std::move(newEntry));
             }
@@ -273,8 +276,7 @@ void InputMethodManager::setCurrentGroup(const std::string &groupName) {
     if (groupName == d->groupOrder_.front()) {
         return;
     }
-    auto iter =
-        std::find(d->groupOrder_.begin(), d->groupOrder_.end(), groupName);
+    auto iter = std::ranges::find(d->groupOrder_, groupName);
     if (iter != d->groupOrder_.end()) {
         emit<InputMethodManager::CurrentGroupAboutToChange>(
             d->groupOrder_.front());
@@ -288,8 +290,7 @@ void InputMethodManager::enumerateGroupTo(const std::string &groupName) {
     if (groupName == d->groupOrder_.front()) {
         return;
     }
-    auto iter =
-        std::find(d->groupOrder_.begin(), d->groupOrder_.end(), groupName);
+    auto iter = std::ranges::find(d->groupOrder_, groupName);
     if (iter != d->groupOrder_.end()) {
         emit<InputMethodManager::CurrentGroupAboutToChange>(
             d->groupOrder_.front());
@@ -347,11 +348,9 @@ void InputMethodManager::setGroup(InputMethodGroup newGroupInfo) {
         }
     }
     auto &list = newGroupInfo.inputMethodList();
-    auto iter = std::remove_if(list.begin(), list.end(),
-                               [d](const InputMethodGroupItem &item) {
-                                   return !d->entries_.count(item.name());
-                               });
-    list.erase(iter, list.end());
+    std::erase_if(list, [d](const InputMethodGroupItem &item) {
+        return !d->entries_.contains(item.name());
+    });
     auto defaultInputMethod = newGroupInfo.defaultInputMethod();
     if (defaultInputMethod.empty()) {
         defaultInputMethod = group->defaultInputMethod();
@@ -368,13 +367,13 @@ void InputMethodManagerPrivate::setGroupOrder(
     groupOrder_.clear();
     std::unordered_set<std::string> added;
     for (const auto &groupName : groupOrder) {
-        if (groups_.count(groupName)) {
+        if (groups_.contains(groupName)) {
             groupOrder_.push_back(groupName);
             added.insert(groupName);
         }
     }
     for (auto &p : groups_) {
-        if (!added.count(p.first)) {
+        if (!added.contains(p.first)) {
             groupOrder_.push_back(p.first);
         }
     }

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1585,14 +1585,13 @@ bool Instance::canRestart() const {
     FCITX_D();
     const auto &addonNames = d->addonManager_.loadedAddonNames();
     return d->binaryMode_ &&
-           std::all_of(addonNames.begin(), addonNames.end(),
-                       [d](const std::string &name) {
-                           auto *addon = d->addonManager_.lookupAddon(name);
-                           if (!addon) {
-                               return true;
-                           }
-                           return addon->canRestart();
-                       });
+           std::ranges::all_of(addonNames, [d](const std::string &name) {
+               auto *addon = d->addonManager_.lookupAddon(name);
+               if (!addon) {
+                   return true;
+               }
+               return addon->canRestart();
+           });
 }
 
 InstancePrivate *Instance::privateData() {
@@ -1726,11 +1725,11 @@ Instance::watchEvent(EventType type, EventWatcherPhase phase,
 
 bool groupContains(const InputMethodGroup &group, const std::string &name) {
     const auto &list = group.inputMethodList();
-    auto iter = std::find_if(list.begin(), list.end(),
-                             [&name](const InputMethodGroupItem &item) {
-                                 return item.name() == name;
-                             });
-    return iter != list.end();
+    auto iter =
+        std::ranges::find_if(list, [&name](const InputMethodGroupItem &item) {
+            return item.name() == name;
+        });
+    return iter != std::ranges::end(list);
 }
 
 std::string Instance::inputMethod(InputContext *ic) {
@@ -2109,11 +2108,11 @@ void Instance::setCurrentInputMethod(InputContext *ic, const std::string &name,
 
     auto &imManager = inputMethodManager();
     const auto &imList = imManager.currentGroup().inputMethodList();
-    auto iter = std::find_if(imList.begin(), imList.end(),
-                             [&name](const InputMethodGroupItem &item) {
-                                 return item.name() == name;
-                             });
-    if (iter == imList.end()) {
+    auto iter =
+        std::ranges::find_if(imList, [&name](const InputMethodGroupItem &item) {
+            return item.name() == name;
+        });
+    if (iter == std::ranges::end(imList)) {
         return;
     }
 

--- a/src/lib/fcitx/userinterfacemanager.cpp
+++ b/src/lib/fcitx/userinterfacemanager.cpp
@@ -6,7 +6,27 @@
  */
 
 #include "userinterfacemanager.h"
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <list>
+#include <memory>
 #include <set>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include "fcitx-utils/capabilityflags.h"
+#include "fcitx-utils/connectableobject.h"
+#include "fcitx-utils/log.h"
+#include "fcitx-utils/macros.h"
+#include "fcitx-utils/misc.h"
+#include "fcitx-utils/signals.h"
+#include "fcitx-utils/stringutils.h"
+#include "fcitx/addoninfo.h"
 #include "action.h"
 #include "event.h"
 #include "inputcontext.h"
@@ -14,6 +34,8 @@
 #include "userinterface.h"
 
 namespace fcitx {
+
+namespace {
 
 struct UserInterfaceComponentHash {
     template <typename T>
@@ -34,13 +56,28 @@ public:
         return value;
     }
     void returnId(int id) {
-        assert(id <= maxId_ && freeList_.count(id) == 0);
+        assert(id <= maxId_ && !freeList_.contains(id));
         freeList_.insert(id);
     }
 
     std::set<int> freeList_;
     int maxId_ = 0;
 };
+
+bool isUserInterfaceValid(UserInterface *userInterface,
+                          InputMethodMode inputMethodMode) {
+    if (userInterface == nullptr || !userInterface->available() ||
+        userInterface->addonInfo() == nullptr) {
+        return false;
+    }
+
+    return (userInterface->addonInfo()->uiType() == UIType::OnScreenKeyboard &&
+            inputMethodMode == InputMethodMode::OnScreenKeyboard) ||
+           (userInterface->addonInfo()->uiType() == UIType::PhyscialKeyboard &&
+            inputMethodMode == InputMethodMode::PhysicalKeyboard);
+}
+
+} // namespace
 
 class UserInterfaceManagerPrivate {
 public:
@@ -146,7 +183,7 @@ void UserInterfaceManager::load(const std::string &uiName) {
     auto names = d->addonManager_->addonNames(AddonCategory::UI);
 
     d->uis_.clear();
-    if (names.count(uiName)) {
+    if (names.contains(uiName)) {
         auto *ui = d->addonManager_->addon(uiName, true);
         if (ui) {
             d->uis_.push_back(uiName);
@@ -155,23 +192,23 @@ void UserInterfaceManager::load(const std::string &uiName) {
 
     if (d->uis_.empty()) {
         d->uis_.insert(d->uis_.end(), names.begin(), names.end());
-        std::sort(d->uis_.begin(), d->uis_.end(),
-                  [d](const std::string &lhs, const std::string &rhs) {
-                      const auto *linfo = d->addonManager_->addonInfo(lhs);
-                      const auto *rinfo = d->addonManager_->addonInfo(rhs);
-                      if (!linfo) {
-                          return false;
-                      }
-                      if (!rinfo) {
-                          return true;
-                      }
-                      auto lp = linfo->uiPriority();
-                      auto rp = rinfo->uiPriority();
-                      if (lp == rp) {
-                          return lhs > rhs;
-                      }
-                      return lp > rp;
-                  });
+        std::ranges::sort(
+            d->uis_, [d](const std::string &lhs, const std::string &rhs) {
+                const auto *linfo = d->addonManager_->addonInfo(lhs);
+                const auto *rinfo = d->addonManager_->addonInfo(rhs);
+                if (!linfo) {
+                    return false;
+                }
+                if (!rinfo) {
+                    return true;
+                }
+                auto lp = linfo->uiPriority();
+                auto rp = rinfo->uiPriority();
+                if (lp == rp) {
+                    return lhs > rhs;
+                }
+                return lp > rp;
+            });
     }
     updateAvailability();
 }
@@ -270,19 +307,6 @@ void UserInterfaceManager::flush() {
     }
     d->updateIndex_.clear();
     d->updateList_.clear();
-}
-
-bool isUserInterfaceValid(UserInterface *userInterface,
-                          InputMethodMode inputMethodMode) {
-    if (userInterface == nullptr || !userInterface->available() ||
-        userInterface->addonInfo() == nullptr) {
-        return false;
-    }
-
-    return (userInterface->addonInfo()->uiType() == UIType::OnScreenKeyboard &&
-            inputMethodMode == InputMethodMode::OnScreenKeyboard) ||
-           (userInterface->addonInfo()->uiType() == UIType::PhyscialKeyboard &&
-            inputMethodMode == InputMethodMode::PhysicalKeyboard);
 }
 
 void UserInterfaceManager::updateAvailability() {

--- a/src/modules/emoji/emoji.cpp
+++ b/src/modules/emoji/emoji.cpp
@@ -6,14 +6,25 @@
  */
 #include "emoji.h"
 #include <sys/stat.h>
+#include <algorithm>
+#include <cstdint>
 #include <functional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 #include <zlib.h>
 #include "fcitx-utils/charutils.h"
+#include "fcitx-utils/fs.h"
+#include "fcitx-utils/log.h"
 #include "fcitx-utils/misc_p.h"
 #include "fcitx-utils/standardpaths.h"
 #include "fcitx-utils/stringutils.h"
 #include "fcitx-utils/utf8.h"
 #include "fcitx/addonfactory.h"
+#include "fcitx/addoninstance.h"
 
 namespace fcitx {
 
@@ -160,7 +171,7 @@ void Emoji::prefix(
 
 namespace {
 bool noSpace(std::string_view str) {
-    return std::any_of(str.begin(), str.end(), charutils::isspace);
+    return std::ranges::any_of(str, charutils::isspace);
 }
 } // namespace
 
@@ -236,7 +247,9 @@ const EmojiMap *Emoji::loadEmoji(const std::string &language,
 }
 
 class EmojiModuleFactory : public AddonFactory {
-    AddonInstance *create(AddonManager *) override { return new Emoji; }
+    AddonInstance *create(AddonManager * /*manager*/) override {
+        return new Emoji;
+    }
 };
 
 } // namespace fcitx

--- a/src/modules/spell/spell-custom-dict.cpp
+++ b/src/modules/spell/spell-custom-dict.cpp
@@ -9,9 +9,15 @@
 #include "spell-custom-dict.h"
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/types.h>
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 #include <format>
 #include "fcitx-utils/cutf8.h"
 #include "fcitx-utils/endian_p.h"
@@ -77,11 +83,15 @@
 
 #define DICT_BIN_MAGIC "FSCD0000"
 
+namespace fcitx {
+
+namespace {
+
 bool checkLang(const std::string &full_lang, const std::string &lang) {
     if (full_lang.empty() || lang.empty()) {
         return false;
     }
-    if (full_lang.compare(0, lang.size(), lang) != 0) {
+    if (!full_lang.starts_with(lang)) {
         return false;
     }
     switch (full_lang[lang.size()]) {
@@ -94,11 +104,9 @@ bool checkLang(const std::string &full_lang, const std::string &lang) {
     return false;
 }
 
-static inline uint32_t load_le32(const void *p) {
-    return le32toh(*(uint32_t *)p);
-}
+inline uint32_t load_le32(const void *p) { return le32toh(*(uint32_t *)p); }
 
-static bool isFirstCapital(const std::string &str) {
+bool isFirstCapital(const std::string &str) {
     if (str.empty()) {
         return false;
     }
@@ -121,12 +129,12 @@ static bool isFirstCapital(const std::string &str) {
     return true;
 }
 
-static bool isAllCapital(const std::string &str) {
+bool isAllCapital(const std::string &str) {
     if (str.empty()) {
         return false;
     }
-    for (auto iter = str.begin(); iter != str.end(); iter++) {
-        switch (*iter) {
+    for (char iter : str) {
+        switch (iter) {
         case_a_z:
             return false;
         default:
@@ -142,14 +150,14 @@ enum {
     CUSTOM_ALL_CAPITAL,
 };
 
-static void toUpperString(std::string &str) {
+void toUpperString(std::string &str) {
     if (str.empty()) {
         return;
     }
-    for (auto iter = str.begin(); iter != str.end(); iter++) {
-        switch (*iter) {
+    for (char &iter : str) {
+        switch (iter) {
         case_a_z:
-            *iter += 'A' - 'a';
+            iter += 'A' - 'a';
             break;
         default:
             break;
@@ -157,7 +165,7 @@ static void toUpperString(std::string &str) {
     }
 }
 
-namespace fcitx {
+} // namespace
 
 class SpellCustomDictEn : public SpellCustomDict {
 public:
@@ -179,6 +187,8 @@ public:
         switch (c2) {
         case_A_Z:
             c2 += 'a' - 'A';
+            break;
+        default:
             break;
         }
         return c1 == c2;
@@ -218,14 +228,6 @@ public:
         }
     }
 };
-
-#if 0
-static inline uint16_t
-load_le16(const void* p)
-{
-    return le16toh(*(uint16_t*)p);
-}
-#endif
 
 void SpellCustomDict::loadDict(const std::string &lang) {
     auto fd = StandardPaths::global().open(
@@ -427,20 +429,19 @@ SpellCustomDict::hint(const std::string &str, size_t limit) {
         return lhs.second < rhs.second;
     };
     for (const auto &wordOffset : words_) {
-        int dist;
         const char *dictWord = data_.data() + wordOffset;
-        if ((dist = getDistance(real_word, word_len, dictWord)) >= 0) {
+        if (int dist = getDistance(real_word, word_len, dictWord); dist >= 0) {
             tops.emplace_back(dictWord, dist);
-            std::push_heap(tops.begin(), tops.end(), compare);
+            std::ranges::push_heap(tops, compare);
             if (tops.size() > limit) {
-                std::pop_heap(tops.begin(), tops.end(), compare);
+                std::ranges::pop_heap(tops, compare);
                 tops.pop_back();
             }
         }
     }
 
     // Or sort heap?..
-    std::sort(tops.begin(), tops.end(), compare);
+    std::ranges::sort(tops, compare);
 
     result.reserve(tops.size());
     for (auto &top : tops) {

--- a/src/modules/spell/spell-enchant.cpp
+++ b/src/modules/spell/spell-enchant.cpp
@@ -7,10 +7,21 @@
  */
 
 #include "spell-enchant.h"
-#include <time.h>
+#include <algorithm>
+#include <ctime>
+#include <iterator>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 #include <enchant.h>
+#include <ranges>
+#include "fcitx-utils/charutils.h"
+#include "fcitx-utils/misc_p.h"
+#include "fcitx-utils/stringutils.h"
 #include "fcitx/misc_p.h"
+#include "spell.h"
 
 namespace fcitx {
 namespace {
@@ -24,13 +35,13 @@ SpellType guessSpellType(const std::string &input) {
         return SpellType::AllLower;
     }
 
-    if (std::all_of(input.begin(), input.end(),
-                    [](char c) { return charutils::isupper(c); })) {
+    if (std::ranges::all_of(input,
+                            [](char c) { return charutils::isupper(c); })) {
         return SpellType::AllUpper;
     }
 
-    if (std::all_of(input.begin() + 1, input.end(),
-                    [](char c) { return charutils::islower(c); })) {
+    if (std::ranges::all_of(input | std::views::drop(1),
+                            [](char c) { return charutils::islower(c); })) {
         if (charutils::isupper(input[0])) {
             return SpellType::FirstUpper;
         }
@@ -50,8 +61,8 @@ std::string formatWord(const std::string &input, SpellType type) {
     std::string result;
     if (type == SpellType::AllUpper) {
         result.reserve(input.size());
-        std::transform(input.begin(), input.end(), std::back_inserter(result),
-                       charutils::toupper);
+        std::ranges::transform(input, std::back_inserter(result),
+                               charutils::toupper);
     } else {
         // FirstUpper
         result = input;
@@ -61,8 +72,6 @@ std::string formatWord(const std::string &input, SpellType type) {
     }
     return result;
 }
-
-} // namespace
 
 template <typename Callback>
 auto foreachLanguage(const std::string &lang, const std::string &systemLanguage,
@@ -81,7 +90,7 @@ auto foreachLanguage(const std::string &lang, const std::string &systemLanguage,
         langList.push_back(systemLanguage);
     };
     langList.push_back(lang);
-    if (auto *fallback = findValue(fallbackLanguage, lang)) {
+    if (const auto *fallback = findValue(fallbackLanguage, lang)) {
         for (const auto &fallbackLang : *fallback) {
             if (fallbackLang != langList[0]) {
                 langList.push_back(fallbackLang);
@@ -97,6 +106,8 @@ auto foreachLanguage(const std::string &lang, const std::string &systemLanguage,
     }
     return result;
 }
+
+} // namespace
 
 SpellEnchant::SpellEnchant(Spell *spell)
     : SpellBackend(spell), broker_(enchant_broker_init()),

--- a/src/modules/unicode/charselectdata.cpp
+++ b/src/modules/unicode/charselectdata.cpp
@@ -21,12 +21,14 @@
 #include <cstdint>
 #include <cstring>
 #include <exception>
+#include <iterator>
 #include <set>
 #include <string>
 #include <utility>
 #include <vector>
 #include <format>
 #include "fcitx-utils/charutils.h"
+#include "fcitx-utils/endian_p.h"
 #include "fcitx-utils/fs.h"
 #include "fcitx-utils/i18n.h"
 #include "fcitx-utils/macros.h"
@@ -63,13 +65,13 @@ static const char JAMO_T_TABLE[][4] = {"",   "G",  "GG", "GS", "N",  "NJ", "NH",
 std::string FormatCode(uint32_t code, int length, const char *prefix);
 
 uint16_t FromLittleEndian16(const char *d) {
-    const uint8_t *data = (const uint8_t *)d;
+    const auto *data = reinterpret_cast<const uint8_t *>(d);
     uint16_t t;
     memcpy(&t, data, sizeof(t));
     return le16toh(t);
 }
 
-CharSelectData::CharSelectData() {}
+CharSelectData::CharSelectData() = default;
 
 bool CharSelectData::load() {
     if (loaded_) {
@@ -376,7 +378,7 @@ std::vector<uint32_t> CharSelectData::find(const std::string &needle) const {
     }
 
     returnRes.reserve(returnRes.size() + result.size());
-    std::copy(result.begin(), result.end(), std::back_inserter(returnRes));
+    std::ranges::copy(result, std::back_inserter(returnRes));
     return returnRes;
 }
 
@@ -580,7 +582,7 @@ void CharSelectData::createIndex() {
     for (auto &p : index_) {
         indexList_.push_back(&p);
     }
-    std::sort(indexList_.begin(), indexList_.end(), [](auto lhs, auto rhs) {
+    std::ranges::sort(indexList_, [](auto lhs, auto rhs) {
         return strcasecmp(lhs->first.c_str(), rhs->first.c_str()) < 0;
     });
 }

--- a/src/modules/unicode/unicodetempmode.cpp
+++ b/src/modules/unicode/unicodetempmode.cpp
@@ -48,7 +48,7 @@ bool isHexKey(const Key &key) {
 
 bool bufferIsValid(const std::string &input, uint32_t *ret) {
     std::string hex = input;
-    std::transform(hex.begin(), hex.end(), hex.begin(), charutils::tolower);
+    std::ranges::for_each(hex, [](char &c) { c = charutils::tolower(c); });
     uint32_t value = 0;
     try {
         value = stoi(hex, nullptr, 16);
@@ -351,15 +351,15 @@ void UnicodeTempMode::updateUI(InputContext *inputContext, bool trigger) {
                     auto primary =
                         unicode_->clipboard()->call<IClipboard::primary>(
                             inputContext);
-                    if (std::find(selectedTexts.begin(), selectedTexts.end(),
-                                  primary) == selectedTexts.end()) {
+                    if (std::ranges::find(selectedTexts, primary) ==
+                        selectedTexts.end()) {
                         selectedTexts.push_back(std::move(primary));
                     }
                 }
                 auto clip = unicode_->clipboard()->call<IClipboard::clipboard>(
                     inputContext);
-                if (std::find(selectedTexts.begin(), selectedTexts.end(),
-                              clip) == selectedTexts.end()) {
+                if (std::ranges::find(selectedTexts, clip) ==
+                    selectedTexts.end()) {
                     selectedTexts.push_back(std::move(clip));
                 }
             }

--- a/src/modules/wayland/waylandmodule.cpp
+++ b/src/modules/wayland/waylandmodule.cpp
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <exception>
 #include <memory>
 #include <optional>
@@ -225,11 +226,11 @@ WaylandModule::WaylandModule(fcitx::Instance *instance)
 void WaylandModule::reloadConfig() { readAsIni(config_, "conf/wayland.conf"); }
 
 bool WaylandModule::openConnection(const std::string &name) {
-    if (conns_.count(name)) {
+    if (conns_.contains(name)) {
         return false;
     }
 
-    if (auto defaultConnection = findValue(conns_, "")) {
+    if (auto *defaultConnection = findValue(conns_, "")) {
         if (name == defaultConnection->get()->realName()) {
             return false;
         }
@@ -264,7 +265,7 @@ bool WaylandModule::openConnectionSocketWithName(int fd,
                                                  const std::string &realName) {
     UnixFD guard = UnixFD::own(fd);
 
-    if (conns_.count(name)) {
+    if (conns_.contains(name)) {
         return false;
     }
 
@@ -284,6 +285,8 @@ bool WaylandModule::openConnectionSocketWithName(int fd,
         guard.release();
         newConnection = iter.first->second.get();
     } catch (const std::exception &e) {
+        FCITX_ERROR() << "Open wayland connection with socket failed: "
+                      << e.what();
     }
     if (newConnection) {
         refreshCanRestart();
@@ -341,6 +344,8 @@ bool WaylandModule::reopenConnectionSocket(const std::string &displayName,
             std::make_unique<WaylandConnection>(this, name, fd, displayName);
         guard.release();
     } catch (const std::exception &e) {
+        FCITX_ERROR() << "Open wayland connection: " << name
+                      << " failed: " << e.what();
     }
     if (newConnection) {
         // At this point connection is already constructed, now we try to
@@ -407,10 +412,10 @@ void WaylandModule::onConnectionClosed(WaylandConnection &conn) {
 }
 
 void WaylandModule::refreshCanRestart() {
-    setCanRestart(std::all_of(conns_.begin(), conns_.end(),
-                              [](const decltype(conns_)::value_type &conn) {
-                                  return !conn.second->isWaylandSocket();
-                              }));
+    setCanRestart(std::ranges::all_of(
+        conns_, [](const decltype(conns_)::value_type &conn) {
+            return !conn.second->isWaylandSocket();
+        }));
 }
 
 void WaylandModule::reloadXkbOption() {
@@ -423,7 +428,7 @@ void WaylandModule::reloadXkbOptionReal() {
     if (!isWaylandSession_) {
         return;
     }
-    auto connection = findValue(conns_, "");
+    auto *connection = findValue(conns_, "");
     if (!connection) {
         return;
     }
@@ -432,15 +437,15 @@ void WaylandModule::reloadXkbOptionReal() {
     std::optional<std::string> xkbOption = std::nullopt;
     if (isKDE5Plus()) {
 
-        auto dbusAddon = dbus();
+        auto *dbusAddon = dbus();
         if (!dbusAddon) {
             return;
         }
 
         fcitx::RawConfig config;
         readAsIni(config, StandardPathsType::Config, "kxkbrc");
-        auto model = config.valueByPath("Layout/Model");
-        auto options = config.valueByPath("Layout/Options");
+        const auto *model = config.valueByPath("Layout/Model");
+        const auto *options = config.valueByPath("Layout/Options");
         xkbOption = (options ? *options : "");
         instance_->setXkbParameters((*connection)->focusGroup()->display(),
                                     DEFAULT_XKB_RULES, model ? *model : "",
@@ -455,7 +460,7 @@ void WaylandModule::reloadXkbOptionReal() {
 
             gchar **value = g_settings_get_strv(settings.get(), "xkb-options");
             if (value) {
-                auto options = g_strjoinv(",", value);
+                auto *options = g_strjoinv(",", value);
                 xkbOption = (options ? options : "");
                 instance_->setXkbParameters(
                     (*connection)->focusGroup()->display(), DEFAULT_XKB_RULES,
@@ -467,7 +472,7 @@ void WaylandModule::reloadXkbOptionReal() {
         }
     }
 #ifdef ENABLE_X11
-    if (auto xcbAddon = xcb(); xcbAddon && xkbOption) {
+    if (auto *xcbAddon = xcb(); xcbAddon && xkbOption) {
         xcbAddon->call<IXCBModule::setXkbOption>(
             xcbAddon->call<IXCBModule::mainDisplay>(), *xkbOption);
     }

--- a/src/modules/xcb/xcbeventreader.cpp
+++ b/src/modules/xcb/xcbeventreader.cpp
@@ -5,8 +5,16 @@
  *
  */
 #include "xcbeventreader.h"
+#include <list>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <utility>
 #include <xcb/xcb.h>
 #include "fcitx-utils/event.h"
+#include "fcitx-utils/eventloopinterface.h"
+#include "fcitx-utils/log.h"
+#include "fcitx-utils/misc.h"
 #include "xcbconnection.h"
 #include "xcbmodule.h"
 

--- a/test/testemoji.cpp
+++ b/test/testemoji.cpp
@@ -5,6 +5,8 @@
  *
  */
 #include <fcntl.h>
+#include <algorithm>
+#include <string>
 #include "fcitx-utils/log.h"
 #include "fcitx-utils/standardpaths.h"
 #include "fcitx-utils/testing.h"
@@ -24,12 +26,10 @@ int main() {
     auto *emoji = manager.addon("emoji", true);
     FCITX_ASSERT(emoji);
     auto emojis = emoji->call<IEmoji::query>("zh", "大笑", false);
-    FCITX_ASSERT(std::find(emojis.begin(), emojis.end(), "\xf0\x9f\x98\x84") !=
-                 emojis.end())
+    FCITX_ASSERT(std::ranges::find(emojis, "\xf0\x9f\x98\x84") != emojis.end())
         << emojis;
     emojis = emoji->call<IEmoji::query>("en", "eggplant", false);
-    FCITX_ASSERT(std::find(emojis.begin(), emojis.end(), "\xf0\x9f\x8d\x86") !=
-                 emojis.end())
+    FCITX_ASSERT(std::ranges::find(emojis, "\xf0\x9f\x8d\x86") != emojis.end())
         << emojis;
 
     auto files =

--- a/test/testlist.cpp
+++ b/test/testlist.cpp
@@ -6,12 +6,17 @@
  */
 
 #include <algorithm>
+#include <cstddef>
 #include <iterator>
+#include <type_traits>
+#include <utility>
 #include <vector>
 #include "fcitx-utils/intrusivelist.h"
 #include "fcitx-utils/log.h"
 
 using namespace fcitx;
+
+namespace {
 
 struct Foo : public IntrusiveListNode {
     Foo(int d) : data(d) {}
@@ -20,7 +25,10 @@ struct Foo : public IntrusiveListNode {
 
 void test_regular() {
     IntrusiveList<Foo> list;
-    Foo a(1), b(2), c(3), d(4);
+    Foo a(1);
+    Foo b(2);
+    Foo c(3);
+    Foo d(4);
     list.push_back(a);
     list.push_back(b);
     list.push_back(c);
@@ -47,13 +55,12 @@ void test_regular() {
     FCITX_ASSERT(idx == 3);
 
     static_assert(
-        std::is_same<
+        std::is_same_v<
             std::iterator_traits<decltype(list)::iterator>::iterator_category,
-            std::bidirectional_iterator_tag>::value,
+            std::bidirectional_iterator_tag>,
         "Error");
 
-    auto iter = std::find_if(list.begin(), list.end(),
-                             [](Foo &f) { return f.data == 2; });
+    auto iter = std::ranges::find_if(list, [](Foo &f) { return f.data == 2; });
     FCITX_ASSERT(iter != list.end());
     list.erase(iter);
     FCITX_ASSERT(list.size() == 2);
@@ -95,7 +102,10 @@ void test_move() {
     {
         // something to empty
         IntrusiveList<Foo> list;
-        Foo a(1), b(2), c(3), d(4);
+        Foo a(1);
+        Foo b(2);
+        Foo c(3);
+        Foo d(4);
         list.push_back(a);
         list.push_back(b);
         list.push_back(c);
@@ -119,7 +129,10 @@ void test_move() {
         // something to empty
         IntrusiveList<Foo> list;
         IntrusiveList<Foo> list2;
-        Foo a(1), b(2), c(3), d(4);
+        Foo a(1);
+        Foo b(2);
+        Foo c(3);
+        Foo d(4);
         list2.push_back(a);
         list2.push_back(b);
         list2.push_back(c);
@@ -137,7 +150,10 @@ void test_const() {
     {
         // something to empty
         IntrusiveList<Foo> list;
-        Foo a(1), b(2), c(3), d(4);
+        Foo a(1);
+        Foo b(2);
+        Foo c(3);
+        Foo d(4);
         list.push_back(a);
         list.push_back(b);
         list.push_back(c);
@@ -145,7 +161,7 @@ void test_const() {
         const IntrusiveList<Foo> &cref = list;
         std::vector<int> check = {1, 2, 3, 4};
         size_t idx = 0;
-        for (auto &f : cref) {
+        for (const auto &f : cref) {
             FCITX_ASSERT(f.data == check[idx]);
             idx++;
         }
@@ -156,6 +172,8 @@ void test_const() {
         citer = iter;
     }
 }
+
+} // namespace
 
 int main() {
     test_regular();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wayland connection error messages with more contextual diagnostics.
  * Improved const-iterator support for list traversal.
* **Refactor**
  * Modernized internal collection processing and validation.
  * Preserved existing input-method, spell-checking, Unicode, emoji, and configuration behavior.
* **Tests**
  * Updated automated checks for modern collection handling and const iteration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->