### PR TITLE
click the tray icon to pop up the menu

### DIFF
--- a/src/modules/notificationitem/notificationitem.cpp
+++ b/src/modules/notificationitem/notificationitem.cpp
@@ -76,9 +76,7 @@ public:
             deltaAcc_ += 120;
         }
     }
-    void activate(int /*unused*/, int /*unused*/) {
-        parent_->instance()->toggle();
-    }
+    void activate(int /*unused*/, int /*unused*/) {}
     void secondaryActivate(int /*unused*/, int /*unused*/) {}
     std::string keyboardIconName() const {
         if (isKDE()) {
@@ -270,7 +268,7 @@ public:
     FCITX_OBJECT_VTABLE_PROPERTY(tooltip, "ToolTip", "(sa(iiay)ss)",
                                  [this]() { return tooltip(); });
     FCITX_OBJECT_VTABLE_PROPERTY(itemIsMenu, "ItemIsMenu", "b",
-                                 []() { return false; });
+                                 []() { return true; });
     FCITX_OBJECT_VTABLE_PROPERTY(menu, "Menu", "o",
                                  []() { return dbus::ObjectPath("/MenuBar"); });
     FCITX_OBJECT_VTABLE_PROPERTY(iconThemePath, "IconThemePath", "s",

--- a/src/ui/classic/xcbtraywindow.cpp
+++ b/src/ui/classic/xcbtraywindow.cpp
@@ -111,15 +111,14 @@ bool XCBTrayWindow::filterEvent(xcb_generic_event_t *event) {
     case XCB_BUTTON_PRESS: {
         auto *press = reinterpret_cast<xcb_button_press_event_t *>(event);
         if (press->event == wid_) {
-            if (press->detail == XCB_BUTTON_INDEX_3) {
+            if (press->detail == XCB_BUTTON_INDEX_1 ||
+                press->detail == XCB_BUTTON_INDEX_3) {
                 updateMenu();
                 XCBMenu *menu = menuPool_.requestMenu(ui_, &menu_, nullptr);
                 menu->show(Rect()
                                .setPosition(press->root_x, press->root_y)
                                .setSize(1, 1),
                            ConstrainAdjustment::Flip);
-            } else if (press->detail == XCB_BUTTON_INDEX_1) {
-                ui_->parent()->instance()->toggle();
             }
             return true;
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tray interactions so both left- and right-clicks open the tray menu.
  * Removed accidental input method toggling when activating the status notifier or clicking the tray icon.
  * Corrected the status notifier to indicate that a menu is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->