### PR TITLE
Add API to allow query raw xkb state (fcitx/fcitx5-rime#151)

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -2620,6 +2620,15 @@ void Instance::clearXkbStateMask(const std::string &display) {
     d->stateMask_.erase(display);
 }
 
+std::optional<std::tuple<uint32_t, uint32_t, uint32_t>>
+Instance::xkbStateMask(const std::string &display) const {
+    FCITX_D();
+    if (const auto *mask = findValue(d->stateMask_, display)) {
+        return *mask;
+    }
+    return std::nullopt;
+}
+
 const char *Instance::version() { return FCITX_VERSION_STRING; }
 
 } // namespace fcitx

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -7,9 +7,12 @@
 #ifndef _FCITX_INSTANCE_H_
 #define _FCITX_INSTANCE_H_
 
+#include <cstdint>
 #include <exception>
 #include <memory>
+#include <optional>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <fcitx-utils/connectableobject.h>
 #include <fcitx-utils/eventdispatcher.h>
@@ -454,6 +457,18 @@ public:
 
     /// Clear xkb state mask for given display
     void clearXkbStateMask(const std::string &display);
+
+    /**
+     * Return xkb state mask for given display
+     *
+     * @see Instance::updateXkbStateMask
+     * @see Instance::clearXkbStateMask
+     * @see InputContext::display
+     * @param display display name
+     * @since 5.1.22
+     */
+    std::optional<std::tuple<uint32_t, uint32_t, uint32_t>>
+    xkbStateMask(const std::string &display) const;
 
     /**
      * Show a small popup with input popup window with current input method


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving XKB modifier state masks for a specified display.
  * Returns the available modifier masks or indicates when no state is stored.
  * Available since version 5.1.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->