### PR TITLE
fix(remote): handle D-Bus connection errors

### DIFF
--- a/src/tools/remote.cpp
+++ b/src/tools/remote.cpp
@@ -63,7 +63,7 @@ enum {
     FCITX_DBUS_OPEN_X11_CONNECTION,
 };
 
-int main(int argc, char *argv[]) {
+int runRemote(int argc, char *argv[]) {
     Bus bus(BusType::Session);
     Message message;
     if (!bus.isOpen()) {
@@ -270,4 +270,13 @@ int main(int argc, char *argv[]) {
 
     auto reply = message.call(defaultTimeout);
     return reply.isError() ? 1 : 0;
+}
+
+int main(int argc, char *argv[]) {
+    try {
+        return runRemote(argc, argv);
+    } catch (const std::exception &e) {
+        std::cerr << "Failed to connect to Fcitx: " << e.what() << std::endl;
+        return 1;
+    }
 }


### PR DESCRIPTION
## Summary

- catch exceptions at the `fcitx5-remote` executable boundary
- report a D-Bus connection failure on stderr and return status 1
- avoid `std::terminate`, SIGABRT, and a core dump when the session bus is unavailable

## Background

`Bus(BusType::Session)` throws when it cannot create the session D-Bus connection. This happens before the existing `bus.isOpen()` check, so the exception currently escapes `main()` and aborts the process.

A missing or inaccessible session bus remains an environment/configuration problem; this change only makes `fcitx5-remote` handle that error gracefully. Related: #723.

## Testing

- built `src/tools/remote.cpp` with C++20 against Fcitx5Utils 5.1.21
- invalid `DBUS_SESSION_BUS_ADDRESS`: prints `Failed to connect to Fcitx: Failed to create dbus connection`, exits 1, and does not dump core
- live user session bus: exits 0 and prints the current Fcitx state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of connection-related errors when using the remote command.
  * The command now reports failures clearly and returns an appropriate failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->