### PR TITLE
Defer default input method selection to input method manager

### DIFF
--- a/src/modules/dbus/dbusmodule.cpp
+++ b/src/modules/dbus/dbusmodule.cpp
@@ -277,7 +277,6 @@ public:
                 InputMethodGroupItem(std::get<0>(entry))
                     .setLayout(std::get<1>(entry)));
         }
-        group.setDefaultInputMethod("");
         imManager.setGroup(std::move(group));
         imManager.save();
     }


### PR DESCRIPTION
* Follow-up to #1624

InputMethodManager::setGroup() already preserves an unspecified default or
falls back when it is invalid. The D-Bus path resolves an empty default to
the second input method before setGroup() runs, so remove that call.