### PR TITLE
fix fcitx5-remote crash on dbus connection creation failure

### DIFF
--- a/src/tools/remote.cpp
+++ b/src/tools/remote.cpp
@@ -5,7 +5,9 @@
  *
  */
 
+#include <exception>
 #include <iostream>
+#include <memory>
 #include <getopt.h>
 #include "fcitx-utils/dbus/bus.h"
 #include "fcitx-utils/environ.h"
@@ -64,15 +66,12 @@ enum {
 };
 
 int main(int argc, char *argv[]) {
-    Bus bus(BusType::Session);
     Message message;
-    if (!bus.isOpen()) {
-        FCITX_ERROR() << "Could not open DBus connection.";
-        return 1;
-    }
     int c;
     int ret = 1;
     int messageType = FCITX_DBUS_GET_CURRENT_STATE;
+    bool check = false;
+    bool printAddress = false;
     std::string imname;
     std::string serviceName = fcitxServiceName;
     struct option longOptions[] = {{"check", no_argument, nullptr, 0},
@@ -85,14 +84,9 @@ int main(int argc, char *argv[]) {
         switch (c) {
         case 0:
             switch (optionIndex) {
-            case 0: {
-                // Make sure we use the unique name to send request to avoid any
-                // race, otherwise it may trigger dbus activation.
-                serviceName = bus.serviceOwner(serviceName, defaultTimeout);
-                if (serviceName.empty()) {
-                    return 1;
-                }
-            } break;
+            case 0:
+                check = true;
+                break;
             }
             break;
         case 'o':
@@ -144,8 +138,8 @@ int main(int argc, char *argv[]) {
             break;
 
         case 'a':
-            std::cout << bus.address() << std::endl;
-            return 0;
+            printAddress = true;
+            break;
         case 'h':
             usage(std::cout);
             return 0;
@@ -159,10 +153,36 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
+    std::unique_ptr<Bus> bus;
+    try {
+        bus = std::make_unique<Bus>(BusType::Session);
+    } catch (const std::exception &e) {
+        FCITX_ERROR() << "Could not open DBus connection: " << e.what();
+        return 1;
+    }
+    if (!bus->isOpen()) {
+        FCITX_ERROR() << "Could not open DBus connection.";
+        return 1;
+    }
+
+    if (check) {
+        // Make sure we use the unique name to send request to avoid any race,
+        // otherwise it may trigger dbus activation.
+        serviceName = bus->serviceOwner(serviceName, defaultTimeout);
+        if (serviceName.empty()) {
+            return 1;
+        }
+    }
+
+    if (printAddress) {
+        std::cout << bus->address() << std::endl;
+        return 0;
+    }
+
 #define CASE(ENUMNAME, MESSAGENAME)                                            \
     case FCITX_DBUS_##ENUMNAME:                                                \
-        message = bus.createMethodCall(serviceName.data(), path,               \
-                                       interfaceName, #MESSAGENAME);           \
+        message = bus->createMethodCall(serviceName.data(), path,              \
+                                        interfaceName, #MESSAGENAME);          \
         break;
 
     switch (messageType) {
@@ -189,7 +209,7 @@ int main(int argc, char *argv[]) {
     // We need to have some special code for this, this is because we don't want
     // to trigger dbus activation for it.
     if (messageType == FCITX_DBUS_EXIT) {
-        auto owner = bus.serviceOwner(serviceName, defaultTimeout);
+        auto owner = bus->serviceOwner(serviceName, defaultTimeout);
         // Either failed or not present, it will be return empty.
         if (owner.empty()) {
             return 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,11 @@ if (ENABLE_DBUS)
     add_executable(DBusWrapper IMPORTED)
     set_target_properties(DBusWrapper PROPERTIES IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/dbus_wrapper.sh")
 
+    add_test(NAME testremotehelp
+             COMMAND ${CMAKE_COMMAND} -E env
+                     "DBUS_SESSION_BUS_ADDRESS=unix:path=${CMAKE_CURRENT_BINARY_DIR}/nonexistent-dbus"
+                     $<TARGET_FILE:fcitx5-remote> --help)
+
     foreach(TESTCASE ${FCITX_UTILS_DBUS_TEST})
         add_executable(${TESTCASE} ${TESTCASE}.cpp)
         target_link_libraries(${TESTCASE} Fcitx5::Utils ${${TESTCASE}_LIBS})


### PR DESCRIPTION
Closes #1653. This PR has a smaller scope of try-catch block, plus doesn't try to connect on --help.

Reproduce: `codex sandbox -- /usr/bin/fcitx5-remote` or `codex sandbox -- /usr/bin/fcitx5-remote --help`.
Stack:
```
#0  0x00007cc0538a642c __pthread_kill_implementation (libc.so.6 + 0xa642c)
#1  0x00007cc053845b7e __GI_raise (libc.so.6 + 0x45b7e)
#2  0x00007cc0538288ec __GI_abort (libc.so.6 + 0x288ec)
#3  0x00007cc053cac275 n/a (libstdc++.so.6 + 0xac275)
#4  0x00007cc053cc364a n/a (libstdc++.so.6 + 0xc364a)
#5  0x00007cc053cabc6c _ZSt9terminatev (libstdc++.so.6 + 0xabc6c)
#6  0x00007cc053cc3901 __cxa_throw (libstdc++.so.6 + 0xc3901)
#7  0x00007cc053f62d49 _ZN5fcitx4dbus3BusC2ENS0_7BusTypeE (libFcitx5Utils.so.2 + 0x38d49)
#8  0x000055bccada163e main (/usr/bin/fcitx5-remote + 0x263e)
#9  0x00007cc05382a601 __libc_start_call_main (libc.so.6 + 0x2a601)
#10 0x00007cc05382a718 __libc_start_main_impl (libc.so.6 + 0x2a718)
#11 0x000055bccada2225 _start (/usr/bin/fcitx5-remote + 0x3225)
ELF object binary architecture: AMD x86-64
```