### PR TITLE
Flush Wayland requests before disconnect

### DIFF
--- a/src/lib/fcitx-wayland/core/display.cpp
+++ b/src/lib/fcitx-wayland/core/display.cpp
@@ -96,7 +96,11 @@ Display::Display(wl_display *display) : display_(display) {
 #endif
 }
 
-Display::~Display() { flush(); }
+Display::~Display() {
+    if (!wl_display_get_error(*this)) {
+        flush();
+    }
+}
 
 void Display::roundtrip() { wl_display_roundtrip(*this); }
 

--- a/src/lib/fcitx-wayland/core/display.cpp
+++ b/src/lib/fcitx-wayland/core/display.cpp
@@ -96,7 +96,7 @@ Display::Display(wl_display *display) : display_(display) {
 #endif
 }
 
-Display::~Display() {}
+Display::~Display() { flush(); }
 
 void Display::roundtrip() { wl_display_roundtrip(*this); }
 


### PR DESCRIPTION
When Fcitx exits, the Wayland display is disconnected after input-context and addon teardown. If Wayland requests are still buffered, the compositor does not observe the resource destruction until the connection closes.

This change flushes pending requests from `Display::~Display()` immediately before the RAII member disconnects the Wayland display. It keeps the change at the connection lifecycle boundary and leaves virtual-key state cleanup to the compositor.

This is the minimal implementation discussed in #1648: no input-context changes, synthetic key releases, or client-side pressed-key tracking are added.

### Testing

- Built `fcitx5` and `fcitx5-rime` through the NUR overlay.
- Tested on NixOS with niri, kitty, Wayland input-method-v2, and fcitx5-rime.
- With Rime taking about seven seconds to unload, stopping Fcitx no longer produced repeated Enter input and browser input remained available during shutdown.
- `SIGKILL` of the unpatched daemon did not reproduce the issue, consistent with compositor cleanup after client disconnect.
- `clang-format --dry-run --Werror` and `git diff --check` pass on current master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wayland display shutdown by avoiding request flushing when the display connection is already in an error state.
  * Prevented potentially invalid cleanup operations during display disconnection, improving shutdown reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->