### PR TITLE
fix build with -fno-operator-names

### DIFF
--- a/src/lib/fcitx-config/option.h
+++ b/src/lib/fcitx-config/option.h
@@ -371,7 +371,7 @@ public:
 
     void dumpDescription(RawConfig &config) const override {
         OptionBase::dumpDescription(config);
-        if constexpr (not std::is_base_of_v<Configuration, T>) {
+        if constexpr (!std::is_base_of_v<Configuration, T>) {
             marshaller_.marshall(config["DefaultValue"], defaultValue_);
         }
         constrain_.dumpDescription(config);


### PR DESCRIPTION
I want to use `RegexConstrain().check` on fcitx5-configtool which needs include option.h. However, the project [includes KDECompilerSettings](https://github.com/fcitx/fcitx5-configtool/blob/a95abe7be84a5fdb3d3b94c0b2521ba1b8f6261d/CMakeLists.txt#L25), which has a [-fno-operator-names](https://github.com/KDE/extra-cmake-modules/blob/bbbaae0dbbbea3a283ba45b00dd10fb0d7b631d9/kde-modules/KDECompilerSettings.cmake#L432) flag to prevent usage of `not`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal condition to use standard operator syntax.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->