### PR TITLE
classicui: expose candidate actions in X11 and Wayland

### DIFF
--- a/src/ui/classic/waylandinputwindow.cpp
+++ b/src/ui/classic/waylandinputwindow.cpp
@@ -42,6 +42,7 @@
 
 namespace fcitx::classicui {
 
+/** Initializes the Wayland input window and its event handlers. */
 WaylandInputWindow::WaylandInputWindow(WaylandUI *ui)
     : InputWindow(ui->parent()), ui_(ui), window_(ui->newWindow()) {
     menuContext_.reset(pango_font_map_create_context(fontMap_.get()));
@@ -133,6 +134,7 @@ WaylandInputWindow::WaylandInputWindow(WaylandUI *ui)
     initPanel();
 }
 
+/** Hides the candidate menu and discards its temporary state. */
 void WaylandInputWindow::clearCandidateMenu() {
     candidateMenuVisible_ = false;
     candidateMenuCandidate_ = nullptr;
@@ -147,6 +149,7 @@ void WaylandInputWindow::clearCandidateMenu() {
     candidateMenuHoveredIndex_ = -1;
 }
 
+/** Restores the input panel surface after a candidate menu closes. */
 void WaylandInputWindow::restorePanelSize() {
     if (!window_ || panelWidth_ <= 0 || panelHeight_ <= 0 ||
         (window_->width() == panelWidth_ &&
@@ -157,6 +160,7 @@ void WaylandInputWindow::restorePanelSize() {
     updateBlur();
 }
 
+/** Builds and shows the candidate action menu at the pointer position. */
 void WaylandInputWindow::showCandidateMenu(int x, int y) {
     auto dismiss = [this]() {
         if (!candidateMenuVisible_) {
@@ -310,6 +314,7 @@ void WaylandInputWindow::showCandidateMenu(int x, int y) {
     repaint();
 }
 
+/** Updates the candidate menu item under the pointer. */
 bool WaylandInputWindow::hoverCandidateMenu(int x, int y) {
     if (!candidateMenuVisible_) {
         return false;
@@ -330,6 +335,7 @@ bool WaylandInputWindow::hoverCandidateMenu(int x, int y) {
     return true;
 }
 
+/** Activates or dismisses the candidate menu after a left click. */
 void WaylandInputWindow::clickCandidateMenu(int x, int y) {
     if (!candidateMenuVisible_) {
         return;
@@ -363,6 +369,7 @@ void WaylandInputWindow::clickCandidateMenu(int x, int y) {
     repaint();
 }
 
+/** Paints the candidate action menu over the input panel. */
 void WaylandInputWindow::paintCandidateMenu(cairo_t *cr) {
     if (!candidateMenuVisible_) {
         return;
@@ -415,6 +422,7 @@ void WaylandInputWindow::paintCandidateMenu(cairo_t *cr) {
     }
 }
 
+/** Creates the Wayland input panel surface when necessary. */
 void WaylandInputWindow::initPanel() {
     if (!window_->surface()) {
         window_->createWindow();
@@ -424,12 +432,14 @@ void WaylandInputWindow::initPanel() {
     setFontDPI(*parent_->config().forceWaylandDPI);
 }
 
+/** Sets the compositor background-effect manager for the input panel. */
 void WaylandInputWindow::setBlurManager(
     std::shared_ptr<wayland::ExtBackgroundEffectManagerV1> blur) {
     blurManager_ = std::move(blur);
     updateBlur();
 }
 
+/** Updates the compositor blur region for the current panel size. */
 void WaylandInputWindow::updateBlur() {
     if (!window_->surface()) {
         return;
@@ -465,10 +475,13 @@ void WaylandInputWindow::updateBlur() {
     blur_->setBlurRegion(region.get());
 }
 
+/** Updates the input window buffer scale. */
 void WaylandInputWindow::updateScale() { window_->updateScale(); }
 
+/** Releases the current Wayland input panel surface. */
 void WaylandInputWindow::resetPanel() { panelSurface_.reset(); }
 
+/** Updates the input panel contents, surface, and candidate menu state. */
 void WaylandInputWindow::update(fcitx::InputContext *ic) {
     clearCandidateMenu();
     const auto oldVisible = visible();
@@ -557,6 +570,7 @@ void WaylandInputWindow::update(fcitx::InputContext *ic) {
     repaintIC_ = ic->watch();
 }
 
+/** Repaints the visible Wayland input window. */
 void WaylandInputWindow::repaint() {
     if (!visible()) {
         return;

--- a/src/ui/classic/waylandinputwindow.cpp
+++ b/src/ui/classic/waylandinputwindow.cpp
@@ -5,13 +5,18 @@
  *
  */
 #include "waylandinputwindow.h"
+#include <algorithm>
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 #include <cairo.h>
+#include <pango/pango-fontmap.h>
+#include <pango/pangocairo.h>
+#include "fcitx-utils/misc_p.h"
 #include "fcitx-utils/rect.h"
 #include "fcitx/inputcontext.h"
 #include "common.h"
@@ -32,42 +37,81 @@
 #include <dev/evdev/input-event-codes.h>
 #else
 #define BTN_LEFT 0x110
+#define BTN_RIGHT 0x111
 #endif
 
 namespace fcitx::classicui {
 
 WaylandInputWindow::WaylandInputWindow(WaylandUI *ui)
     : InputWindow(ui->parent()), ui_(ui), window_(ui->newWindow()) {
+    menuContext_.reset(pango_font_map_create_context(fontMap_.get()));
+    menuLayout_.reset(pango_layout_new(menuContext_.get()));
     window_->createWindow();
     window_->repaint().connect([this]() {
         if (auto *ic = repaintIC_.get()) {
             if (ic->hasFocus()) {
-                update(ic);
+                if (candidateMenuVisible_) {
+                    repaint();
+                } else {
+                    update(ic);
+                }
             }
         }
     });
-    window_->click().connect([this](int x, int y, uint32_t button,
-                                    uint32_t state) {
-        if (state == WL_POINTER_BUTTON_STATE_PRESSED && button == BTN_LEFT) {
-            click(x, y);
-        }
-    });
+    window_->click().connect(
+        [this](int x, int y, uint32_t button, uint32_t state) {
+            if (state != WL_POINTER_BUTTON_STATE_PRESSED) {
+                return;
+            }
+            if (button == BTN_RIGHT) {
+                showCandidateMenu(x, y);
+            } else if (button == BTN_LEFT) {
+                if (candidateMenuVisible_) {
+                    clickCandidateMenu(x, y);
+                } else {
+                    click(x, y);
+                }
+            }
+        });
     window_->hover().connect([this](int x, int y) {
-        if (hover(x, y)) {
+        bool needRepaint = false;
+        if (candidateMenuVisible_) {
+            needRepaint = hoverCandidateMenu(x, y);
+            if (!candidateMenuRegion_.contains(x, y)) {
+                needRepaint = hover(x, y) || needRepaint;
+            }
+        } else {
+            needRepaint = hover(x, y);
+        }
+        if (needRepaint) {
             repaint();
         }
     });
     window_->leave().connect([this]() {
-        if (hover(-1, -1)) {
+        bool needRepaint = hover(-1, -1);
+        if (candidateMenuHoveredIndex_ != -1) {
+            candidateMenuHoveredIndex_ = -1;
+            needRepaint = true;
+        }
+        if (needRepaint) {
             repaint();
         }
     });
-    window_->touchDown().connect([this](int x, int y) { click(x, y); });
+    window_->touchDown().connect([this](int x, int y) {
+        if (candidateMenuVisible_) {
+            clickCandidateMenu(x, y);
+        } else {
+            click(x, y);
+        }
+    });
     window_->touchUp().connect([](int, int) {
         // do nothing
     });
     window_->axis().connect([this](int, int, uint32_t axis, wl_fixed_t value) {
         if (axis != WL_POINTER_AXIS_VERTICAL_SCROLL) {
+            return;
+        }
+        if (candidateMenuVisible_) {
             return;
         }
         scroll_ += value;
@@ -87,6 +131,288 @@ WaylandInputWindow::WaylandInputWindow(WaylandUI *ui)
         }
     });
     initPanel();
+}
+
+void WaylandInputWindow::clearCandidateMenu() {
+    candidateMenuVisible_ = false;
+    candidateMenuCandidate_ = nullptr;
+    candidateMenuList_.reset();
+    candidateMenuActions_.clear();
+    candidateMenuRegions_.clear();
+    candidateMenuRegion_ = Rect();
+    candidateMenuX_ = candidateMenuY_ = 0;
+    candidateMenuWidth_ = candidateMenuHeight_ = 0;
+    candidateMenuItemWidth_ = candidateMenuItemHeight_ = 0;
+    candidateMenuHasCheckable_ = false;
+    candidateMenuHoveredIndex_ = -1;
+}
+
+void WaylandInputWindow::restorePanelSize() {
+    if (!window_ || panelWidth_ <= 0 || panelHeight_ <= 0 ||
+        (window_->width() == panelWidth_ &&
+         window_->height() == panelHeight_)) {
+        return;
+    }
+    window_->resize(panelWidth_, panelHeight_);
+    updateBlur();
+}
+
+void WaylandInputWindow::showCandidateMenu(int x, int y) {
+    auto dismiss = [this]() {
+        if (!candidateMenuVisible_) {
+            return;
+        }
+        clearCandidateMenu();
+        restorePanelSize();
+        repaint();
+    };
+
+    auto *inputContext = inputContext_.get();
+    if (!inputContext) {
+        dismiss();
+        return;
+    }
+
+    const auto candidateList = inputContext->inputPanel().candidateList();
+    if (!candidateList) {
+        dismiss();
+        return;
+    }
+
+    const CandidateWord *candidate = nullptr;
+    for (size_t idx = 0, e = candidateRegions_.size(); idx < e; idx++) {
+        if (candidateRegions_[idx].contains(x, y)) {
+            candidate = nthCandidateIgnorePlaceholder(*candidateList, idx);
+            break;
+        }
+    }
+
+    auto *actionable = candidateList->toActionable();
+    if (!candidate || !actionable || !actionable->hasAction(*candidate)) {
+        dismiss();
+        return;
+    }
+
+    auto actions = actionable->candidateActions(*candidate);
+    if (actions.empty() ||
+        std::ranges::all_of(actions, &CandidateAction::isSeparator) ||
+        !menuContext_ || !menuLayout_) {
+        dismiss();
+        return;
+    }
+
+    clearCandidateMenu();
+    candidateMenuList_ = candidateList;
+    candidateMenuCandidate_ = candidate;
+    candidateMenuActions_ = std::move(actions);
+
+    auto &theme = ui_->parent()->theme();
+    const auto &menu = *theme.menu;
+    const auto &contentMargin = *menu.contentMargin;
+    const auto &textMargin = *menu.textMargin;
+    const auto &checkBox = theme.loadBackground(*menu.checkBox);
+    const auto &separator = theme.loadBackground(*menu.separator);
+
+    auto *fontDescription = pango_font_description_from_string(
+        ui_->parent()->config().menuFont->c_str());
+    pango_context_set_font_description(menuContext_.get(), fontDescription);
+    pango_layout_set_font_description(menuLayout_.get(), fontDescription);
+    pango_font_description_free(fontDescription);
+
+    int maxTextWidth = 0;
+    int maxTextHeight = 0;
+    for (const auto &action : candidateMenuActions_) {
+        candidateMenuHasCheckable_ =
+            candidateMenuHasCheckable_ ||
+            (action.isCheckable() && !action.isSeparator());
+        if (action.isSeparator()) {
+            continue;
+        }
+        pango_layout_set_text(menuLayout_.get(), action.text().c_str(),
+                              action.text().size());
+        int textWidth = 0;
+        int textHeight = 0;
+        pango_layout_get_pixel_size(menuLayout_.get(), &textWidth, &textHeight);
+        maxTextWidth = std::max(maxTextWidth, textWidth);
+        maxTextHeight = std::max(maxTextHeight, textHeight);
+    }
+
+    int maxItemWidth = maxTextWidth;
+    int maxItemHeight = maxTextHeight;
+    if (candidateMenuHasCheckable_) {
+        maxItemWidth += checkBox.width();
+        maxItemHeight = std::max(maxItemHeight, checkBox.height());
+    }
+    candidateMenuItemWidth_ =
+        maxItemWidth + *textMargin.marginLeft + *textMargin.marginRight;
+    candidateMenuItemHeight_ =
+        maxItemHeight + *textMargin.marginTop + *textMargin.marginBottom;
+
+    candidateMenuWidth_ = *contentMargin.marginLeft + candidateMenuItemWidth_ +
+                          *contentMargin.marginRight;
+    candidateMenuHeight_ =
+        *contentMargin.marginTop + *contentMargin.marginBottom;
+    for (const auto &action : candidateMenuActions_) {
+        candidateMenuHeight_ +=
+            action.isSeparator()
+                ? (separator.isPattern() ? 2 : separator.height())
+                : candidateMenuItemHeight_;
+    }
+    if (candidateMenuActions_.size() > 1) {
+        candidateMenuHeight_ +=
+            (candidateMenuActions_.size() - 1) * *menu.spacing;
+    }
+    candidateMenuWidth_ = std::max(candidateMenuWidth_, 1);
+    candidateMenuHeight_ = std::max(candidateMenuHeight_, 1);
+
+    const int panelWidth = panelWidth_ > 0 ? panelWidth_ : window_->width();
+    const int panelHeight = panelHeight_ > 0 ? panelHeight_ : window_->height();
+    candidateMenuX_ =
+        std::min(std::max(x, 0), std::max(0, panelWidth - candidateMenuWidth_));
+    candidateMenuY_ = std::min(std::max(y, 0),
+                               std::max(0, panelHeight - candidateMenuHeight_));
+    candidateMenuRegion_.setPosition(candidateMenuX_, candidateMenuY_)
+        .setSize(candidateMenuWidth_, candidateMenuHeight_);
+
+    candidateMenuRegions_.reserve(candidateMenuActions_.size());
+    int itemY = candidateMenuY_ + *contentMargin.marginTop;
+    for (size_t i = 0; i < candidateMenuActions_.size(); i++) {
+        const auto &action = candidateMenuActions_[i];
+        const int itemHeight =
+            action.isSeparator()
+                ? (separator.isPattern() ? 2 : separator.height())
+                : candidateMenuItemHeight_;
+        const int itemWidth = action.isSeparator()
+                                  ? candidateMenuWidth_ -
+                                        *contentMargin.marginLeft -
+                                        *contentMargin.marginRight
+                                  : candidateMenuItemWidth_;
+        candidateMenuRegions_.push_back(
+            Rect()
+                .setPosition(candidateMenuX_ + *contentMargin.marginLeft, itemY)
+                .setSize(std::max(itemWidth, 0), std::max(itemHeight, 0)));
+        itemY += itemHeight;
+        if (i + 1 < candidateMenuActions_.size()) {
+            itemY += *menu.spacing;
+        }
+    }
+
+    candidateMenuVisible_ = true;
+    candidateMenuHoveredIndex_ = -1;
+    const int width =
+        std::max(panelWidth, candidateMenuX_ + candidateMenuWidth_);
+    const int height =
+        std::max(panelHeight, candidateMenuY_ + candidateMenuHeight_);
+    if (window_->width() != width || window_->height() != height) {
+        window_->resize(width, height);
+        updateBlur();
+    }
+    repaint();
+}
+
+bool WaylandInputWindow::hoverCandidateMenu(int x, int y) {
+    if (!candidateMenuVisible_) {
+        return false;
+    }
+
+    int index = -1;
+    for (size_t i = 0; i < candidateMenuActions_.size(); i++) {
+        if (!candidateMenuActions_[i].isSeparator() &&
+            candidateMenuRegions_[i].contains(x, y)) {
+            index = static_cast<int>(i);
+            break;
+        }
+    }
+    if (candidateMenuHoveredIndex_ == index) {
+        return false;
+    }
+    candidateMenuHoveredIndex_ = index;
+    return true;
+}
+
+void WaylandInputWindow::clickCandidateMenu(int x, int y) {
+    if (!candidateMenuVisible_) {
+        return;
+    }
+
+    int index = -1;
+    for (size_t i = 0; i < candidateMenuActions_.size(); i++) {
+        if (!candidateMenuActions_[i].isSeparator() &&
+            candidateMenuRegions_[i].contains(x, y)) {
+            index = static_cast<int>(i);
+            break;
+        }
+    }
+    if (index < 0) {
+        clearCandidateMenu();
+        restorePanelSize();
+        repaint();
+        return;
+    }
+
+    const auto candidateList = candidateMenuList_;
+    const auto *candidate = candidateMenuCandidate_;
+    const int id = candidateMenuActions_[index].id();
+    clearCandidateMenu();
+    restorePanelSize();
+    if (candidateList && candidate) {
+        if (auto *actionable = candidateList->toActionable()) {
+            actionable->triggerAction(*candidate, id);
+        }
+    }
+    repaint();
+}
+
+void WaylandInputWindow::paintCandidateMenu(cairo_t *cr) {
+    if (!candidateMenuVisible_) {
+        return;
+    }
+
+    auto &theme = ui_->parent()->theme();
+    const auto &menu = *theme.menu;
+    const auto &textMargin = *menu.textMargin;
+    const auto &checkBox = theme.loadBackground(*menu.checkBox);
+    theme.paint(cr, *menu.background, candidateMenuX_, candidateMenuY_,
+                candidateMenuWidth_, candidateMenuHeight_, 1.0);
+
+    for (size_t i = 0; i < candidateMenuActions_.size(); i++) {
+        const auto &action = candidateMenuActions_[i];
+        const auto &region = candidateMenuRegions_[i];
+        if (action.isSeparator()) {
+            theme.paint(cr, *menu.separator, region.left(), region.top(),
+                        region.width(), region.height(), 1.0);
+            continue;
+        }
+
+        if (candidateMenuHoveredIndex_ == static_cast<int>(i)) {
+            theme.paint(cr, *menu.highlight, region.left(), region.top(),
+                        region.width(), region.height(), 1.0);
+        }
+
+        if (action.isChecked()) {
+            const int checkX = region.left() + *textMargin.marginLeft;
+            const int checkY =
+                region.top() + (region.height() - checkBox.height()) / 2;
+            theme.paint(cr, *menu.checkBox, checkX, checkY, -1, -1, 1.0);
+        }
+
+        pango_layout_set_text(menuLayout_.get(), action.text().c_str(),
+                              action.text().size());
+        int textHeight = 0;
+        pango_layout_get_pixel_size(menuLayout_.get(), nullptr, &textHeight);
+        const int textX = region.left() + *textMargin.marginLeft +
+                          (candidateMenuHasCheckable_ ? checkBox.width() : 0);
+        const int textY = region.top() + (region.height() - textHeight) / 2;
+
+        cairo_save(cr);
+        cairoSetSourceColor(cr,
+                            candidateMenuHoveredIndex_ == static_cast<int>(i)
+                                ? theme.menuSelectedItemText()
+                                : theme.menuText());
+        cairo_move_to(cr, textX, textY);
+        pango_cairo_show_layout(cr, menuLayout_.get());
+        cairo_restore(cr);
+    }
 }
 
 void WaylandInputWindow::initPanel() {
@@ -144,6 +470,7 @@ void WaylandInputWindow::updateScale() { window_->updateScale(); }
 void WaylandInputWindow::resetPanel() { panelSurface_.reset(); }
 
 void WaylandInputWindow::update(fcitx::InputContext *ic) {
+    clearCandidateMenu();
     const auto oldVisible = visible();
     auto [width, height] = InputWindow::update(ic);
     CLASSICUI_DEBUG() << "Wayland Input Window visible:" << visible()
@@ -213,6 +540,8 @@ void WaylandInputWindow::update(fcitx::InputContext *ic) {
         window_->resize(width, height);
         updateBlur();
     }
+    panelWidth_ = width;
+    panelHeight_ = height;
 
     if (auto *surface = window_->prerender()) {
         cairo_t *c = cairo_create(surface);
@@ -221,6 +550,7 @@ void WaylandInputWindow::update(fcitx::InputContext *ic) {
             window_->bufferScale() / WaylandWindow::ScaleDominatorF,
             window_->bufferScale() / WaylandWindow::ScaleDominatorF);
         paint(c, width, height);
+        paintCandidateMenu(c);
         cairo_destroy(c);
         window_->render();
     }
@@ -239,6 +569,7 @@ void WaylandInputWindow::repaint() {
             window_->bufferScale() / WaylandWindow::ScaleDominatorF,
             window_->bufferScale() / WaylandWindow::ScaleDominatorF);
         paint(c, window_->width(), window_->height());
+        paintCandidateMenu(c);
         cairo_destroy(c);
         window_->render();
     }

--- a/src/ui/classic/waylandinputwindow.h
+++ b/src/ui/classic/waylandinputwindow.h
@@ -7,7 +7,9 @@
 #ifndef _FCITX_UI_CLASSIC_WAYLANDINPUTWINDOW_H_
 #define _FCITX_UI_CLASSIC_WAYLANDINPUTWINDOW_H_
 
+#include <cstddef>
 #include <memory>
+#include <vector>
 #include <wayland-util.h>
 #include "fcitx-utils/trackableobject.h"
 #include "fcitx/inputcontext.h"
@@ -35,10 +37,24 @@ public:
     void updateScale();
 
 private:
+    /// Build and show the candidate action menu at the pointer position.
+    void showCandidateMenu(int x, int y);
+    /// Hide the candidate action menu and discard its temporary state.
+    void clearCandidateMenu();
+    /// Restore the input panel surface after a candidate menu closes.
+    void restorePanelSize();
+    /// Update the menu item under the pointer.
+    bool hoverCandidateMenu(int x, int y);
+    /// Activate or dismiss the menu in response to a left click.
+    void clickCandidateMenu(int x, int y);
+    /// Paint the candidate action menu over the input panel.
+    void paintCandidateMenu(cairo_t *cr);
     void updateBlur();
 
     WaylandUI *ui_;
     wl_fixed_t scroll_ = 0;
+    GObjectUniquePtr<PangoContext> menuContext_;
+    GObjectUniquePtr<PangoLayout> menuLayout_;
     std::unique_ptr<wayland::ZwpInputPanelSurfaceV1> panelSurface_;
     TrackableObjectReference<InputContext> v2IC_;
     std::unique_ptr<wayland::ZwpInputPopupSurfaceV2> panelSurfaceV2_;
@@ -46,6 +62,23 @@ private:
     TrackableObjectReference<InputContext> repaintIC_;
     std::shared_ptr<wayland::ExtBackgroundEffectManagerV1> blurManager_;
     std::unique_ptr<wayland::ExtBackgroundEffectSurfaceV1> blur_;
+
+    std::shared_ptr<CandidateList> candidateMenuList_;
+    const CandidateWord *candidateMenuCandidate_ = nullptr;
+    std::vector<CandidateAction> candidateMenuActions_;
+    std::vector<Rect> candidateMenuRegions_;
+    Rect candidateMenuRegion_;
+    int candidateMenuX_ = 0;
+    int candidateMenuY_ = 0;
+    int candidateMenuWidth_ = 0;
+    int candidateMenuHeight_ = 0;
+    int candidateMenuItemWidth_ = 0;
+    int candidateMenuItemHeight_ = 0;
+    bool candidateMenuHasCheckable_ = false;
+    int candidateMenuHoveredIndex_ = -1;
+    int panelWidth_ = 0;
+    int panelHeight_ = 0;
+    bool candidateMenuVisible_ = false;
 };
 
 } // namespace fcitx::classicui

--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -29,11 +29,13 @@
 
 namespace fcitx::classicui {
 
+/** Initializes the X11 input window and its candidate menu state. */
 XCBInputWindow::XCBInputWindow(XCBUI *ui)
     : XCBWindow(ui), InputWindow(ui->parent()),
       atomBlur_(ui_->parent()->xcb()->call<IXCBModule::atom>(
           ui_->displayName(), "_KDE_NET_WM_BLUR_BEHIND_REGION", false)) {}
 
+/** Hides the candidate menu and unregisters its temporary actions. */
 void XCBInputWindow::clearCandidateMenu() {
     if (candidateMenuWindow_) {
         candidateMenuWindow_->hideAll();
@@ -51,6 +53,7 @@ void XCBInputWindow::clearCandidateMenu() {
     candidateActions_.clear();
 }
 
+/** Shows the actions for the candidate under the pointer. */
 bool XCBInputWindow::showCandidateMenu(int x, int y, int rootX, int rootY) {
     auto *inputContext = inputContext_.get();
     if (!inputContext) {
@@ -122,6 +125,7 @@ bool XCBInputWindow::showCandidateMenu(int x, int y, int rootX, int rootY) {
     return true;
 }
 
+/** Applies X11 properties and event masks after window creation. */
 void XCBInputWindow::postCreateWindow() {
     if (ui_->ewmh()->_NET_WM_WINDOW_TYPE_COMBO &&
         ui_->ewmh()->_NET_WM_WINDOW_TYPE) {
@@ -145,6 +149,7 @@ void XCBInputWindow::postCreateWindow() {
             XCB_EVENT_MASK_LEAVE_WINDOW);
 }
 
+/** Finds the screen nearest to the input cursor. */
 const Rect *XCBInputWindow::getClosestScreen(const Rect &cursorRect) const {
     const Rect *closestScreen = nullptr;
 
@@ -161,6 +166,7 @@ const Rect *XCBInputWindow::getClosestScreen(const Rect &cursorRect) const {
     return closestScreen;
 }
 
+/** Calculates an input window x-coordinate constrained to a screen. */
 int XCBInputWindow::calculatePositionX(const Rect &cursorRect,
                                        const Rect *closestScreen) const {
     // TODO: RTL support.
@@ -191,6 +197,7 @@ int XCBInputWindow::calculatePositionX(const Rect &cursorRect,
     return x;
 }
 
+/** Calculates an input window y-coordinate constrained to a screen. */
 int XCBInputWindow::calculatePositionY(const Rect &cursorRect,
                                        const Rect *closestScreen) const {
     // TODO: RTL support.
@@ -240,6 +247,7 @@ int XCBInputWindow::calculatePositionY(const Rect &cursorRect,
     return y;
 }
 
+/** Positions the input window relative to the cursor. */
 void XCBInputWindow::updatePosition(InputContext *inputContext) {
     if (!visible()) {
         return;
@@ -257,12 +265,14 @@ void XCBInputWindow::updatePosition(InputContext *inputContext) {
                              &wc);
 }
 
+/** Updates the window scale for the cursor's display. */
 void XCBInputWindow::updateDPI(InputContext *inputContext) {
     auto dpi = ui_->dpiByPosition(inputContext->cursorRect().left(),
                                   inputContext->cursorRect().top());
     setScale(scaleForDPI(dpi));
 }
 
+/** Updates the input panel contents and visibility. */
 void XCBInputWindow::update(InputContext *inputContext) {
     clearCandidateMenu();
     if (!wid_) {
@@ -333,6 +343,7 @@ void XCBInputWindow::update(InputContext *inputContext) {
     render();
 }
 
+/** Handles X11 events for the input window. */
 bool XCBInputWindow::filterEvent(xcb_generic_event_t *event) {
     uint8_t response_type = event->response_type & ~0x80;
     switch (response_type) {
@@ -390,6 +401,7 @@ bool XCBInputWindow::filterEvent(xcb_generic_event_t *event) {
     return false;
 }
 
+/** Repaints the visible input window. */
 void XCBInputWindow::repaint() {
     if (!visible()) {
         return;

--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -17,8 +17,10 @@
 #include <xcb/xcb_ewmh.h>
 #include <xcb/xcb_icccm.h>
 #include <xcb/xproto.h>
+#include "fcitx-utils/misc_p.h"
 #include "fcitx-utils/rect.h"
 #include "fcitx/inputcontext.h"
+#include "fcitx/userinterfacemanager.h"
 #include "inputwindow.h"
 #include "theme.h"
 #include "xcb_public.h"
@@ -31,6 +33,90 @@ XCBInputWindow::XCBInputWindow(XCBUI *ui)
     : XCBWindow(ui), InputWindow(ui->parent()),
       atomBlur_(ui_->parent()->xcb()->call<IXCBModule::atom>(
           ui_->displayName(), "_KDE_NET_WM_BLUR_BEHIND_REGION", false)) {}
+
+void XCBInputWindow::clearCandidateMenu() {
+    if (candidateMenuWindow_) {
+        candidateMenuWindow_->hideAll();
+        candidateMenuWindow_ = nullptr;
+    }
+
+    for (auto *action : candidateMenu_.actions()) {
+        candidateMenu_.removeAction(action);
+    }
+
+    auto &uiManager = ui_->parent()->instance()->userInterfaceManager();
+    for (auto &action : candidateActions_) {
+        uiManager.unregisterAction(&action);
+    }
+    candidateActions_.clear();
+}
+
+bool XCBInputWindow::showCandidateMenu(int x, int y, int rootX, int rootY) {
+    auto *inputContext = inputContext_.get();
+    if (!inputContext) {
+        return false;
+    }
+
+    const auto candidateList = inputContext->inputPanel().candidateList();
+    if (!candidateList) {
+        return false;
+    }
+
+    const CandidateWord *candidate = nullptr;
+    for (size_t idx = 0, e = candidateRegions_.size(); idx < e; idx++) {
+        if (candidateRegions_[idx].contains(x, y)) {
+            candidate = nthCandidateIgnorePlaceholder(*candidateList, idx);
+            break;
+        }
+    }
+
+    auto *actionable = candidateList->toActionable();
+    if (!candidate || !actionable || !actionable->hasAction(*candidate)) {
+        return false;
+    }
+
+    const auto actions = actionable->candidateActions(*candidate);
+    if (actions.empty()) {
+        return false;
+    }
+
+    clearCandidateMenu();
+    auto &uiManager = ui_->parent()->instance()->userInterfaceManager();
+    for (const auto &candidateAction : actions) {
+        candidateActions_.emplace_back();
+        auto &action = candidateActions_.back();
+        action.setShortText(candidateAction.text());
+        action.setIcon(candidateAction.icon());
+        action.setCheckable(candidateAction.isCheckable());
+        action.setChecked(candidateAction.isChecked());
+        action.setSeparator(candidateAction.isSeparator());
+
+        const auto id = candidateAction.id();
+        action.connect<SimpleAction::Activated>(
+            [candidateList, candidate, id](InputContext *) {
+                if (auto *actionable = candidateList->toActionable()) {
+                    actionable->triggerAction(*candidate, id);
+                }
+            });
+
+        if (!uiManager.registerAction(&action)) {
+            candidateActions_.pop_back();
+            continue;
+        }
+        candidateMenu_.addAction(&action);
+    }
+
+    if (candidateMenu_.actions().empty()) {
+        clearCandidateMenu();
+        return false;
+    }
+
+    candidateMenuWindow_ =
+        candidateMenuPool_.requestMenu(ui_, &candidateMenu_, nullptr);
+    candidateMenuWindow_->show(Rect().setPosition(rootX, rootY).setSize(1, 1),
+                               ConstrainAdjustment::Flip);
+    return true;
+}
 
 void XCBInputWindow::postCreateWindow() {
     if (ui_->ewmh()->_NET_WM_WINDOW_TYPE_COMBO &&
@@ -174,6 +260,7 @@ void XCBInputWindow::updateDPI(InputContext *inputContext) {
 }
 
 void XCBInputWindow::update(InputContext *inputContext) {
+    clearCandidateMenu();
     if (!wid_) {
         return;
     }
@@ -258,7 +345,11 @@ bool XCBInputWindow::filterEvent(xcb_generic_event_t *event) {
         if (buttonPress->event != wid_) {
             break;
         }
-        if (buttonPress->detail == XCB_BUTTON_INDEX_1) {
+        if (buttonPress->detail == XCB_BUTTON_INDEX_3) {
+            showCandidateMenu(logicalFromPhysical(buttonPress->event_x),
+                              logicalFromPhysical(buttonPress->event_y),
+                              buttonPress->root_x, buttonPress->root_y);
+        } else if (buttonPress->detail == XCB_BUTTON_INDEX_1) {
             click(logicalFromPhysical(buttonPress->event_x),
                   logicalFromPhysical(buttonPress->event_y));
         } else if (buttonPress->detail == XCB_BUTTON_INDEX_4) {

--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -83,6 +83,7 @@ bool XCBInputWindow::showCandidateMenu(int x, int y, int rootX, int rootY) {
 
     clearCandidateMenu();
     auto &uiManager = ui_->parent()->instance()->userInterfaceManager();
+    bool hasRegisteredAction = false;
     for (const auto &candidateAction : actions) {
         candidateActions_.emplace_back();
         auto &action = candidateActions_.back();
@@ -105,9 +106,11 @@ bool XCBInputWindow::showCandidateMenu(int x, int y, int rootX, int rootY) {
             continue;
         }
         candidateMenu_.addAction(&action);
+        hasRegisteredAction =
+            hasRegisteredAction || !candidateAction.isSeparator();
     }
 
-    if (candidateMenu_.actions().empty()) {
+    if (!hasRegisteredAction) {
         clearCandidateMenu();
         return false;
     }

--- a/src/ui/classic/xcbinputwindow.cpp
+++ b/src/ui/classic/xcbinputwindow.cpp
@@ -76,7 +76,8 @@ bool XCBInputWindow::showCandidateMenu(int x, int y, int rootX, int rootY) {
     }
 
     const auto actions = actionable->candidateActions(*candidate);
-    if (actions.empty()) {
+    if (actions.empty() ||
+        std::ranges::all_of(actions, &CandidateAction::isSeparator)) {
         return false;
     }
 

--- a/src/ui/classic/xcbinputwindow.h
+++ b/src/ui/classic/xcbinputwindow.h
@@ -7,11 +7,15 @@
 #ifndef _FCITX_UI_CLASSIC_XCBINPUTWINDOW_H_
 #define _FCITX_UI_CLASSIC_XCBINPUTWINDOW_H_
 
+#include <list>
 #include <xcb/xcb.h>
 #include <xcb/xproto.h>
 #include "fcitx-utils/rect.h"
+#include "fcitx/action.h"
 #include "fcitx/inputcontext.h"
+#include "fcitx/menu.h"
 #include "inputwindow.h"
+#include "xcbmenu.h"
 #include "xcbui.h"
 #include "xcbwindow.h"
 
@@ -30,6 +34,8 @@ public:
     void updateDPI(InputContext *inputContext);
 
 private:
+    bool showCandidateMenu(int x, int y, int rootX, int rootY);
+    void clearCandidateMenu();
     void repaint();
     const Rect *getClosestScreen(const Rect &cursorRect) const;
     int calculatePositionX(const Rect &cursorRect,
@@ -38,6 +44,11 @@ private:
                            const Rect *closestScreen) const;
 
     xcb_atom_t atomBlur_;
+
+    MenuPool candidateMenuPool_;
+    Menu candidateMenu_;
+    std::list<SimpleAction> candidateActions_;
+    XCBMenu *candidateMenuWindow_ = nullptr;
 };
 
 } // namespace fcitx::classicui

--- a/src/ui/classic/xcbinputwindow.h
+++ b/src/ui/classic/xcbinputwindow.h
@@ -34,7 +34,9 @@ public:
     void updateDPI(InputContext *inputContext);
 
 private:
+    /// Build and show the candidate action menu at the pointer position.
     bool showCandidateMenu(int x, int y, int rootX, int rootY);
+    /// Hide the candidate action menu and unregister its temporary actions.
     void clearCandidateMenu();
     void repaint();
     const Rect *getClosestScreen(const Rect &cursorRect) const;


### PR DESCRIPTION
## Summary

Expose the generic candidate actions provided by `ActionableCandidateList` from the Classic UI candidate window.

Both Classic UI backends now support right-clicking a candidate and choosing one of its actions:

- X11 uses the existing `Menu`/`XCBMenu` infrastructure.
- Wayland renders and handles the action menu inside the existing input popup surface, so it works with the current input-method popup protocol.

The UI invokes `triggerAction()` with the originating candidate and action id; no Pinyin-specific operation is hard-coded.

## Behavior

- A menu is shown only when the clicked candidate has at least one non-separator action.
- Separators, checkable state, and checked state are preserved where the backend can represent them.
- Temporary menu state is cleared when the input panel updates or the menu is dismissed.
- Existing left-click, wheel, touch, keyboard, and paging behavior remains unchanged when the menu is not active.
- The Wayland menu is sized and positioned within the popup surface, expanding the surface only when needed.

Closes #1663.

## Testing

- `cmake --build build-x11 -j2`
- `ctest --test-dir build-x11 --output-on-failure` (50/50 passed)
- `cmake --build build-wayland -j2`
- `ctest --test-dir build-wayland --output-on-failure` (50/50 passed)
- `clang-format --dry-run --Werror src/ui/classic/xcbinputwindow.cpp src/ui/classic/xcbinputwindow.h src/ui/classic/waylandinputwindow.cpp src/ui/classic/waylandinputwindow.h`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right-click menus for candidate actions in the input panel.
  * Menus support toggles, separators, hover states, scrolling, and themed rendering.
  * On supported Wayland configurations, menus open in a separate popup surface.
  * Menu placement and sizing adapt to the input panel and display.
* **Bug Fixes**
  * Candidates with no actionable options no longer open an empty menu.
  * Existing left-click behavior for selecting candidates remains unchanged.
* **Usability**
  * Menus dismiss and refresh correctly when input or candidate content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->