### PR TITLE
Add two new signal AboutToExit & Exit, to help execute some clean up code.

### DIFF
--- a/src/lib/fcitx/instance.cpp
+++ b/src/lib/fcitx/instance.cpp
@@ -1491,8 +1491,10 @@ void Instance::initialize() {
 #endif
 
     d->exitEvent_ = d->eventLoop_.addExitEvent([this](EventSource *) {
-        FCITX_DEBUG() << "Running save...";
+        emit<Instance::AboutToExit>();
+        FCITX_INFO() << "Save before exiting...";
         save();
+        emit<Instance::Exit>();
         return false;
     });
     d->notifications_ = d->addonManager_.addon("notifications", true);

--- a/src/lib/fcitx/instance.h
+++ b/src/lib/fcitx/instance.h
@@ -332,6 +332,8 @@ public:
                          void(InputContext *inputContext, Text &orig));
     FCITX_DECLARE_SIGNAL(Instance, KeyEventResult,
                          void(const KeyEvent &keyEvent));
+    FCITX_DECLARE_SIGNAL(Instance, AboutToExit, void());
+    FCITX_DECLARE_SIGNAL(Instance, Exit, void());
     FCITX_DECLARE_SIGNAL(
         Instance, XkbStateMaskChanged,
         void(const std::string &display,

--- a/src/lib/fcitx/instance_p.h
+++ b/src/lib/fcitx/instance_p.h
@@ -193,6 +193,8 @@ public:
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, KeyEventResult);
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, CheckUpdate);
     FCITX_DEFINE_SIGNAL_PRIVATE(Instance, XkbStateMaskChanged);
+    FCITX_DEFINE_SIGNAL_PRIVATE(Instance, AboutToExit);
+    FCITX_DEFINE_SIGNAL_PRIVATE(Instance, Exit);
 
     FactoryFor<InputState> inputStateFactory_{
         [this](InputContext &ic) { return new InputState(this, &ic); }};

--- a/src/modules/dbus/dbusmodule.cpp
+++ b/src/modules/dbus/dbusmodule.cpp
@@ -620,8 +620,8 @@ public:
     void openWaylandConnectionSocket(UnixFD &fd) {
 #ifdef WAYLAND_FOUND
         if (auto *wayland = module_->wayland()) {
-            if (!wayland->call<IWaylandModule::openConnectionSocket>(
-                    fd.release())) {
+            if (!wayland->call<IWaylandModule::openConnectionSocketV2>(
+                    std::move(fd))) {
                 throw dbus::MethodCallError(
                     "org.freedesktop.DBus.Error.InvalidArgs",
                     "Failed to create wayland connection.");
@@ -638,8 +638,8 @@ public:
     void reopenWaylandConnectionSocket(const std::string &name, UnixFD &fd) {
 #ifdef WAYLAND_FOUND
         if (auto *wayland = module_->wayland()) {
-            if (!wayland->call<IWaylandModule::reopenConnectionSocket>(
-                    name, fd.release())) {
+            if (!wayland->call<IWaylandModule::reopenConnectionSocketV2>(
+                    name, std::move(fd))) {
                 throw dbus::MethodCallError(
                     "org.freedesktop.DBus.Error.InvalidArgs",
                     "Failed to create wayland connection.");

--- a/src/modules/wayland/wayland_public.h
+++ b/src/modules/wayland/wayland_public.h
@@ -9,6 +9,8 @@
 
 #include <functional>
 #include <memory>
+#include <string>
+#include <fcitx-utils/fs.h>
 #include <fcitx-utils/handlertable.h>
 #include <fcitx-utils/metastring.h>
 #include <fcitx/addoninstance.h>
@@ -41,5 +43,10 @@ FCITX_ADDON_DECLARE_FUNCTION(WaylandModule, reopenConnectionSocket,
 FCITX_ADDON_DECLARE_FUNCTION(WaylandModule, repeatInfo,
                              std::optional<std::tuple<int32_t, int32_t>>(
                                  const std::string &name, wl_seat *));
+
+FCITX_ADDON_DECLARE_FUNCTION(WaylandModule, openConnectionSocketV2,
+                             bool(fcitx::UnixFD fd));
+FCITX_ADDON_DECLARE_FUNCTION(WaylandModule, reopenConnectionSocketV2,
+                             bool(const std::string &name, UnixFD fd));
 
 #endif // _FCITX_MODULES_WAYLAND_WAYLAND_PUBLIC_H_

--- a/src/modules/wayland/waylandmodule.cpp
+++ b/src/modules/wayland/waylandmodule.cpp
@@ -122,7 +122,7 @@ WaylandConnection::WaylandConnection(WaylandModule *wayland, std::string name)
 }
 
 WaylandConnection::WaylandConnection(WaylandModule *wayland, std::string name,
-                                     int fd, std::string realName)
+                                     UnixFD fd, std::string realName)
     : parent_(wayland), name_(std::move(name)), realName_(std::move(realName)),
       isWaylandSocket_(true) {
     wl_display *display = nullptr;
@@ -131,7 +131,7 @@ WaylandConnection::WaylandConnection(WaylandModule *wayland, std::string name,
         if (wayland_log().checkLogLevel(Debug)) {
             env = std::make_unique<ScopedEnvvar>("WAYLAND_DEBUG", "1");
         }
-        display = wl_display_connect_to_fd(fd);
+        display = wl_display_connect_to_fd(fd.release());
     }
     if (!display) {
         throw std::runtime_error("Failed to open wayland connection");
@@ -275,14 +275,20 @@ bool WaylandModule::openConnection(const std::string &name) {
 }
 
 bool WaylandModule::openConnectionSocket(int fd) {
-    auto name = stringutils::concat("socket:", fd);
-    return openConnectionSocketWithName(fd, name, "");
+    return openConnectionSocketV2(UnixFD::own(fd));
 }
 
-bool WaylandModule::openConnectionSocketWithName(int fd,
+bool WaylandModule::openConnectionSocketV2(UnixFD fd) {
+    if (!fd.isValid()) {
+        return false;
+    }
+    auto name = stringutils::concat("socket:", fd.fd());
+    return openConnectionSocketWithName(std::move(fd), name, "");
+}
+
+bool WaylandModule::openConnectionSocketWithName(UnixFD fd,
                                                  const std::string &name,
                                                  const std::string &realName) {
-    UnixFD guard = UnixFD::own(fd);
     if (instance_->exiting()) {
         return false;
     }
@@ -292,19 +298,18 @@ bool WaylandModule::openConnectionSocketWithName(int fd,
     }
 
     for (const auto &[name, connection] : conns_) {
-        if (connection->display()->fd() == fd) {
+        if (connection->display()->fd() == fd.fd()) {
             return false;
         }
     }
 
     WaylandConnection *newConnection = nullptr;
     try {
-        auto connection =
-            std::make_unique<WaylandConnection>(this, name, fd, realName);
+        auto connection = std::make_unique<WaylandConnection>(
+            this, name, std::move(fd), realName);
         auto iter = conns_.emplace(
             std::piecewise_construct, std::forward_as_tuple(name),
             std::forward_as_tuple(std::move(connection)));
-        guard.release();
         newConnection = iter.first->second.get();
     } catch (const std::exception &e) {
         FCITX_ERROR() << "Open wayland connection with socket failed: "
@@ -320,7 +325,11 @@ bool WaylandModule::openConnectionSocketWithName(int fd,
 
 bool WaylandModule::reopenConnectionSocket(const std::string &displayName,
                                            int fd) {
-    UnixFD guard = UnixFD::own(fd);
+    return reopenConnectionSocketV2(displayName, UnixFD::own(fd));
+}
+
+bool WaylandModule::reopenConnectionSocketV2(const std::string &displayName,
+                                             UnixFD fd) {
     if (instance_->exiting()) {
         return false;
     }
@@ -344,14 +353,14 @@ bool WaylandModule::reopenConnectionSocket(const std::string &displayName,
                     }
                 }
             }
-            return openConnectionSocketWithName(guard.release(), name,
+            return openConnectionSocketWithName(std::move(fd), name,
                                                 displayName);
 
         } while (0);
     }
 
     for (const auto &[name, connection] : conns_) {
-        if (connection->display()->fd() == fd) {
+        if (connection->display()->fd() == fd.fd()) {
             return false;
         }
     }
@@ -365,9 +374,8 @@ bool WaylandModule::reopenConnectionSocket(const std::string &displayName,
 
     std::unique_ptr<WaylandConnection> newConnection;
     try {
-        newConnection =
-            std::make_unique<WaylandConnection>(this, name, fd, displayName);
-        guard.release();
+        newConnection = std::make_unique<WaylandConnection>(
+            this, name, std::move(fd), displayName);
     } catch (const std::exception &e) {
         FCITX_ERROR() << "Open wayland connection: " << name
                       << " failed: " << e.what();

--- a/src/modules/wayland/waylandmodule.cpp
+++ b/src/modules/wayland/waylandmodule.cpp
@@ -282,10 +282,10 @@ bool WaylandModule::openConnectionSocket(int fd) {
 bool WaylandModule::openConnectionSocketWithName(int fd,
                                                  const std::string &name,
                                                  const std::string &realName) {
+    UnixFD guard = UnixFD::own(fd);
     if (instance_->exiting()) {
         return false;
     }
-    UnixFD guard = UnixFD::own(fd);
 
     if (conns_.contains(name)) {
         return false;
@@ -320,10 +320,10 @@ bool WaylandModule::openConnectionSocketWithName(int fd,
 
 bool WaylandModule::reopenConnectionSocket(const std::string &displayName,
                                            int fd) {
+    UnixFD guard = UnixFD::own(fd);
     if (instance_->exiting()) {
         return false;
     }
-    UnixFD guard = UnixFD::own(fd);
     std::string name = displayName;
 
     auto iter = conns_.find(name);

--- a/src/modules/wayland/waylandmodule.cpp
+++ b/src/modules/wayland/waylandmodule.cpp
@@ -139,7 +139,16 @@ WaylandConnection::WaylandConnection(WaylandModule *wayland, std::string name,
     init(display);
 }
 
-WaylandConnection::~WaylandConnection() {}
+WaylandConnection::~WaylandConnection() {
+    // Stop all event handling.
+    eventReader_.reset();
+
+    // Try to flush the last event, this should help to apply virtual keyboard
+    // do the final destroy.
+    if (!wl_display_get_error(*display_)) {
+        display_->flush();
+    }
+}
 
 void WaylandConnection::init(wl_display *display) {
     display_ = std::make_unique<wayland::Display>(display);
@@ -221,11 +230,21 @@ WaylandModule::WaylandModule(fcitx::Instance *instance)
             });
     });
 #endif
+
+    exitConnection_ = instance_->connect<Instance::AboutToExit>([this]() {
+        // Handle about to exit signal
+        while (!conns_.empty()) {
+            removeConnection(conns_.begin()->first);
+        }
+    });
 }
 
 void WaylandModule::reloadConfig() { readAsIni(config_, "conf/wayland.conf"); }
 
 bool WaylandModule::openConnection(const std::string &name) {
+    if (instance_->exiting()) {
+        return false;
+    }
     if (conns_.contains(name)) {
         return false;
     }
@@ -263,6 +282,9 @@ bool WaylandModule::openConnectionSocket(int fd) {
 bool WaylandModule::openConnectionSocketWithName(int fd,
                                                  const std::string &name,
                                                  const std::string &realName) {
+    if (instance_->exiting()) {
+        return false;
+    }
     UnixFD guard = UnixFD::own(fd);
 
     if (conns_.contains(name)) {
@@ -298,6 +320,9 @@ bool WaylandModule::openConnectionSocketWithName(int fd,
 
 bool WaylandModule::reopenConnectionSocket(const std::string &displayName,
                                            int fd) {
+    if (instance_->exiting()) {
+        return false;
+    }
     UnixFD guard = UnixFD::own(fd);
     std::string name = displayName;
 

--- a/src/modules/wayland/waylandmodule.h
+++ b/src/modules/wayland/waylandmodule.h
@@ -26,6 +26,7 @@
 #include "fcitx-utils/log.h"
 #include "fcitx-utils/signals.h"
 #include "fcitx-utils/trackableobject.h"
+#include "fcitx-utils/unixfd.h"
 #include "fcitx/addoninstance.h"
 #include "fcitx/addonmanager.h"
 #include "fcitx/instance.h"
@@ -84,7 +85,7 @@ private:
 class WaylandConnection : public TrackableObject<WaylandConnection> {
 public:
     WaylandConnection(WaylandModule *wayland, std::string name);
-    WaylandConnection(WaylandModule *wayland, std::string name, int fd,
+    WaylandConnection(WaylandModule *wayland, std::string name, UnixFD fd,
                       std::string realName);
     ~WaylandConnection();
 
@@ -126,10 +127,11 @@ public:
 
     bool openConnection(const std::string &name);
     bool openConnectionSocket(int fd);
-    bool openConnectionSocketWithName(int fd, const std::string &name,
-                                      const std::string &realName);
     bool reopenConnectionSocket(const std::string &name, int fd);
     void removeConnection(const std::string &name);
+
+    bool openConnectionSocketV2(UnixFD fd);
+    bool reopenConnectionSocketV2(const std::string &name, UnixFD fd);
 
     std::unique_ptr<HandlerTableEntry<WaylandConnectionCreated>>
     addConnectionCreatedCallback(WaylandConnectionCreated callback);
@@ -152,6 +154,8 @@ public:
     void setLayoutToCompositor();
 
 private:
+    bool openConnectionSocketWithName(UnixFD fd, const std::string &name,
+                                      const std::string &realName);
     void onConnectionCreated(WaylandConnection &conn);
     void onConnectionClosed(WaylandConnection &conn);
     void refreshCanRestart();
@@ -178,6 +182,8 @@ private:
     FCITX_ADDON_EXPORT_FUNCTION(WaylandModule, openConnectionSocket);
     FCITX_ADDON_EXPORT_FUNCTION(WaylandModule, reopenConnectionSocket);
     FCITX_ADDON_EXPORT_FUNCTION(WaylandModule, repeatInfo);
+    FCITX_ADDON_EXPORT_FUNCTION(WaylandModule, openConnectionSocketV2);
+    FCITX_ADDON_EXPORT_FUNCTION(WaylandModule, reopenConnectionSocketV2);
 
     std::vector<std::unique_ptr<HandlerTableEntry<EventHandler>>>
         eventHandlers_;

--- a/src/modules/wayland/waylandmodule.h
+++ b/src/modules/wayland/waylandmodule.h
@@ -183,6 +183,7 @@ private:
         eventHandlers_;
     std::unique_ptr<EventSourceTime> delayedReloadXkbOption_;
     std::unique_ptr<EventSourceTime> deferredDiagnose_;
+    ScopedConnection exitConnection_;
 };
 
 FCITX_DECLARE_LOG_CATEGORY(wayland_log);

--- a/src/modules/xcb/xcbmodule.cpp
+++ b/src/modules/xcb/xcbmodule.cpp
@@ -43,6 +43,13 @@ XCBModule::XCBModule(Instance *instance) : instance_(instance) {
                            "nodefault")) {
         openConnection("");
     }
+
+    exitConnection_ = instance_->connect<Instance::AboutToExit>([this]() {
+        // Handle about to exit signal
+        while (!conns_.empty()) {
+            removeConnection(conns_.begin()->first);
+        }
+    });
 }
 
 void XCBModule::reloadConfig() { readAsIni(config_, "conf/xcb.conf"); }
@@ -52,13 +59,16 @@ void XCBModule::openConnection(const std::string &name_) {
 }
 
 bool XCBModule::openConnectionChecked(const std::string &name_) {
+    if (instance_->exiting()) {
+        return false;
+    }
     std::string name = name_;
     if (name.empty()) {
         if (auto env = getEnvironment("DISPLAY")) {
             name = *env;
         }
     }
-    if (name.empty() || conns_.count(name)) {
+    if (name.empty() || conns_.contains(name)) {
         return false;
     }
 

--- a/src/modules/xcb/xcbmodule.h
+++ b/src/modules/xcb/xcbmodule.h
@@ -21,6 +21,7 @@
 #include "fcitx-utils/handlertable.h"
 #include "fcitx-utils/i18n.h"
 #include "fcitx-utils/log.h"
+#include "fcitx-utils/signals.h"
 #include "fcitx/addoninstance.h"
 #include "fcitx/addonmanager.h"
 #include "fcitx/instance.h"
@@ -129,6 +130,7 @@ private:
     HandlerTable<XCBConnectionCreated> createdCallbacks_;
     HandlerTable<XCBConnectionClosed> closedCallbacks_;
     std::string mainDisplay_;
+    ScopedConnection exitConnection_;
     FCITX_ADDON_EXPORT_FUNCTION(XCBModule, openConnection);
     FCITX_ADDON_EXPORT_FUNCTION(XCBModule, openConnectionChecked);
     FCITX_ADDON_EXPORT_FUNCTION(XCBModule, addEventFilter);


### PR DESCRIPTION
X11 & Wayland will try to end all connection at AboutToExit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown by saving state at the appropriate stage and completing cleanup before exit.
  * Wayland and X11 connections now close reliably during shutdown.
  * Prevented new Wayland or X11 connections from opening while the application is exiting.
  * Improved Wayland connection handling to transfer and close socket resources safely.
  * Added shutdown notifications to support coordinated cleanup across input and display components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->