### PR TITLE
Add signal for xkb state mask change.

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -2611,16 +2611,21 @@ void Instance::updateXkbStateMask(const std::string &display,
                                   uint32_t depressed_mods,
                                   uint32_t latched_mods, uint32_t locked_mods) {
     FCITX_D();
-    d->stateMask_[display] =
-        std::make_tuple(depressed_mods, latched_mods, locked_mods);
-    emit<Instance::XkbStateMaskChanged>(display);
+    auto oldMask = xkbStateMask(display);
+    auto &newMask = d->stateMask_[display];
+    newMask = std::make_tuple(depressed_mods, latched_mods, locked_mods);
+    emit<Instance::XkbStateMaskChanged>(display, oldMask, newMask);
 }
 
 void Instance::clearXkbStateMask(const std::string &display) {
     FCITX_D();
+    auto oldMask = xkbStateMask(display);
+    if (!oldMask.has_value()) {
+        return;
+    }
     bool changed = d->stateMask_.erase(display) > 0;
     if (changed) {
-        emit<XkbStateMaskChanged>(display);
+        emit<XkbStateMaskChanged>(display, oldMask, std::nullopt);
     }
 }
 

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -2614,6 +2614,9 @@ void Instance::updateXkbStateMask(const std::string &display,
     auto oldMask = xkbStateMask(display);
     auto &newMask = d->stateMask_[display];
     newMask = std::make_tuple(depressed_mods, latched_mods, locked_mods);
+    if (oldMask == newMask) {
+        return;
+    }
     emit<Instance::XkbStateMaskChanged>(display, oldMask, newMask);
 }
 

--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -2613,11 +2613,15 @@ void Instance::updateXkbStateMask(const std::string &display,
     FCITX_D();
     d->stateMask_[display] =
         std::make_tuple(depressed_mods, latched_mods, locked_mods);
+    emit<Instance::XkbStateMaskChanged>(display);
 }
 
 void Instance::clearXkbStateMask(const std::string &display) {
     FCITX_D();
-    d->stateMask_.erase(display);
+    bool changed = d->stateMask_.erase(display) > 0;
+    if (changed) {
+        emit<XkbStateMaskChanged>(display);
+    }
 }
 
 std::optional<std::tuple<uint32_t, uint32_t, uint32_t>>

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -332,8 +332,11 @@ public:
                          void(InputContext *inputContext, Text &orig));
     FCITX_DECLARE_SIGNAL(Instance, KeyEventResult,
                          void(const KeyEvent &keyEvent));
-    FCITX_DECLARE_SIGNAL(Instance, XkbStateMaskChanged,
-                         void(const std::string &display));
+    FCITX_DECLARE_SIGNAL(
+        Instance, XkbStateMaskChanged,
+        void(const std::string &display,
+             std::optional<std::tuple<uint32_t, uint32_t, uint32_t>> oldMask,
+             std::optional<std::tuple<uint32_t, uint32_t, uint32_t>> newMask));
     /**
      * \deprecated
      */

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -332,6 +332,8 @@ public:
                          void(InputContext *inputContext, Text &orig));
     FCITX_DECLARE_SIGNAL(Instance, KeyEventResult,
                          void(const KeyEvent &keyEvent));
+    FCITX_DECLARE_SIGNAL(Instance, XkbStateMaskChanged,
+                         void(const std::string &display));
     /**
      * \deprecated
      */

--- a/src/lib/fcitx/instance_p.h
+++ b/src/lib/fcitx/instance_p.h
@@ -21,6 +21,7 @@
 #include <fcitx/instance.h>
 #include <fcitx/tempmodemanager.h>
 #include <fcitx/userinterfacemanager.h>
+#include "fcitx-utils/connectableobject.h"
 #include "config.h"
 
 #ifdef ENABLE_KEYBOARD
@@ -191,6 +192,7 @@ public:
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, OutputFilter);
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, KeyEventResult);
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, CheckUpdate);
+    FCITX_DEFINE_SIGNAL_PRIVATE(Instance, XkbStateMaskChanged);
 
     FactoryFor<InputState> inputStateFactory_{
         [this](InputContext &ic) { return new InputState(this, &ic); }};

--- a/test/testinstance.cpp
+++ b/test/testinstance.cpp
@@ -24,6 +24,8 @@
 
 using namespace fcitx;
 
+namespace {
+
 void testCheckUpdate(Instance &instance) {
     instance.eventDispatcher().schedule([&instance]() {
         FCITX_ASSERT(!instance.checkUpdate());
@@ -159,6 +161,25 @@ void testModifierOnlyHotkey(Instance &instance) {
     });
 }
 
+void testXkbStateMask(Instance &instance) {
+    instance.eventDispatcher().schedule([&instance]() {
+        bool xkbStateMaskChanged = false;
+        auto connection = instance.connect<Instance::XkbStateMaskChanged>(
+            [&](const std::string &event) {
+                FCITX_ASSERT(event == "testdisplay");
+                xkbStateMaskChanged = true;
+            });
+
+        instance.updateXkbStateMask("testdisplay", 1, 2, 3);
+        FCITX_ASSERT(xkbStateMaskChanged);
+        xkbStateMaskChanged = false;
+        instance.clearXkbStateMask("testdisplay");
+        FCITX_ASSERT(xkbStateMaskChanged);
+    });
+}
+
+} // namespace
+
 int main() {
     setupTestingEnvironmentPath(FCITX5_BINARY_DIR, {"bin"}, {"test"});
 
@@ -179,6 +200,7 @@ int main() {
     testReloadGlobalConfig(instance);
     testSetGroupDefaultInputMethod(instance);
     testModifierOnlyHotkey(instance);
+    testXkbStateMask(instance);
     instance.eventDispatcher().schedule([&instance]() { instance.exit(); });
     instance.exec();
     return 0;

--- a/test/testinstance.cpp
+++ b/test/testinstance.cpp
@@ -187,7 +187,11 @@ void testXkbStateMask(Instance &instance) {
         FCITX_ASSERT(instance.xkbStateMask("testdisplay") ==
                      std::make_tuple(1, 2, 3));
         FCITX_ASSERT(instance.xkbStateMask("baddisplay") == std::nullopt);
+
         xkbStateMaskChanged = false;
+        instance.updateXkbStateMask("testdisplay", 1, 2, 3);
+        FCITX_ASSERT(!xkbStateMaskChanged);
+
         instance.clearXkbStateMask("testdisplay");
         FCITX_ASSERT(xkbStateMaskChanged);
         FCITX_ASSERT(savedOldMask == std::make_tuple(1, 2, 3));

--- a/test/testinstance.cpp
+++ b/test/testinstance.cpp
@@ -5,8 +5,11 @@
  *
  */
 #include <chrono>
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <utility>
 #include <vector>
 #include "fcitx-utils/eventdispatcher.h"
@@ -164,17 +167,31 @@ void testModifierOnlyHotkey(Instance &instance) {
 void testXkbStateMask(Instance &instance) {
     instance.eventDispatcher().schedule([&instance]() {
         bool xkbStateMaskChanged = false;
+        std::optional<std::tuple<uint32_t, uint32_t, uint32_t>> savedOldMask;
+        std::optional<std::tuple<uint32_t, uint32_t, uint32_t>> savedNewMask;
         auto connection = instance.connect<Instance::XkbStateMaskChanged>(
-            [&](const std::string &event) {
+            [&](const std::string &event,
+                std::optional<std::tuple<uint32_t, uint32_t, uint32_t>> oldMask,
+                std::optional<std::tuple<uint32_t, uint32_t, uint32_t>>
+                    newMask) {
                 FCITX_ASSERT(event == "testdisplay");
+                savedOldMask = oldMask;
+                savedNewMask = newMask;
                 xkbStateMaskChanged = true;
             });
 
         instance.updateXkbStateMask("testdisplay", 1, 2, 3);
         FCITX_ASSERT(xkbStateMaskChanged);
+        FCITX_ASSERT(savedOldMask == std::nullopt);
+        FCITX_ASSERT(savedNewMask == std::make_tuple(1, 2, 3));
+        FCITX_ASSERT(instance.xkbStateMask("testdisplay") ==
+                     std::make_tuple(1, 2, 3));
+        FCITX_ASSERT(instance.xkbStateMask("baddisplay") == std::nullopt);
         xkbStateMaskChanged = false;
         instance.clearXkbStateMask("testdisplay");
         FCITX_ASSERT(xkbStateMaskChanged);
+        FCITX_ASSERT(savedOldMask == std::make_tuple(1, 2, 3));
+        FCITX_ASSERT(savedNewMask == std::nullopt);
     });
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added notifications when a display’s keyboard modifier state changes.
  * Notifications include previous and current states when available, including when the state is cleared.

* **Bug Fixes**
  * Prevented duplicate notifications when the modifier state remains unchanged.
  * Prevented notifications when no keyboard state exists to clear.

* **Tests**
  * Added coverage for state updates, unchanged values, and clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->