### PR TITLE
Pull window position when UI update to xim client

### DIFF
--- a/src/frontend/xim/xim.cpp
+++ b/src/frontend/xim/xim.cpp
@@ -298,14 +298,6 @@ public:
 
     const char *frontend() const override { return "xim"; }
 
-    void maybeUpdateCursorLocationForRootStyle() {
-        if ((validatedInputStyle() & XCB_IM_PreeditPosition) ==
-            XCB_IM_PreeditPosition) {
-            return;
-        }
-        updateCursorLocation();
-    }
-
     void updateCursorLocation() {
         // kinds of like notification for position moving
         auto mask = xcb_im_input_context_get_preedit_attr_mask(xic_);
@@ -703,7 +695,7 @@ XIMModule::XIMModule(Instance *instance) : instance_(instance) {
             if (uiEvent.component() == UserInterfaceComponent::InputPanel &&
                 ic->frontendName() == "xim") {
                 auto *xic = static_cast<XIMInputContext *>(ic);
-                xic->maybeUpdateCursorLocationForRootStyle();
+                xic->updateCursorLocation();
             }
         });
 }


### PR DESCRIPTION
Originally it was to avoid pulling window position update, but after all it may
not be matter since every rendering is already a heavy process.

Fix #1622


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cursor positioning updates for XIM input contexts.
  * Ensured cursor location refreshes consistently when the UI is flushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->