### PR TITLE
fix *-import-addon.cpp overwrite on reconfigure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.18)
 project(fcitx VERSION 5.1.22)
 set(FCITX_VERSION ${PROJECT_VERSION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.13)
 project(fcitx VERSION 5.1.22)
 set(FCITX_VERSION ${PROJECT_VERSION})
 

--- a/src/lib/fcitx-utils/CMakeLists.txt
+++ b/src/lib/fcitx-utils/CMakeLists.txt
@@ -187,6 +187,7 @@ install(FILES  "${CMAKE_CURRENT_BINARY_DIR}/Fcitx5UtilsConfig.cmake"
                "${CMAKE_CURRENT_BINARY_DIR}/Fcitx5UtilsConfigVersion.cmake"
                Fcitx5Macros.cmake
                Fcitx5Download.cmake.in
+               Fcitx5ImportAddon.cpp.in
                Fcitx5ModuleTemplate.cmake.in
                "${PROJECT_SOURCE_DIR}/cmake/Fcitx5CompilerSettings.cmake"
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/Fcitx5Utils

--- a/src/lib/fcitx-utils/Fcitx5ImportAddon.cpp.in
+++ b/src/lib/fcitx-utils/Fcitx5ImportAddon.cpp.in
@@ -1,0 +1,3 @@
+#include <fcitx/addonloader.h>
+extern fcitx::StaticAddonRegistry &@FCITX5_IMPORT_REGISTRY_VARNAME@();
+FCITX_IMPORT_ADDON_FACTORY(@FCITX5_IMPORT_REGISTRY_VARNAME@, @FCITX5_IMPORT_ADDON@);

--- a/src/lib/fcitx-utils/Fcitx5Macros.cmake
+++ b/src/lib/fcitx-utils/Fcitx5Macros.cmake
@@ -22,7 +22,7 @@ function(fcitx5_import_addons target)
 
   foreach(addon IN LISTS FCITX5_IMPORT_ADDONS)
       set(filename "${CMAKE_CURRENT_BINARY_DIR}/${target}-${addon}-import-addon.cpp")
-      file(WRITE "${filename}" "
+      file(CONFIGURE OUTPUT "${filename}" CONTENT "
 #include <fcitx/addonloader.h>
 extern fcitx::StaticAddonRegistry &${FCITX5_IMPORT_REGISTRY_VARNAME}();
 FCITX_IMPORT_ADDON_FACTORY(${FCITX5_IMPORT_REGISTRY_VARNAME}, ${addon});

--- a/src/lib/fcitx-utils/Fcitx5Macros.cmake
+++ b/src/lib/fcitx-utils/Fcitx5Macros.cmake
@@ -22,11 +22,9 @@ function(fcitx5_import_addons target)
 
   foreach(addon IN LISTS FCITX5_IMPORT_ADDONS)
       set(filename "${CMAKE_CURRENT_BINARY_DIR}/${target}-${addon}-import-addon.cpp")
-      file(CONFIGURE OUTPUT "${filename}" CONTENT "
-#include <fcitx/addonloader.h>
-extern fcitx::StaticAddonRegistry &${FCITX5_IMPORT_REGISTRY_VARNAME}();
-FCITX_IMPORT_ADDON_FACTORY(${FCITX5_IMPORT_REGISTRY_VARNAME}, ${addon});
-")
+      set(FCITX5_IMPORT_ADDON "${addon}")
+      configure_file("${_Fcitx5Macro_SELF_DIR}/Fcitx5ImportAddon.cpp.in"
+                     "${filename}" @ONLY)
       target_sources(${target} PRIVATE ${filename})
       target_link_libraries(${target} ${addon})
   endforeach()


### PR DESCRIPTION
Ref: https://cmake.org/cmake/help/git-stage/command/file.html
~`file(write` is not suitable for build input. `file(configure` needs cmake 3.18 which I think is OK since Ubuntu 24.04 is the [targeting system](https://groups.google.com/g/fcitx/c/1ZpjYVwVpqA) and it ships [cmake 3.28](https://launchpad.net/ubuntu/noble/+package/cmake).~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build and Packaging**
  * Improved generation of Fcitx5 addon import sources during builds.
  * Included the addon import template with the installed Fcitx5 utility package configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->