### PR TITLE
Add ForceXWaylandDPI option to classic UI

### DIFF
--- a/src/ui/classic/classicui.h
+++ b/src/ui/classic/classicui.h
@@ -190,6 +190,18 @@ FCITX_CONFIGURATION(
                "screen scale factor. This option allows you to override the "
                "font DPI. If the value is 0, it means this option is "
                "disabled.")}};
+    Option<int, IntConstrain, DefaultMarshaller<int>, ToolTipAnnotation>
+        forceXWaylandDPI{
+            this,
+            "ForceXWaylandDPI",
+            _("Force font DPI on XWayland"),
+            0,
+            IntConstrain(0),
+            {},
+            {_("XWayland reports 96 DPI regardless of the screen scale. This "
+               "option allows you to override the font DPI when the compositor "
+               "does not scale X11 windows, for example 192 on a 2x screen. "
+               "If the value is 0, it means this option is disabled.")}};
 
     OptionWithAnnotation<bool, ToolTipAnnotation> fractionalScale{
         this,

--- a/src/ui/classic/xcbui.cpp
+++ b/src/ui/classic/xcbui.cpp
@@ -730,8 +730,12 @@ int XCBUI::dpiByPosition(int x, int y) {
 }
 
 int XCBUI::scaledDPI(int dpi) {
-    if (!*parent_->config().perScreenDPI ||
-        parent_->xcb()->call<IXCBModule::isXWayland>(displayName_)) {
+    const bool isXWayland =
+        parent_->xcb()->call<IXCBModule::isXWayland>(displayName_);
+    if (isXWayland && *parent_->config().forceXWaylandDPI > 0) {
+        return *parent_->config().forceXWaylandDPI;
+    }
+    if (!*parent_->config().perScreenDPI || isXWayland) {
         // CLASSICUI_DEBUG() << "Use font option dpi: " << fontOption_.dpi;
         if (fontOption_.dpi > 0) {
             return fontOption_.dpi;


### PR DESCRIPTION
## Problem

XWayland reports the X screen at 96 DPI regardless of the output scale. Compositors that leave X11 windows unscaled (Hyprland with `xwayland:force_zero_scaling`, as shipped by Omarchy) have no XSETTINGS daemon and nothing sets `Xft.dpi`. `XCBUI::scaledDPI` then falls back to the fake 96, so the classic UI draws the candidate window at 1x on a 2x screen whenever the focused client is an X11 app (Electron apps such as Feishu or WeChat).

Publishing `Xft.dpi` on the root window is not a fix in those sessions. GTK treats the resource as an unscaled value and multiplies it by `GDK_SCALE`, so GTK and Chromium based X11 apps render at 4x. Changing the X screen size at runtime is a no-op in XWayland, and Hyprland hardcodes the Xwayland command line, so `-dpi` cannot be passed either.

## Change

Add `ForceXWaylandDPI` to the classic UI configuration, mirroring `ForceWaylandDPI`. It is 0 (off) by default and only consulted when the display is XWayland, so real X11 sessions and compositors that scale X11 windows themselves are unchanged. When set it takes precedence over `Xft.dpi`, like the Wayland option overrides the output scale.

## Testing

Built against the 5.1.21 tag and loaded into the running daemon on Omarchy (Hyprland 0.56, `force_zero_scaling`, `GDK_SCALE=2`, 2880x1800 at scale 2). With `ForceXWaylandDPI=192` the candidate window in Feishu matches the size in native Wayland apps; with 0 it is back to 1x. `clang-format --dry-run -Werror` is clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HE2TCjo1j9HnXq83cqsUX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to override font DPI when the application runs through XWayland.
  * The setting supports non-negative values and is disabled by default.
  * Added guidance explaining when a custom DPI value may be needed for scaled displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->