### PR TITLE
Release virtual keys before destroying Wayland input context

### DIFF
--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -253,7 +253,7 @@ void WaylandIMInputContextV2::deactivate() {
     if (realFocus()) {
         if (vkReady_) {
             bool releasedKey = false;
-            // If last key to vk is press, send a release.
+            // Release keys that are still pressed on the virtual keyboard.
             while (!pressedVKKey_.empty()) {
                 auto [vkkey, vktime] = *pressedVKKey_.begin();
                 // This is key release, so we don't need real sym and states.
@@ -617,8 +617,7 @@ void WaylandIMInputContextV2::sendKeyToVK(uint32_t time, const Key &key,
     }
     // Erase old to ensure order, and released ones can the be removed.
     pressedVKKey_.erase(code);
-    if (state == WL_KEYBOARD_KEY_STATE_PRESSED &&
-        xkb_keymap_key_repeats(server_->keymap_.get(), key.code())) {
+    if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
         pressedVKKey_[code] = time;
     }
     vk_->key(time, code, state);

--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -271,6 +271,7 @@ void WaylandIMInputContextV2::deactivate() {
 }
 
 WaylandIMInputContextV2::~WaylandIMInputContextV2() {
+    deactivate();
     server_->remove(seat_.get());
     destroy();
 }

--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -252,12 +252,17 @@ void WaylandIMInputContextV2::deactivate() {
     timeEvent_->setEnabled(false);
     if (realFocus()) {
         if (vkReady_) {
+            bool releasedKey = false;
             // If last key to vk is press, send a release.
             while (!pressedVKKey_.empty()) {
                 auto [vkkey, vktime] = *pressedVKKey_.begin();
                 // This is key release, so we don't need real sym and states.
                 sendKeyToVK(vktime, Key(FcitxKey_None, KeyStates(), vkkey + 8),
                             WL_KEYBOARD_KEY_STATE_RELEASED);
+                releasedKey = true;
+            }
+            if (releasedKey) {
+                server_->display()->flush();
             }
         }
         focusOutWrapper();

--- a/src/frontend/waylandim/waylandimserverv2.cpp
+++ b/src/frontend/waylandim/waylandimserverv2.cpp
@@ -172,34 +172,7 @@ WaylandIMInputContextV2::WaylandIMInputContextV2(
         ++serial_;
         if (pendingDeactivate_) {
             pendingDeactivate_ = false;
-            keyboardGrab_.reset();
-            repeatInfo_.reset();
-            // This is the only place we update wayland xkb mask, so it is ok to
-            // reset it to 0. This breaks the caps lock or num lock. But we have
-            // no other option until we can listen to the mod change globally.
-            server_->instance()->clearXkbStateMask(server_->group()->display());
-
-            timeEvent_->setEnabled(false);
-            if (realFocus()) {
-                if (vkReady_) {
-                    // If last key to vk is press, send a release.
-                    while (!pressedVKKey_.empty()) {
-                        auto [vkkey, vktime] = *pressedVKKey_.begin();
-                        // This is key release, so we don't need real sym and
-                        // states.
-                        sendKeyToVK(vktime,
-                                    Key(FcitxKey_None, KeyStates(), vkkey + 8),
-                                    WL_KEYBOARD_KEY_STATE_RELEASED);
-                    }
-                }
-                focusOutWrapper();
-            }
-            if (!server_->parent()->persistentVirtualKeyboard()) {
-                vk_.reset();
-                vkReady_ = false;
-            }
-            surroundingText().invalidate();
-            updateSurroundingTextWrapper();
+            deactivate();
         }
         if (pendingActivate_) {
             pendingActivate_ = false;
@@ -266,6 +239,35 @@ WaylandIMInputContextV2::WaylandIMInputContextV2(
         virtualICManager_ = std::make_unique<VirtualInputContextManager>(
             &inputContextManager, this, appMonitor);
     }
+}
+
+void WaylandIMInputContextV2::deactivate() {
+    keyboardGrab_.reset();
+    repeatInfo_.reset();
+    // This is the only place we update wayland xkb mask, so it is ok to
+    // reset it to 0. This breaks the caps lock or num lock. But we have no
+    // other option until we can listen to the mod change globally.
+    server_->instance()->clearXkbStateMask(server_->group()->display());
+
+    timeEvent_->setEnabled(false);
+    if (realFocus()) {
+        if (vkReady_) {
+            // If last key to vk is press, send a release.
+            while (!pressedVKKey_.empty()) {
+                auto [vkkey, vktime] = *pressedVKKey_.begin();
+                // This is key release, so we don't need real sym and states.
+                sendKeyToVK(vktime, Key(FcitxKey_None, KeyStates(), vkkey + 8),
+                            WL_KEYBOARD_KEY_STATE_RELEASED);
+            }
+        }
+        focusOutWrapper();
+    }
+    if (!server_->parent()->persistentVirtualKeyboard()) {
+        vk_.reset();
+        vkReady_ = false;
+    }
+    surroundingText().invalidate();
+    updateSurroundingTextWrapper();
 }
 
 WaylandIMInputContextV2::~WaylandIMInputContextV2() {

--- a/src/frontend/waylandim/waylandimserverv2.h
+++ b/src/frontend/waylandim/waylandimserverv2.h
@@ -117,6 +117,7 @@ protected:
     void updatePreeditDelegate(InputContext *ic) const override;
 
 private:
+    void deactivate();
     void repeat();
     void surroundingTextCallback(const char *text, uint32_t cursor,
                                  uint32_t anchor);


### PR DESCRIPTION
## Summary

- reuse the Wayland input method v2 deactivation path during input context destruction
- release virtual keys that are still logically pressed during shutdown
- flush those release requests before the virtual keyboard is destroyed

## Problem

When Fcitx is stopped from an interactive terminal, the Enter press used to run the stop or restart command may already have been forwarded through the Wayland virtual keyboard while its physical release has not reached Fcitx yet. The input context can then be destroyed with Enter still recorded as pressed.

The deactivation code generates a matching release, but Wayland requests are buffered. If the virtual keyboard is destroyed immediately afterward, the compositor may continue repeating the key until Fcitx finishes shutting down.

Calling the normal deactivation path from the destructor and flushing after pending virtual-key releases ensures the compositor observes the release before the virtual keyboard goes away.

## Reproduction

The issue was reproduced with the following environment:

- Fcitx 5.1.21 using the Wayland input-method-v2 frontend
- niri as the Wayland compositor
- kitty as the focused terminal (the same behavior was also visible in other applications)
- `fcitx5-rime` enabled

Steps:

1. Focus a terminal whose input context uses the Wayland input-method-v2 frontend.
2. Type `systemctl --user restart fcitx5-daemon.service` (or `systemctl --user stop fcitx5-daemon.service`).
3. Press Enter normally to execute it, without adding a delay before the systemd command.
4. Observe repeated Enter input while Fcitx is stopping.
5. Before the stop operation finishes, switch to another application such as a browser and try to type. No characters are delivered until Fcitx has completely stopped. Normal input resumes immediately after stop completes, even though the Fcitx daemon is no longer running.

In the captured run, the Enter press was forwarded through the virtual keyboard and systemd began stopping Fcitx about 28 ms later, before the physical Enter release reached Fcitx. At destruction time, evdev key 28 was therefore still recorded as pressed. Adding a delay, for example running `sleep 1; systemctl --user restart fcitx5-daemon.service`, avoids the race because the release is processed before shutdown starts.

The temporary input loss in other applications follows the same shutdown window. It does not appear to be application-specific: both terminal and browser input are affected, and input resumes as soon as the daemon has fully exited. This is consistent with the compositor still waiting on the Wayland input method/keyboard grab teardown rather than a problem in kitty or the browser.

The problem is much more visible when an addon takes a long time to shut down. In this setup, Rime synchronizes user data while unloading and extended shutdown by about 6-7 seconds. Repeated Enter input and the inability to type in other applications continued throughout that interval. Rime is not the source of the synthetic key events or input loss; its slow shutdown only makes the incomplete Wayland teardown observable for much longer. With fast addon shutdown, the same race can be too brief to notice.

## Testing

- reproduced with Wayland input-method-v2 on niri by running `systemctl --user restart fcitx5-daemon.service` interactively
- verified through logging that shutdown began while evdev key 28 (Enter) was still pressed
- verified on Fcitx 5.1.21 that the repeated Enter input disappears after the explicit flush
- built the patched `fcitx5` and `fcitx5-rime` packages successfully
- ran `clang-format --dry-run --Werror` on the changed files against current master

This is a draft while the shutdown behavior and preferred flush placement are reviewed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup when Wayland input contexts are deactivated or destroyed.
  * Ensured all pressed virtual keys are released and pending releases are sent promptly, improving keyboard input reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->